### PR TITLE
Just noop if trying to sync an Android channel that doesn't have an FCM ID

### DIFF
--- a/core/msgio/android.go
+++ b/core/msgio/android.go
@@ -21,7 +21,7 @@ func SyncAndroidChannel(fc *fcm.Client, channel *models.Channel) error {
 	// no FCM ID for this channel, noop, we can't trigger a sync
 	fcmID := channel.ConfigValue(models.ChannelConfigFCMID, "")
 	if fcmID == "" {
-		return errors.New("channel has no FCM ID")
+		return nil
 	}
 
 	sync := &fcm.Message{

--- a/core/msgio/android_test.go
+++ b/core/msgio/android_test.go
@@ -84,7 +84,7 @@ func TestSyncAndroidChannel(t *testing.T) {
 	err = msgio.SyncAndroidChannel(nil, channel1)
 	assert.EqualError(t, err, "instance has no FCM configuration")
 	err = msgio.SyncAndroidChannel(fc, channel1)
-	assert.EqualError(t, err, "channel has no FCM ID")
+	assert.NoError(t, err)
 	err = msgio.SyncAndroidChannel(fc, channel2)
 	assert.EqualError(t, err, "error syncing channel: 401 error: 401 Unauthorized")
 	err = msgio.SyncAndroidChannel(fc, channel3)


### PR DESCRIPTION
Apparently this is quite normal..