### PR TITLE
Simplify message time fields

### DIFF
--- a/core/handlers/ivr_created.go
+++ b/core/handlers/ivr_created.go
@@ -34,7 +34,7 @@ func handleIVRCreated(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa 
 		return nil
 	}
 
-	msg := models.NewOutgoingIVR(rt.Config, oa.OrgID(), call, event.Msg, event.CreatedOn())
+	msg := models.NewOutgoingIVR(rt.Config, oa.OrgID(), call, event.Msg)
 
 	// register to have this message committed
 	scene.AppendToEventPreCommitHook(hooks.CommitIVRHook, msg)

--- a/core/handlers/msg_created.go
+++ b/core/handlers/msg_created.go
@@ -100,7 +100,7 @@ func handleMsgCreated(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa 
 		tpl = oa.TemplateByUUID(event.Msg.Templating().Template().UUID)
 	}
 
-	msg, err := models.NewOutgoingFlowMsg(rt, oa.Org(), channel, scene.Session(), flow, event.Msg, tpl, event.CreatedOn())
+	msg, err := models.NewOutgoingFlowMsg(rt, oa.Org(), channel, scene.Session(), flow, event.Msg, tpl)
 	if err != nil {
 		return errors.Wrapf(err, "error creating outgoing message to %s", event.Msg.URN())
 	}

--- a/core/handlers/optin_requested.go
+++ b/core/handlers/optin_requested.go
@@ -56,7 +56,7 @@ func handleOptInRequested(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx,
 		flow = flowAsset.(*models.Flow)
 	}
 
-	msg := models.NewOutgoingOptInMsg(rt, scene.Session(), flow, optIn, channel, urn, event.CreatedOn())
+	msg := models.NewOutgoingOptInMsg(rt, scene.Session(), flow, optIn, channel, urn)
 
 	// register to have this message committed and sent
 	scene.AppendToEventPreCommitHook(hooks.CommitMessagesHook, msg)

--- a/core/ivr/ivr.go
+++ b/core/ivr/ivr.go
@@ -576,7 +576,7 @@ func buildMsgResume(
 	msgIn := flows.NewMsgIn(msgUUID, urn, channel.Reference(), resume.Input, attachments)
 
 	// create an incoming message
-	msg := models.NewIncomingIVR(rt.Config, oa.OrgID(), call, msgIn, time.Now())
+	msg := models.NewIncomingIVR(rt.Config, oa.OrgID(), call, msgIn)
 
 	// commit it
 	if err := models.InsertMessages(ctx, rt.DB, []*models.Msg{msg}); err != nil {

--- a/core/models/broadcasts.go
+++ b/core/models/broadcasts.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"context"
-	"time"
 
 	"github.com/lib/pq"
 	"github.com/nyaruka/gocommon/i18n"
@@ -292,7 +291,7 @@ func (b *BroadcastBatch) createMessage(rt *runtime.Runtime, oa *OrgAssets, c *Co
 	// create our outgoing message
 	out, ch := NewMsgOut(oa, contact, text, attachments, quickReplies, locale)
 
-	msg, err := NewOutgoingBroadcastMsg(rt, oa.Org(), ch, contact, out, time.Now(), b)
+	msg, err := NewOutgoingBroadcastMsg(rt, oa.Org(), ch, contact, out, b)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating outgoing message")
 	}

--- a/core/runner/runner_test.go
+++ b/core/runner/runner_test.go
@@ -53,7 +53,7 @@ func TestStartFlowBatch(t *testing.T) {
 		Returns(2)
 
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE contact_id = ANY($1) AND text = 'Hey, how are you?' AND org_id = 1 AND status = 'Q' 
-		AND queued_on IS NOT NULL AND direction = 'O' AND msg_type = 'T'`, pq.Array([]models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})).
+		AND direction = 'O' AND msg_type = 'T'`, pq.Array([]models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})).
 		Returns(2)
 
 	assertdb.Query(t, rt.DB, `SELECT status FROM flows_flowstart WHERE id = $1`, start1.ID).Returns("P")

--- a/web/msg/send.go
+++ b/web/msg/send.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/msgio"
@@ -57,9 +56,9 @@ func handleSend(ctx context.Context, rt *runtime.Runtime, r *sendRequest) (any, 
 	var msg *models.Msg
 
 	if r.TicketID != models.NilTicketID {
-		msg, err = models.NewOutgoingTicketMsg(rt, oa.Org(), ch, contact, out, dates.Now(), r.TicketID, r.UserID)
+		msg, err = models.NewOutgoingTicketMsg(rt, oa.Org(), ch, contact, out, r.TicketID, r.UserID)
 	} else {
-		msg, err = models.NewOutgoingChatMsg(rt, oa.Org(), ch, contact, out, dates.Now(), r.UserID)
+		msg, err = models.NewOutgoingChatMsg(rt, oa.Org(), ch, contact, out, r.UserID)
 	}
 
 	if err != nil {

--- a/web/msg/testdata/send.json
+++ b/web/msg/testdata/send.json
@@ -63,7 +63,7 @@
             "text": "hello",
             "attachments": [],
             "status": "Q",
-            "created_on": "2018-07-06T12:30:00.123456789Z",
+            "created_on": "$recent_timestamp$",
             "modified_on": "$recent_timestamp$"
         },
         "db_assertions": [
@@ -104,7 +104,7 @@
                 "audio/mp3:https://aws.com/test/test.mp3"
             ],
             "status": "Q",
-            "created_on": "2018-07-06T12:30:00.123456789Z",
+            "created_on": "$recent_timestamp$",
             "modified_on": "$recent_timestamp$"
         }
     },
@@ -134,7 +134,7 @@
             "text": "we can help",
             "attachments": [],
             "status": "Q",
-            "created_on": "2018-07-06T12:30:00.123456789Z",
+            "created_on": "$recent_timestamp$",
             "modified_on": "$recent_timestamp$"
         },
         "db_assertions": [


### PR DESCRIPTION
 * Make `Msg.created_on` always be db insertion time
 * Stop writing `queued_on` which isn't meaningful - it was being set to db insert time because we create outgoing messages with status=Q to save having to update them after queuing.