### PR TITLE
Add support for pausing and resuming a task owner within a redis queue

### DIFF
--- a/utils/queues/fair_sorted_test.go
+++ b/utils/queues/fair_sorted_test.go
@@ -88,7 +88,37 @@ func TestQueues(t *testing.T) {
 
 	assertredis.ZGetAll(t, rc, "test:active", map[string]float64{})
 
-	//  if we somehow get into a state where an owner is in the active set but doesn't have queued tasks, pop will retry
+	q.Push(rc, "type1", 1, "task6", queues.DefaultPriority)
+	q.Push(rc, "type1", 1, "task7", queues.DefaultPriority)
+	q.Push(rc, "type1", 2, "task8", queues.DefaultPriority)
+	q.Push(rc, "type1", 2, "task9", queues.DefaultPriority)
+
+	assertPop(1, `"task6"`)
+
+	q.Pause(rc, 1)
+	q.Pause(rc, 1) // no-op if already paused
+
+	assertredis.ZGetAll(t, rc, "test:active", map[string]float64{"2": 0})
+	assertredis.ZGetAll(t, rc, "test:paused", map[string]float64{"1": 1})
+
+	assertPop(2, `"task8"`)
+	assertPop(2, `"task9"`)
+	assertPop(0, "") // no more tasks
+
+	q.Resume(rc, 1)
+	q.Resume(rc, 1) // no-op if already active
+
+	assertredis.ZGetAll(t, rc, "test:active", map[string]float64{"1": 1})
+	assertredis.ZGetAll(t, rc, "test:paused", map[string]float64{})
+
+	assertPop(1, `"task7"`)
+
+	q.Done(rc, 1)
+	q.Done(rc, 1)
+	q.Done(rc, 2)
+	q.Done(rc, 2)
+
+	// if we somehow get into a state where an owner is in the active set but doesn't have queued tasks, pop will retry
 	q.Push(rc, "type1", 1, "task6", queues.DefaultPriority)
 	q.Push(rc, "type1", 2, "task7", queues.DefaultPriority)
 

--- a/utils/queues/lua/fair_sorted_done.lua
+++ b/utils/queues/lua/fair_sorted_done.lua
@@ -1,10 +1,16 @@
-local activeSetKey = KEYS[1]
+local activeSetKey, pausedSetKey = KEYS[1], KEYS[2]
 local ownerID = ARGV[1]
 
+local isPaused = redis.call("ZSCORE", pausedSetKey, ownerID) ~= false
+local setKey = activeSetKey
+if isPaused then
+    setKey = pausedSetKey
+end
+
 -- decrement our workers for this task owner
-local active = tonumber(redis.call("ZINCRBY", activeSetKey, -1, ownerID))
+local active = tonumber(redis.call("ZINCRBY", setKey, -1, ownerID))
 
 -- reset to zero if we somehow go below
 if active < 0 then
-    redis.call("ZADD", activeSetKey, 0, ownerID)
+    redis.call("ZADD", setKey, 0, ownerID)
 end

--- a/utils/queues/lua/fair_sorted_pause.lua
+++ b/utils/queues/lua/fair_sorted_pause.lua
@@ -1,0 +1,11 @@
+local activeSetKey, pausedSetKey = KEYS[1], KEYS[2]
+local ownerID = ARGV[1]
+
+local score = redis.call("ZSCORE", activeSetKey, ownerID)
+if score ~= false then
+    redis.call("ZREM", activeSetKey, ownerID)
+else
+    score = 0
+end
+
+redis.call("ZINCRBY", pausedSetKey, score, ownerID)

--- a/utils/queues/lua/fair_sorted_push.lua
+++ b/utils/queues/lua/fair_sorted_push.lua
@@ -1,0 +1,12 @@
+local activeSetKey, pausedSetKey, queueKey = KEYS[1], KEYS[2], KEYS[3]
+local ownerID, payload, score = ARGV[1], ARGV[2], ARGV[3]
+
+redis.call("ZADD", queueKey, score, payload)
+
+local isPaused = redis.call("ZSCORE", pausedSetKey, ownerID) ~= false
+local setKey = activeSetKey
+if isPaused then
+    setKey = pausedSetKey
+end
+
+redis.call("ZINCRBY", setKey, 0, ownerID)

--- a/utils/queues/lua/fair_sorted_resume.lua
+++ b/utils/queues/lua/fair_sorted_resume.lua
@@ -1,0 +1,11 @@
+local activeSetKey, pausedSetKey = KEYS[1], KEYS[2]
+local ownerID = ARGV[1]
+
+local score = redis.call("ZSCORE", pausedSetKey, ownerID)
+if score ~= false then
+    redis.call("ZREM", pausedSetKey, ownerID)
+else
+    score = 0
+end
+
+redis.call("ZINCRBY", activeSetKey, score, ownerID)

--- a/utils/queues/lua/fair_sorted_size.lua
+++ b/utils/queues/lua/fair_sorted_size.lua
@@ -1,11 +1,18 @@
-local activeSetKey = KEYS[1]
+local activeSetKey, pausedSetKey = KEYS[1], KEYS[2]
 local queueBase = ARGV[1]
 
-local results = redis.call("ZRANGE", activeSetKey, 0, -1)
+local active = redis.call("ZRANGE", activeSetKey, 0, -1)
+local paused = redis.call("ZRANGE", pausedSetKey, 0, -1)
+
 local count = 0
 
-for i = 1, #results do
-    local result = redis.call("ZCARD", queueBase .. ":" .. results[i])
+for i = 1, #active do
+    local result = redis.call("ZCARD", queueBase .. ":" .. active[i])
+    count = count + result
+end
+
+for i = 1, #paused do
+    local result = redis.call("ZCARD", queueBase .. ":" .. paused[i])
     count = count + result
 end
 


### PR DESCRIPTION
The other way we could do this is by adding a value like 1000000 to the score... still on the fence about which way would be better.

Where I am going with this is that there would be a separate queue for starts that can be paused and resumed by a cron job which is looking at outbox size.