### PR TITLE
Rename throttled redis queue to tasks:throttled

### DIFF
--- a/core/tasks/task.go
+++ b/core/tasks/task.go
@@ -15,7 +15,7 @@ import (
 
 var HandlerQueue = queues.NewFairSorted("handler")
 var BatchQueue = queues.NewFairSorted("batch")
-var ThrottledQueue = queues.NewFairSorted("throttled")
+var ThrottledQueue = queues.NewFairSorted("tasks:throttled")
 
 // TODO remove once starts are using throttled
 var StartsQueue = queues.NewFairSorted("starts")

--- a/mailroom.go
+++ b/mailroom.go
@@ -48,7 +48,7 @@ func NewMailroom(config *runtime.Config) *Mailroom {
 
 	mr.handlerForeman = NewForeman(mr.rt, mr.wg, tasks.HandlerQueue, config.HandlerWorkers)
 	mr.batchForeman = NewForeman(mr.rt, mr.wg, tasks.BatchQueue, config.BatchWorkers)
-	mr.throttledForeman = NewForeman(mr.rt, mr.wg, tasks.StartsQueue, config.BatchWorkers)
+	mr.throttledForeman = NewForeman(mr.rt, mr.wg, tasks.ThrottledQueue, config.BatchWorkers)
 	mr.startsForeman = NewForeman(mr.rt, mr.wg, tasks.StartsQueue, config.BatchWorkers)
 
 	return mr


### PR DESCRIPTION
Gonna switch over the others as well so then our main queues will be named like `tasks:` (mailroom) and `msgs:` (courier)