### PR TITLE
Don't send `machine_detection` param to Nexmo if empty

### DIFF
--- a/services/ivr/vonage/client.go
+++ b/services/ivr/vonage/client.go
@@ -23,7 +23,7 @@ type CallRequest struct {
 	EventMethod  string   `json:"event_method"`
 
 	NCCO             []NCCO `json:"ncco,omitempty"`
-	MachineDetection string `json:"machine_detection"`
+	MachineDetection string `json:"machine_detection,omitempty"`
 	LengthTimer      int    `json:"length_timer,omitempty"`
 	RingingTimer     int    `json:"ringing_timer,omitempty"`
 }


### PR DESCRIPTION
Avoids..

```
{"type":400,"title":"Bad Request","invalid_parameters":[{"reason":"accepted values are continue and hangup","name":"machine_detection"}]}
```