### PR TITLE
Cleanup broadcasts and starts

### DIFF
--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -774,18 +774,6 @@ func FailChannelMessages(ctx context.Context, db Queryer, orgID OrgID, channelID
 	return nil
 }
 
-// MarkBroadcastSent marks the given broadcast as sent
-func MarkBroadcastSent(ctx context.Context, db Queryer, id BroadcastID) error {
-	_, err := db.ExecContext(ctx, `UPDATE msgs_broadcast SET status = 'S', modified_on = now() WHERE id = $1`, id)
-	return errors.Wrapf(err, "error marking broadcast #%d as sent", id)
-}
-
-// MarkBroadcastFailed marks the given broadcast as failed
-func MarkBroadcastFailed(ctx context.Context, db Queryer, id BroadcastID) error {
-	_, err := db.ExecContext(ctx, `UPDATE msgs_broadcast SET status = 'S', modified_on = now() WHERE id = $1`, id)
-	return errors.Wrapf(err, "error marking broadcast #%d as failed", id)
-}
-
 // NilID implementations
 
 func (i *MsgID) Scan(value any) error         { return null.ScanInt(value, i) }

--- a/core/models/starts_test.go
+++ b/core/models/starts_test.go
@@ -64,11 +64,11 @@ func TestStarts(t *testing.T) {
 	assert.Equal(t, null.JSON(`{"parent_uuid": "532a3899-492f-4ffe-aed7-e75ad524efab", "ancestors": 3, "ancestors_since_input": 1}`), start.SessionHistory)
 	assert.Equal(t, null.JSON(`{"foo": "bar"}`), start.Extra)
 
-	err = models.MarkStartStarted(ctx, rt.DB, startID, 2, []models.ContactID{testdata.George.ID})
+	err = models.MarkStartStarted(ctx, rt.DB, startID, 2)
 	require.NoError(t, err)
 
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM flows_flowstart WHERE id = $1 AND status = 'S' AND contact_count = 2`, startID).Returns(1)
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM flows_flowstart_contacts WHERE flowstart_id = $1`, startID).Returns(3)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM flows_flowstart_contacts WHERE flowstart_id = $1`, startID).Returns(2)
 
 	batch := start.CreateBatch([]models.ContactID{testdata.Cathy.ID, testdata.Bob.ID}, false, 3)
 	assert.Equal(t, startID, batch.StartID)

--- a/core/search/resolve_test.go
+++ b/core/search/resolve_test.go
@@ -28,14 +28,12 @@ func TestResolveRecipients(t *testing.T) {
 	require.NoError(t, err)
 
 	tcs := []struct {
-		recipients         *search.Recipients
-		expectedIDs        []models.ContactID
-		expectedCreatedIDs []models.ContactID
+		recipients  *search.Recipients
+		expectedIDs []models.ContactID
 	}{
 		{
-			recipients:         &search.Recipients{},
-			expectedIDs:        []models.ContactID{},
-			expectedCreatedIDs: []models.ContactID{},
+			recipients:  &search.Recipients{},
+			expectedIDs: []models.ContactID{},
 		},
 		{
 			recipients: &search.Recipients{
@@ -43,39 +41,34 @@ func TestResolveRecipients(t *testing.T) {
 				GroupIDs:   []models.GroupID{group1.ID},
 				Query:      `name = "Cathy" OR name = "Bob"`,
 			},
-			expectedIDs:        []models.ContactID{testdata.Bob.ID, testdata.George.ID, testdata.Alexandria.ID, testdata.Cathy.ID},
-			expectedCreatedIDs: []models.ContactID{},
+			expectedIDs: []models.ContactID{testdata.Bob.ID, testdata.George.ID, testdata.Alexandria.ID, testdata.Cathy.ID},
 		},
 		{
 			recipients: &search.Recipients{
 				ContactIDs:      []models.ContactID{testdata.George.ID, testdata.Bob.ID},
 				ExcludeGroupIDs: []models.GroupID{group2.ID},
 			},
-			expectedIDs:        []models.ContactID{testdata.Bob.ID},
-			expectedCreatedIDs: []models.ContactID{},
+			expectedIDs: []models.ContactID{testdata.Bob.ID},
 		},
 		{
 			recipients: &search.Recipients{
 				ContactIDs: []models.ContactID{testdata.Bob.ID},
 				URNs:       []urns.URN{"tel:+1234567890", "tel:+1234567891"},
 			},
-			expectedIDs:        []models.ContactID{testdata.Bob.ID, 30000, 30001},
-			expectedCreatedIDs: []models.ContactID{30000, 30001},
+			expectedIDs: []models.ContactID{testdata.Bob.ID, 30000, 30001},
 		},
 		{
 			recipients: &search.Recipients{
 				Query:      `name = "Cathy" OR name = "Bob"`,
 				QueryLimit: 1,
 			},
-			expectedIDs:        []models.ContactID{testdata.Cathy.ID},
-			expectedCreatedIDs: []models.ContactID{},
+			expectedIDs: []models.ContactID{testdata.Cathy.ID},
 		},
 	}
 
 	for i, tc := range tcs {
-		actualIDs, actualCreatedIDs, err := search.ResolveRecipients(ctx, rt, oa, tc.recipients)
+		actualIDs, err := search.ResolveRecipients(ctx, rt, oa, tc.recipients)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "contact ids mismatch in %d", i)
-		assert.ElementsMatch(t, tc.expectedCreatedIDs, actualCreatedIDs, "created contact ids mismatch in %d", i)
 	}
 }

--- a/core/tasks/msgs/send_broadcast.go
+++ b/core/tasks/msgs/send_broadcast.go
@@ -62,7 +62,7 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, bcast *mod
 		return errors.Wrapf(err, "error getting org assets")
 	}
 
-	contactIDs, _, err := search.ResolveRecipients(ctx, rt, oa, &search.Recipients{
+	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, &search.Recipients{
 		ContactIDs:      bcast.ContactIDs,
 		GroupIDs:        bcast.GroupIDs,
 		URNs:            bcast.URNs,
@@ -75,10 +75,12 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, bcast *mod
 	}
 
 	// if there are no contacts to send to, mark our broadcast as sent, we are done
-	if len(contactIDs) == 0 && bcast.ID != models.NilBroadcastID {
-		err = models.MarkBroadcastSent(ctx, rt.DB, bcast.ID)
-		if err != nil {
-			return errors.Wrapf(err, "error marking broadcast as sent")
+	if len(contactIDs) == 0 {
+		if bcast.ID != models.NilBroadcastID {
+			err = models.MarkBroadcastSent(ctx, rt.DB, bcast.ID)
+			if err != nil {
+				return errors.Wrapf(err, "error marking broadcast as sent")
+			}
 		}
 		return nil
 	}

--- a/core/tasks/starts/start_flow.go
+++ b/core/tasks/starts/start_flow.go
@@ -61,7 +61,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, start *mod
 		return errors.Wrap(err, "error loading org assets")
 	}
 
-	var contactIDs, createdContactIDs []models.ContactID
+	var contactIDs []models.ContactID
 
 	if start.CreateContact {
 		// if we are meant to create a new contact, do so
@@ -70,7 +70,6 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, start *mod
 			return errors.Wrapf(err, "error creating new contact")
 		}
 		contactIDs = []models.ContactID{contact.ID()}
-		createdContactIDs = []models.ContactID{contact.ID()}
 	} else {
 		// otherwise resolve recipients across contacts, groups, urns etc
 
@@ -80,7 +79,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, start *mod
 			queryLimit = 1
 		}
 
-		contactIDs, createdContactIDs, err = search.ResolveRecipients(ctx, rt, oa, &search.Recipients{
+		contactIDs, err = search.ResolveRecipients(ctx, rt, oa, &search.Recipients{
 			ContactIDs:      start.ContactIDs,
 			GroupIDs:        start.GroupIDs,
 			URNs:            start.URNs,
@@ -94,7 +93,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, start *mod
 	}
 
 	// mark our start as starting, last task will mark as complete
-	err = models.MarkStartStarted(ctx, rt.DB, start.ID, len(contactIDs), createdContactIDs)
+	err = models.MarkStartStarted(ctx, rt.DB, start.ID, len(contactIDs))
 	if err != nil {
 		return errors.Wrapf(err, "error marking start as started")
 	}


### PR DESCRIPTION
Mostly re-organizing code but contains one meaningful change - in the past for flow starts we've resolved URNs to contact ids and then saved those back onto the start for record keeping. I was going to make broadcasts do the same thing but have talked myself out of it because... in the case of starts, now pretty much everything is a query and we never save those contact ids back onto the start. So now I've gotten rid of that code for starts and given up on the idea that a start or broadcast should save the final set of contact ids. Even for groups it's misleading because contact membership can obviously change after a start or broadcast.