### PR TITLE
Refactor FCM functionality

### DIFF
--- a/core/hooks/send_messages.go
+++ b/core/hooks/send_messages.go
@@ -32,6 +32,6 @@ func (h *sendMessagesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *s
 		msgs = append(msgs, sceneMsgs...)
 	}
 
-	msgio.QueueMessages(ctx, rt, tx, nil, msgs)
+	msgio.QueueMessages(ctx, rt, tx, msgs)
 	return nil
 }

--- a/core/msgio/android_test.go
+++ b/core/msgio/android_test.go
@@ -16,8 +16,7 @@ func TestSyncAndroidChannel(t *testing.T) {
 
 	defer testsuite.Reset(testsuite.ResetData)
 
-	mockFCM := testsuite.NewMockFCMService("FCMID3")
-	fc := mockFCM.GetClient(ctx)
+	mockFCM := rt.FCM.(*testsuite.MockFCMClient)
 
 	// create some Android channels
 	testChannel1 := testdata.InsertChannel(rt, testdata.Org1, "A", "Android 1", "123", []string{"tel"}, "SR", map[string]any{"FCM_ID": ""})       // no FCM ID
@@ -31,13 +30,13 @@ func TestSyncAndroidChannel(t *testing.T) {
 	channel2 := oa.ChannelByID(testChannel2.ID)
 	channel3 := oa.ChannelByID(testChannel3.ID)
 
-	err = msgio.SyncAndroidChannel(ctx, rt, nil, channel1)
-	assert.EqualError(t, err, "instance has no FCM configuration")
-	err = msgio.SyncAndroidChannel(ctx, rt, fc, channel1)
+	err = msgio.SyncAndroidChannel(ctx, rt, channel1)
+	assert.NoError(t, err) // noop
+	err = msgio.SyncAndroidChannel(ctx, rt, channel1)
 	assert.NoError(t, err)
-	err = msgio.SyncAndroidChannel(ctx, rt, fc, channel2)
+	err = msgio.SyncAndroidChannel(ctx, rt, channel2)
 	assert.EqualError(t, err, "error syncing channel: 401 error: 401 Unauthorized")
-	err = msgio.SyncAndroidChannel(ctx, rt, fc, channel3)
+	err = msgio.SyncAndroidChannel(ctx, rt, channel3)
 	assert.NoError(t, err)
 
 	// check that we try to sync the 2 channels with FCM IDs, even tho one fails
@@ -48,17 +47,4 @@ func TestSyncAndroidChannel(t *testing.T) {
 	assert.Equal(t, "high", mockFCM.Messages[0].Android.Priority)
 	assert.Equal(t, "sync", mockFCM.Messages[0].Android.CollapseKey)
 	assert.Equal(t, map[string]string{"msg": "sync"}, mockFCM.Messages[0].Data)
-}
-
-func TestCreateFCMClient(t *testing.T) {
-	ctx, rt := testsuite.Runtime()
-
-	rt.Config.AndroidFCMServiceAccountFile = `testdata/android.json`
-
-	assert.NotNil(t, msgio.CreateFCMClient(ctx, rt.Config))
-
-	rt.Config.AndroidFCMServiceAccountFile = ""
-
-	assert.Nil(t, msgio.CreateFCMClient(ctx, rt.Config))
-
 }

--- a/core/msgio/send_test.go
+++ b/core/msgio/send_test.go
@@ -49,8 +49,7 @@ func TestQueueMessages(t *testing.T) {
 
 	defer testsuite.Reset(testsuite.ResetData)
 
-	mockFCM := testsuite.NewMockFCMService("FCMID3")
-	fc := mockFCM.GetClient(ctx)
+	mockFCM := rt.FCM.(*testsuite.MockFCMClient)
 
 	// create some Andoid channels
 	androidChannel1 := testdata.InsertChannel(rt, testdata.Org1, "A", "Android 1", "123", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID1"})
@@ -158,7 +157,7 @@ func TestQueueMessages(t *testing.T) {
 		rc.Do("FLUSHDB")
 		mockFCM.Messages = nil
 
-		msgio.QueueMessages(ctx, rt, rt.DB, fc, msgs)
+		msgio.QueueMessages(ctx, rt, rt.DB, msgs)
 
 		testsuite.AssertCourierQueues(t, tc.QueueSizes, "courier queue sizes mismatch in '%s'", tc.Description)
 

--- a/core/tasks/channels/cron.go
+++ b/core/tasks/channels/cron.go
@@ -17,7 +17,6 @@ func init() {
 }
 
 type SyncAndroidChannelsCron struct {
-	FCMClient msgio.FCMClient
 }
 
 func (s *SyncAndroidChannelsCron) AllInstances() bool {
@@ -30,11 +29,6 @@ func (s *SyncAndroidChannelsCron) Next(last time.Time) time.Time {
 }
 
 func (s *SyncAndroidChannelsCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
-
-	if s.FCMClient == nil {
-		s.FCMClient = msgio.CreateFCMClient(ctx, rt.Config)
-	}
-
 	oldSeenAndroidChannels, err := models.GetAndroidChannelsToSync(ctx, rt.DB)
 	if err != nil {
 		return nil, fmt.Errorf("error loading old seen android channels: %w", err)
@@ -44,7 +38,7 @@ func (s *SyncAndroidChannelsCron) Run(ctx context.Context, rt *runtime.Runtime) 
 	syncedCount := 0
 
 	for _, channel := range oldSeenAndroidChannels {
-		err := msgio.SyncAndroidChannel(ctx, rt, s.FCMClient, &channel)
+		err := msgio.SyncAndroidChannel(ctx, rt, &channel)
 		if err != nil {
 			slog.Error("error syncing messages", "error", err, "channel_uuid", channel.UUID())
 			erroredCount += 1

--- a/core/tasks/channels/cron_test.go
+++ b/core/tasks/channels/cron_test.go
@@ -17,9 +17,6 @@ func TestSyncAndroidChannelsCron(t *testing.T) {
 
 	defer testsuite.Reset(testsuite.ResetData)
 
-	mockFCM := testsuite.NewMockFCMService("FCMID3", "FCMID4", "FCMID5")
-	fc := mockFCM.GetClient(ctx)
-
 	testChannel1 := testdata.InsertChannel(rt, testdata.Org1, "A", "Android 1", "123", []string{"tel"}, "SR", map[string]any{"FCM_ID": ""})       // no FCM ID
 	testChannel2 := testdata.InsertChannel(rt, testdata.Org1, "A", "Android 2", "234", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID2"}) // invalid FCM ID
 	testChannel3 := testdata.InsertChannel(rt, testdata.Org1, "A", "Android 3", "456", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID3"}) // valid FCM ID
@@ -34,7 +31,7 @@ func TestSyncAndroidChannelsCron(t *testing.T) {
 
 	time.Sleep(5 * time.Millisecond)
 
-	cron := &channels.SyncAndroidChannelsCron{FCMClient: fc}
+	cron := &channels.SyncAndroidChannelsCron{}
 	res, err := cron.Run(ctx, rt)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]any{"synced": 2, "errored": 1}, res)

--- a/core/tasks/msgs/retry_errored_messages.go
+++ b/core/tasks/msgs/retry_errored_messages.go
@@ -42,7 +42,7 @@ func (c *RetryMessagesCron) Run(ctx context.Context, rt *runtime.Runtime) (map[s
 		return nil, fmt.Errorf("error marking messages as queued: %w", err)
 	}
 
-	msgio.QueueMessages(ctx, rt, rt.DB, nil, msgs)
+	msgio.QueueMessages(ctx, rt, rt.DB, msgs)
 
 	return map[string]any{"retried": len(msgs)}, nil
 }

--- a/core/tasks/msgs/send_broadcast_batch.go
+++ b/core/tasks/msgs/send_broadcast_batch.go
@@ -53,6 +53,6 @@ func (t *SendBroadcastBatchTask) Perform(ctx context.Context, rt *runtime.Runtim
 		return fmt.Errorf("error creating broadcast messages: %w", err)
 	}
 
-	msgio.QueueMessages(ctx, rt, rt.DB, nil, msgs)
+	msgio.QueueMessages(ctx, rt, rt.DB, msgs)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
+	google.golang.org/api v0.187.0
 )
 
 require (
@@ -88,7 +89,6 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/api v0.187.0 // indirect
 	google.golang.org/appengine/v2 v2.0.6 // indirect
 	google.golang.org/genproto v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240701130421-f6361c86f094 // indirect

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"context"
 	"database/sql"
 
+	"firebase.google.com/go/v4/messaging"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/gomodule/redigo/redis"
 	"github.com/jmoiron/sqlx"
@@ -16,8 +18,14 @@ type Runtime struct {
 	ReadonlyDB        *sql.DB
 	RP                *redis.Pool
 	ES                *elasticsearch.TypedClient
+	FCM               FCMClient
 	AttachmentStorage storage.Storage
 	SessionStorage    storage.Storage
 	LogStorage        storage.Storage
 	Config            *Config
+}
+
+// FCMClient is an interface to allow mocking in tests
+type FCMClient interface {
+	Send(ctx context.Context, message ...*messaging.Message) (*messaging.BatchResponse, error)
 }

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -76,6 +76,7 @@ func Runtime() (context.Context, *runtime.Runtime) {
 		ReadonlyDB:        dbx.DB,
 		RP:                getRP(),
 		ES:                getES(),
+		FCM:               &MockFCMClient{ValidTokens: []string{"FCMID3", "FCMID4", "FCMID5"}},
 		AttachmentStorage: storage.NewFS(attachmentStorageDir, 0766),
 		SessionStorage:    storage.NewFS(sessionStorageDir, 0766),
 		LogStorage:        storage.NewFS(logStorageDir, 0766),

--- a/web/android/sync.go
+++ b/web/android/sync.go
@@ -30,8 +30,7 @@ func handleSync(ctx context.Context, rt *runtime.Runtime, r *syncRequest) (any, 
 		return nil, 0, fmt.Errorf("missing android channel registration id")
 	}
 
-	fc := msgio.CreateFCMClient(ctx, rt.Config)
-	err = msgio.SyncAndroidChannel(ctx, rt, fc, channel)
+	err = msgio.SyncAndroidChannel(ctx, rt, channel)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error syncing android channel: %w", err)
 	}

--- a/web/msg/resend.go
+++ b/web/msg/resend.go
@@ -44,7 +44,7 @@ func handleResend(ctx context.Context, rt *runtime.Runtime, r *resendRequest) (a
 		return nil, 0, fmt.Errorf("error resending messages: %w", err)
 	}
 
-	msgio.QueueMessages(ctx, rt, rt.DB, nil, resends)
+	msgio.QueueMessages(ctx, rt, rt.DB, resends)
 
 	// response is the ids of the messages that were actually resent
 	resentMsgIDs := make([]models.MsgID, len(resends))

--- a/web/msg/send.go
+++ b/web/msg/send.go
@@ -80,7 +80,7 @@ func handleSend(ctx context.Context, rt *runtime.Runtime, r *sendRequest) (any, 
 		}
 	}
 
-	msgio.QueueMessages(ctx, rt, rt.DB, nil, []*models.Msg{msg})
+	msgio.QueueMessages(ctx, rt, rt.DB, []*models.Msg{msg})
 
 	return map[string]any{
 		"id":          msg.ID(),


### PR DESCRIPTION
* Move client onto runtime
* Simplify testing - tokens and messages are properties of the mocked client, no more "service"