### PR TITLE
🚦 Courier queuing updates

### DIFF
--- a/core/hooks/send_messages.go
+++ b/core/hooks/send_messages.go
@@ -3,11 +3,10 @@ package hooks
 import (
 	"context"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/msgio"
 	"github.com/nyaruka/mailroom/runtime"
-
-	"github.com/jmoiron/sqlx"
 )
 
 // SendMessagesHook is our hook for sending scene messages
@@ -20,17 +19,15 @@ func (h *sendMessagesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *s
 	msgs := make([]*models.Msg, 0, 1)
 
 	// for each scene gather all our messages
-	for s, args := range scenes {
+	for _, args := range scenes {
 		sceneMsgs := make([]*models.Msg, 0, 1)
 
 		for _, m := range args {
 			sceneMsgs = append(sceneMsgs, m.(*models.Msg))
 		}
 
-		// if our scene has a timeout, set it on our last message
-		if len(sceneMsgs) > 0 && s.Session().Timeout() != nil && s.Session().WaitStartedOn() != nil {
-			sceneMsgs[len(sceneMsgs)-1].SetTimeout(*s.Session().WaitStartedOn(), *s.Session().Timeout())
-		}
+		// mark the last message in the sprint (used for setting timeouts)
+		sceneMsgs[len(sceneMsgs)-1].LastInSprint = true
 
 		msgs = append(msgs, sceneMsgs...)
 	}

--- a/core/msgio/courier_test.go
+++ b/core/msgio/courier_test.go
@@ -1,6 +1,7 @@
 package msgio_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/msgio"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
 	"github.com/nyaruka/null/v2"
@@ -35,6 +37,7 @@ func TestNewCourierMsg(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, oa.Org().Suspended())
 
+	_, cathy := testdata.Cathy.Load(rt, oa)
 	channel := oa.ChannelByUUID(testdata.TwilioChannel.UUID)
 	flow, _ := oa.FlowByID(testdata.Favorites.ID)
 	urn := urns.URN(fmt.Sprintf("tel:+250700000001?id=%d", testdata.Cathy.URNID))
@@ -52,34 +55,24 @@ func TestNewCourierMsg(t *testing.T) {
 
 	// create a non-priority flow message.. i.e. the session isn't responding to an incoming message
 	testdata.InsertWaitingSession(rt, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, testdata.Favorites, models.NilCallID, time.Now(), time.Now(), false, nil)
-	_, flowContact := testdata.Cathy.Load(rt, oa)
-	session, err := models.FindWaitingSessionForContact(ctx, rt.DB, rt.SessionStorage, oa, models.FlowTypeMessaging, flowContact)
+	session, err := models.FindWaitingSessionForContact(ctx, rt.DB, rt.SessionStorage, oa, models.FlowTypeMessaging, cathy)
 	require.NoError(t, err)
 
 	msg1, err := models.NewOutgoingFlowMsg(rt, oa.Org(), channel, session, flow, flowMsg1, time.Date(2021, 11, 9, 14, 3, 30, 0, time.UTC))
 	require.NoError(t, err)
 
-	cathy := session.Contact()
-
-	err = models.InsertMessages(ctx, rt.DB, []*models.Msg{msg1})
-	require.NoError(t, err)
-
-	cmsg1, err := msgio.NewCourierMsg(oa, msg1, channel)
-	assert.NoError(t, err)
-
-	marshaled := jsonx.MustMarshal(cmsg1)
-
-	test.AssertEqualJSON(t, []byte(fmt.Sprintf(`{
+	createAndAssertCourierMsg(t, ctx, rt, oa, msg1, fmt.Sprintf(`{
 		"attachments": [
 			"image/jpeg:https://dl-foo.com/image.jpg"
 		],
 		"channel_uuid": "74729f45-7f29-4868-9dc4-90e491e3c7d8",
 		"contact_id": 10000,
+		"contact_last_seen_on": null,
 		"contact_urn_id": 10000,
 		"created_on": "2021-11-09T14:03:30Z",
 		"flow": {"uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", "name": "Favorites"},
 		"high_priority": false,
-		"id": %d,
+		"id": 1,
 		"locale": "eng-US",
 		"metadata": {
 			"templating": {
@@ -101,7 +94,7 @@ func TestNewCourierMsg(t *testing.T) {
 		"tps_cost": 2,
 		"urn": "tel:+250700000001?id=10000",
 		"uuid": "%s"
-	}`, msg1.ID(), session.ID(), msg1.UUID())), marshaled)
+	}`, session.ID(), msg1.UUID()))
 
 	// create a priority flow message.. i.e. the session is responding to an incoming message
 	flowMsg2 := flows.NewMsgOut(
@@ -118,23 +111,16 @@ func TestNewCourierMsg(t *testing.T) {
 	msg2, err := models.NewOutgoingFlowMsg(rt, oa.Org(), channel, session, flow, flowMsg2, time.Date(2021, 11, 9, 14, 3, 30, 0, time.UTC))
 	require.NoError(t, err)
 
-	err = models.InsertMessages(ctx, rt.DB, []*models.Msg{msg2})
-	require.NoError(t, err)
-
-	cmsg2, err := msgio.NewCourierMsg(oa, msg2, channel)
-	assert.NoError(t, err)
-
-	marshaled = jsonx.MustMarshal(cmsg2)
-
-	test.AssertEqualJSON(t, []byte(fmt.Sprintf(`{
+	createAndAssertCourierMsg(t, ctx, rt, oa, msg2, fmt.Sprintf(`{
 		"channel_uuid": "74729f45-7f29-4868-9dc4-90e491e3c7d8",
 		"contact_id": 10000,
+		"contact_last_seen_on": null,
 		"contact_urn_id": 10000,
 		"created_on": "2021-11-09T14:03:30Z",
 		"flow": {"uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", "name": "Favorites"},
 		"response_to_external_id": "EX123",
 		"high_priority": true,
-		"id": %d,
+		"id": 3,
 		"org_id": 1,
 		"origin": "flow",
 		"session_id": %d,
@@ -143,36 +129,44 @@ func TestNewCourierMsg(t *testing.T) {
 		"tps_cost": 1,
 		"urn": "tel:+250700000001?id=10000",
 		"uuid": "%s"
-	}`, msg2.ID(), session.ID(), msg2.UUID())), marshaled)
+	}`, session.ID(), msg2.UUID()))
 
-	// try a broadcast message which won't have session and flow fields set
+	// try a broadcast message which won't have session and flow fields set and won't be high priority
 	bcastID := testdata.InsertBroadcast(rt, testdata.Org1, `eng`, map[envs.Language]string{`eng`: "Blast"}, models.NilScheduleID, []*testdata.Contact{testdata.Cathy}, nil)
 	bcastMsg1 := flows.NewMsgOut(urn, assets.NewChannelReference(testdata.TwilioChannel.UUID, "Test Channel"), "Blast", nil, nil, nil, flows.NilMsgTopic, envs.NilLocale, flows.NilUnsendableReason)
 	msg3, err := models.NewOutgoingBroadcastMsg(rt, oa.Org(), channel, cathy, bcastMsg1, time.Date(2021, 11, 9, 14, 3, 30, 0, time.UTC), &models.BroadcastBatch{BroadcastID: bcastID, CreatedByID: testdata.Admin.ID})
 	require.NoError(t, err)
 
-	err = models.InsertMessages(ctx, rt.DB, []*models.Msg{msg3})
-	require.NoError(t, err)
-
-	cmsg3, err := msgio.NewCourierMsg(oa, msg3, channel)
-	assert.NoError(t, err)
-
-	marshaled = jsonx.MustMarshal(cmsg3)
-
-	test.AssertEqualJSON(t, []byte(fmt.Sprintf(`{
+	createAndAssertCourierMsg(t, ctx, rt, oa, msg3, fmt.Sprintf(`{
 		"channel_uuid": "74729f45-7f29-4868-9dc4-90e491e3c7d8",
 		"contact_id": 10000,
+		"contact_last_seen_on": null,
 		"contact_urn_id": 10000,
 		"created_on": "2021-11-09T14:03:30Z",
 		"high_priority": false,
-		"id": %d,
+		"id": 4,
 		"org_id": 1,
 		"origin": "broadcast",
 		"text": "Blast",
 		"tps_cost": 1,
 		"urn": "tel:+250700000001?id=10000",
 		"uuid": "%s"
-	}`, msg3.ID(), msg3.UUID())), marshaled)
+	}`, msg3.UUID()))
+}
+
+func createAndAssertCourierMsg(t *testing.T, ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, m *models.Msg, expectedJSON string) {
+	// insert to db so that it gets an id
+	err := models.InsertMessages(ctx, rt.DB, []*models.Msg{m})
+	require.NoError(t, err)
+
+	channel := oa.ChannelByID(m.ChannelID())
+
+	cmsg3, err := msgio.NewCourierMsg(oa, m, channel)
+	assert.NoError(t, err)
+
+	marshaled := jsonx.MustMarshal(cmsg3)
+
+	test.AssertEqualJSON(t, []byte(expectedJSON), marshaled)
 }
 
 func TestQueueCourierMessages(t *testing.T) {

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -21,7 +21,7 @@ func TestSend(t *testing.T) {
 		"cathy_ticket_id": fmt.Sprintf("%d", cathyTicket.ID),
 	})
 
-	testsuite.AssertCourierQueues(t, map[string][]int{"msgs:74729f45-7f29-4868-9dc4-90e491e3c7d8|10/0": {1, 1, 1}})
+	testsuite.AssertCourierQueues(t, map[string][]int{"msgs:74729f45-7f29-4868-9dc4-90e491e3c7d8|10/1": {1, 1, 1}})
 }
 
 func TestResend(t *testing.T) {


### PR DESCRIPTION
* Fix not queuing chat/ticket messages as high priority
* Add `contact_last_seen_on` to queued messages
* Simplify transient fields on `models.Msg` which are only needed for courier