### PR TITLE
Fix not supporting channel events with extra with non-string values

### DIFF
--- a/core/models/channel_event.go
+++ b/core/models/channel_event.go
@@ -39,7 +39,7 @@ type ChannelEvent struct {
 		ChannelID  ChannelID        `json:"channel_id"   db:"channel_id"`
 		ContactID  ContactID        `json:"contact_id"   db:"contact_id"`
 		URNID      URNID            `json:"urn_id"       db:"contact_urn_id"`
-		Extra      null.Map[string] `json:"extra"        db:"extra"`
+		Extra      null.Map[any]    `json:"extra"        db:"extra"`
 		OccurredOn time.Time        `json:"occurred_on"  db:"occurred_on"`
 
 		// only in JSON representation
@@ -50,14 +50,21 @@ type ChannelEvent struct {
 	}
 }
 
-func (e *ChannelEvent) ID() ChannelEventID       { return e.e.ID }
-func (e *ChannelEvent) ContactID() ContactID     { return e.e.ContactID }
-func (e *ChannelEvent) URNID() URNID             { return e.e.URNID }
-func (e *ChannelEvent) OrgID() OrgID             { return e.e.OrgID }
-func (e *ChannelEvent) ChannelID() ChannelID     { return e.e.ChannelID }
-func (e *ChannelEvent) IsNewContact() bool       { return e.e.NewContact }
-func (e *ChannelEvent) OccurredOn() time.Time    { return e.e.OccurredOn }
-func (e *ChannelEvent) Extra() map[string]string { return e.e.Extra }
+func (e *ChannelEvent) ID() ChannelEventID    { return e.e.ID }
+func (e *ChannelEvent) ContactID() ContactID  { return e.e.ContactID }
+func (e *ChannelEvent) URNID() URNID          { return e.e.URNID }
+func (e *ChannelEvent) OrgID() OrgID          { return e.e.OrgID }
+func (e *ChannelEvent) ChannelID() ChannelID  { return e.e.ChannelID }
+func (e *ChannelEvent) IsNewContact() bool    { return e.e.NewContact }
+func (e *ChannelEvent) OccurredOn() time.Time { return e.e.OccurredOn }
+func (e *ChannelEvent) Extra() map[string]any { return e.e.Extra }
+func (e *ChannelEvent) ExtraString(key string) string {
+	asStr, ok := e.e.Extra[key].(string)
+	if ok {
+		return asStr
+	}
+	return ""
+}
 
 // MarshalJSON is our custom marshaller so that our inner struct get output
 func (e *ChannelEvent) MarshalJSON() ([]byte, error) {
@@ -81,7 +88,7 @@ func (e *ChannelEvent) Insert(ctx context.Context, db DBorTx) error {
 }
 
 // NewChannelEvent creates a new channel event for the passed in parameters, returning it
-func NewChannelEvent(eventType ChannelEventType, orgID OrgID, channelID ChannelID, contactID ContactID, urnID URNID, extra map[string]string, isNewContact bool) *ChannelEvent {
+func NewChannelEvent(eventType ChannelEventType, orgID OrgID, channelID ChannelID, contactID ContactID, urnID URNID, extra map[string]any, isNewContact bool) *ChannelEvent {
 	event := &ChannelEvent{}
 	e := &event.e
 
@@ -93,9 +100,9 @@ func NewChannelEvent(eventType ChannelEventType, orgID OrgID, channelID ChannelI
 	e.NewContact = isNewContact
 
 	if extra == nil {
-		e.Extra = null.Map[string]{}
+		e.Extra = null.Map[any]{}
 	} else {
-		e.Extra = null.Map[string](extra)
+		e.Extra = null.Map[any](extra)
 	}
 
 	now := time.Now()

--- a/core/models/channel_event_test.go
+++ b/core/models/channel_event_test.go
@@ -24,15 +24,17 @@ func TestChannelEvents(t *testing.T) {
 	err := e.Insert(ctx, rt.DB)
 	assert.NoError(t, err)
 	assert.NotZero(t, e.ID())
-	assert.Equal(t, map[string]string{}, e.Extra())
+	assert.Equal(t, map[string]any{}, e.Extra())
 	assert.True(t, e.OccurredOn().After(start))
 
 	// with extra
-	e2 := models.NewChannelEvent(models.MOMissEventType, testdata.Org1.ID, testdata.TwilioChannel.ID, testdata.Cathy.ID, testdata.Cathy.URNID, map[string]string{"referral_id": "foobar"}, false)
+	e2 := models.NewChannelEvent(models.MOMissEventType, testdata.Org1.ID, testdata.TwilioChannel.ID, testdata.Cathy.ID, testdata.Cathy.URNID, map[string]any{"referral_id": "foobar"}, false)
 	err = e2.Insert(ctx, rt.DB)
 	assert.NoError(t, err)
 	assert.NotZero(t, e2.ID())
-	assert.Equal(t, map[string]string{"referral_id": "foobar"}, e2.Extra())
+	assert.Equal(t, map[string]any{"referral_id": "foobar"}, e2.Extra())
+	assert.Equal(t, "foobar", e2.ExtraString("referral_id"))
+	assert.Equal(t, "", e2.ExtraString("invalid"))
 
 	asJSON, err := json.Marshal(e2)
 	assert.NoError(t, err)

--- a/core/tasks/handler/contact_tasks.go
+++ b/core/tasks/handler/contact_tasks.go
@@ -189,7 +189,7 @@ func HandleChannelEvent(ctx context.Context, rt *runtime.Runtime, eventType mode
 		trigger = models.FindMatchingNewConversationTrigger(oa, channel)
 
 	case models.ReferralEventType:
-		trigger = models.FindMatchingReferralTrigger(oa, channel, event.Extra()["referrer_id"])
+		trigger = models.FindMatchingReferralTrigger(oa, channel, event.ExtraString("referrer_id"))
 
 	case models.MOMissEventType:
 		trigger = models.FindMatchingMissedCallTrigger(oa)

--- a/core/tasks/handler/handle_contact_event_test.go
+++ b/core/tasks/handler/handle_contact_event_test.go
@@ -427,7 +427,7 @@ func TestChannelEvents(t *testing.T) {
 		URNID          models.URNID
 		OrgID          models.OrgID
 		ChannelID      models.ChannelID
-		Extra          map[string]string
+		Extra          map[string]any
 		Response       string
 		UpdateLastSeen bool
 	}{


### PR DESCRIPTION
Courier channel events extra are always string -> string... I forgot about android syncs from RP (e.g. https://textit.sentry.io/issues/4472957645/)