### PR TITLE
Deprecate `broadcast.template_state` and add `broadcast.expressions`

### DIFF
--- a/core/models/broadcasts_test.go
+++ b/core/models/broadcasts_test.go
@@ -29,8 +29,8 @@ func TestInsertBroadcast(t *testing.T) {
 	bcast := models.NewBroadcast(
 		testdata.Org1.ID,
 		flows.BroadcastTranslations{"eng": {Text: "Hi there"}},
-		models.TemplateStateUnevaluated,
 		"eng",
+		true,
 		optIn.ID,
 		[]models.GroupID{testdata.DoctorsGroup.ID},
 		[]models.ContactID{testdata.Alexandria.ID, testdata.Bob.ID, testdata.Cathy.ID},
@@ -93,8 +93,8 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 	bcast := models.NewBroadcast(
 		testdata.Org1.ID,
 		translations,
-		models.TemplateStateUnevaluated,
 		"eng",
+		true,
 		optIn.ID,
 		[]models.GroupID{testdata.DoctorsGroup.ID},
 		[]models.ContactID{testdata.Alexandria.ID, testdata.Bob.ID, testdata.Cathy.ID},

--- a/core/models/schedules.go
+++ b/core/models/schedules.go
@@ -295,6 +295,7 @@ SELECT ROW_TO_JSON(s) FROM (
                 b.translations,
                 'unevaluated' AS template_state,
                 b.base_language,
+				TRUE AS expressions,
                 b.optin_id,
                 (SELECT ARRAY_AGG(bc.contact_id) FROM (SELECT contact_id FROM msgs_broadcast_contacts WHERE broadcast_id = b.id) bc) AS contact_ids,
                 (SELECT ARRAY_AGG(bg.contactgroup_id) FROM (SELECT contactgroup_id FROM msgs_broadcast_groups WHERE broadcast_id = b.id) bg) AS group_ids

--- a/core/models/schedules_test.go
+++ b/core/models/schedules_test.go
@@ -131,13 +131,14 @@ func TestGetExpired(t *testing.T) {
 	bcast := schedules[2].Broadcast
 	assert.NotNil(t, bcast)
 	assert.Equal(t, i18n.Language("eng"), bcast.BaseLanguage)
-	assert.Equal(t, models.TemplateStateUnevaluated, bcast.TemplateState)
 	assert.Equal(t, "Test message", bcast.Translations["eng"].Text)
 	assert.Equal(t, "Un Message", bcast.Translations["fra"].Text)
+	assert.True(t, bcast.Expressions)
 	assert.Equal(t, optIn.ID, bcast.OptInID)
 	assert.Equal(t, testdata.Org1.ID, bcast.OrgID)
 	assert.Equal(t, []models.ContactID{testdata.Cathy.ID, testdata.George.ID}, bcast.ContactIDs)
 	assert.Equal(t, []models.GroupID{testdata.DoctorsGroup.ID}, bcast.GroupIDs)
+	assert.Equal(t, models.TemplateStateUnevaluated, bcast.TemplateState) // deprecated
 }
 
 func TestGetNextFire(t *testing.T) {

--- a/core/tasks/msgs/send_broadcast_test.go
+++ b/core/tasks/msgs/send_broadcast_test.go
@@ -204,8 +204,8 @@ func TestBroadcastTask(t *testing.T) {
 
 	tcs := []struct {
 		translations    flows.BroadcastTranslations
-		templateState   models.TemplateState
 		baseLanguage    i18n.Language
+		expressions     bool
 		optIn           *testdata.OptIn
 		groupIDs        []models.GroupID
 		contactIDs      []models.ContactID
@@ -221,8 +221,8 @@ func TestBroadcastTask(t *testing.T) {
 			translations: flows.BroadcastTranslations{
 				"eng": {Text: "hello world"},
 			},
-			templateState:   models.TemplateStateEvaluated,
 			baseLanguage:    "eng",
+			expressions:     false,
 			optIn:           polls,
 			groupIDs:        []models.GroupID{testdata.DoctorsGroup.ID},
 			contactIDs:      []models.ContactID{testdata.Cathy.ID},
@@ -236,8 +236,8 @@ func TestBroadcastTask(t *testing.T) {
 			translations: flows.BroadcastTranslations{
 				"eng": {Text: "hi @(title(contact.name)) from @globals.org_name goflow URN: @urns.tel Gender: @fields.gender"},
 			},
-			templateState:   models.TemplateStateUnevaluated,
 			baseLanguage:    "eng",
+			expressions:     true,
 			contactIDs:      []models.ContactID{testdata.Cathy.ID},
 			exclusions:      models.NoExclusions,
 			createdByID:     testdata.Agent.ID,
@@ -250,8 +250,8 @@ func TestBroadcastTask(t *testing.T) {
 				"eng": {Text: "hello"},
 				"spa": {Text: "hola"},
 			},
-			templateState:   models.TemplateStateUnevaluated,
 			baseLanguage:    "eng",
+			expressions:     true,
 			query:           "name = Cathy OR name = George OR name = Bob",
 			exclusions:      models.NoExclusions,
 			queue:           tasks.BatchQueue,
@@ -263,8 +263,8 @@ func TestBroadcastTask(t *testing.T) {
 				"eng": {Text: "goodbye"},
 				"spa": {Text: "chau"},
 			},
-			templateState:   models.TemplateStateUnevaluated,
 			baseLanguage:    "eng",
+			expressions:     true,
 			query:           "name = Cathy OR name = George OR name = Bob",
 			exclusions:      models.Exclusions{NotSeenSinceDays: 60},
 			queue:           tasks.BatchQueue,
@@ -282,7 +282,7 @@ func TestBroadcastTask(t *testing.T) {
 			optInID = tc.optIn.ID
 		}
 
-		bcast := models.NewBroadcast(oa.OrgID(), tc.translations, tc.templateState, tc.baseLanguage, optInID, tc.groupIDs, tc.contactIDs, tc.URNs, tc.query, tc.exclusions, tc.createdByID)
+		bcast := models.NewBroadcast(oa.OrgID(), tc.translations, tc.baseLanguage, tc.expressions, optInID, tc.groupIDs, tc.contactIDs, tc.URNs, tc.query, tc.exclusions, tc.createdByID)
 
 		task := &msgs.SendBroadcastTask{Broadcast: bcast}
 

--- a/web/msg/broadcast.go
+++ b/web/msg/broadcast.go
@@ -29,10 +29,10 @@ func init() {
 //	  "user_id": 56,
 //	  "translations": {"eng": {"text": "Hello @contact"}, "spa": {"text": "Hola @contact"}},
 //	  "base_language": "eng",
+//	  "optin_id": 456,
 //	  "group_ids": [101, 102],
 //	  "contact_ids": [4646],
 //	  "urns": [4646],
-//	  "optin_id": 456,
 //	  "schedule": {
 //	    "start": "2024-06-20T09:04:30Z",
 //	    "repeat_period": "W",
@@ -40,18 +40,20 @@ func init() {
 //	  }
 //	}
 type broadcastRequest struct {
-	OrgID        models.OrgID                `json:"org_id"        validate:"required"`
-	UserID       models.UserID               `json:"user_id"       validate:"required"`
-	Translations flows.BroadcastTranslations `json:"translations"  validate:"required"`
-	BaseLanguage i18n.Language               `json:"base_language" validate:"required"`
-	GroupIDs     []models.GroupID            `json:"group_ids"`
-	ContactIDs   []models.ContactID          `json:"contact_ids"`
-	URNs         []urns.URN                  `json:"urns"`
-	Query        string                      `json:"query"`
-	NodeUUID     flows.NodeUUID              `json:"node_uuid"`
-	Exclude      models.Exclusions           `json:"exclude"`
-	OptInID      models.OptInID              `json:"optin_id"`
-	Schedule     *struct {
+	OrgID             models.OrgID                `json:"org_id"        validate:"required"`
+	UserID            models.UserID               `json:"user_id"       validate:"required"`
+	Translations      flows.BroadcastTranslations `json:"translations"  validate:"required"`
+	BaseLanguage      i18n.Language               `json:"base_language" validate:"required"`
+	OptInID           models.OptInID              `json:"optin_id"`
+	TemplateID        models.TemplateID           `json:"template_id"`
+	TemplateVariables []string                    `json:"template_variables"`
+	GroupIDs          []models.GroupID            `json:"group_ids"`
+	ContactIDs        []models.ContactID          `json:"contact_ids"`
+	URNs              []urns.URN                  `json:"urns"`
+	Query             string                      `json:"query"`
+	NodeUUID          flows.NodeUUID              `json:"node_uuid"`
+	Exclude           models.Exclusions           `json:"exclude"`
+	Schedule          *struct {
 		Start            time.Time           `json:"start"`
 		RepeatPeriod     models.RepeatPeriod `json:"repeat_period"`
 		RepeatDaysOfWeek string              `json:"repeat_days_of_week"`
@@ -84,7 +86,9 @@ func handleBroadcast(ctx context.Context, rt *runtime.Runtime, r *broadcastReque
 		return nil, 0, fmt.Errorf("error beginning transaction: %w", err)
 	}
 
-	bcast := models.NewBroadcast(r.OrgID, r.Translations, models.TemplateStateUnevaluated, r.BaseLanguage, r.OptInID, r.GroupIDs, r.ContactIDs, r.URNs, r.Query, r.Exclude, r.UserID)
+	bcast := models.NewBroadcast(r.OrgID, r.Translations, r.BaseLanguage, true, r.OptInID, r.GroupIDs, r.ContactIDs, r.URNs, r.Query, r.Exclude, r.UserID)
+	bcast.TemplateID = r.TemplateID
+	bcast.TemplateVariables = r.TemplateVariables
 
 	if r.Schedule != nil {
 		sched, err := models.NewSchedule(oa, r.Schedule.Start, r.Schedule.RepeatPeriod, r.Schedule.RepeatDaysOfWeek)


### PR DESCRIPTION
`TemplateState` getting a bit confusing alongside `TemplateID` and `TemplateVariables` that mean something completely different. Matches https://github.com/nyaruka/rapidpro/pull/5350