### PR TITLE
Simplify where we load a single contact 

### DIFF
--- a/core/handlers/base_test.go
+++ b/core/handlers/base_test.go
@@ -212,10 +212,9 @@ func RunTestCases(t *testing.T, ctx context.Context, rt *runtime.Runtime, tcs []
 		// create scenes for our contacts
 		scenes := make([]*models.Scene, 0, len(tc.Modifiers))
 		for contact, mods := range tc.Modifiers {
-			contacts, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{contact.ID})
+			contact, err := models.LoadContact(ctx, rt.DB, oa, contact.ID)
 			assert.NoError(t, err)
 
-			contact := contacts[0]
 			flowContact, err := contact.FlowContact(oa)
 			assert.NoError(t, err)
 

--- a/core/models/contacts.go
+++ b/core/models/contacts.go
@@ -246,7 +246,7 @@ func LoadContact(ctx context.Context, db Queryer, oa *OrgAssets, id ContactID) (
 		return nil, err
 	}
 	if len(contacts) == 0 {
-		return nil, errors.Errorf("no such contact #%d in org #%d", id, oa.OrgID())
+		return nil, sql.ErrNoRows
 	}
 	return contacts[0], nil
 }
@@ -579,11 +579,10 @@ func CreateContact(ctx context.Context, db DB, oa *OrgAssets, userID UserID, nam
 	}
 
 	// load a full contact so that we can calculate dynamic groups
-	contacts, err := LoadContacts(ctx, db, oa, []ContactID{contactID})
+	contact, err := LoadContact(ctx, db, oa, contactID)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error loading new contact")
 	}
-	contact := contacts[0]
 
 	flowContact, err := contact.FlowContact(oa)
 	if err != nil {
@@ -616,11 +615,10 @@ func GetOrCreateContact(ctx context.Context, db DB, oa *OrgAssets, urnz []urns.U
 	}
 
 	// load a full contact so that we can calculate dynamic groups
-	contacts, err := LoadContacts(ctx, db, oa, []ContactID{contactID})
+	contact, err := LoadContact(ctx, db, oa, contactID)
 	if err != nil {
 		return nil, nil, false, errors.Wrapf(err, "error loading new contact")
 	}
-	contact := contacts[0]
 
 	flowContact, err := contact.FlowContact(oa)
 	if err != nil {

--- a/testsuite/testdata/contacts.go
+++ b/testsuite/testdata/contacts.go
@@ -23,10 +23,10 @@ type Contact struct {
 func (c *Contact) Load(rt *runtime.Runtime, oa *models.OrgAssets) (*models.Contact, *flows.Contact, []*models.ContactURN) {
 	ctx := context.Background()
 
-	contacts, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{c.ID})
-	must(err, len(contacts) == 1)
+	contact, err := models.LoadContact(ctx, rt.DB, oa, c.ID)
+	must(err)
 
-	flowContact, err := contacts[0].FlowContact(oa)
+	flowContact, err := contact.FlowContact(oa)
 	must(err)
 
 	var urnIDs []models.URNID
@@ -36,7 +36,7 @@ func (c *Contact) Load(rt *runtime.Runtime, oa *models.OrgAssets) (*models.Conta
 	urns, err := models.LoadContactURNs(ctx, rt.DB, urnIDs)
 	must(err)
 
-	return contacts[0], flowContact, urns
+	return contact, flowContact, urns
 }
 
 type Group struct {

--- a/web/msg/testdata/send.json
+++ b/web/msg/testdata/send.json
@@ -35,7 +35,7 @@
         },
         "status": 500,
         "response": {
-            "error": "error loading contact: no such contact #123456789 in org #1"
+            "error": "error loading contact: sql: no rows in result set"
         }
     },
     {


### PR DESCRIPTION
And ignore events rather than error when contact no longer exists

Fixes panics where we try to handle a task but the contact has been deleted. e.g. https://textit.sentry.io/issues/4506966895/