### PR TITLE
Fix trigger_session actions with IVR flows

### DIFF
--- a/core/hooks/create_starts.go
+++ b/core/hooks/create_starts.go
@@ -67,6 +67,13 @@ func (h *createStartsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *s
 				WithParentSummary(event.RunSummary).
 				WithSessionHistory(historyJSON)
 
+			// TODO find another way to pass start info to new calls
+			if flow.FlowType() == models.FlowTypeVoice {
+				if err := models.InsertFlowStarts(ctx, tx, []*models.FlowStart{start}); err != nil {
+					return fmt.Errorf("error inserting flow start: %w", err)
+				}
+			}
+
 			err = tasks.Queue(rc, tasks.BatchQueue, oa.OrgID(), &starts.StartFlowTask{FlowStart: start}, queues.DefaultPriority)
 			if err != nil {
 				return fmt.Errorf("error queuing flow start: %w", err)

--- a/testsuite/testdata/contacts.go
+++ b/testsuite/testdata/contacts.go
@@ -20,6 +20,10 @@ type Contact struct {
 	URNID models.URNID
 }
 
+func (c *Contact) Reference() *flows.ContactReference {
+	return &flows.ContactReference{UUID: c.UUID, Name: ""}
+}
+
 func (c *Contact) Load(rt *runtime.Runtime, oa *models.OrgAssets) (*models.Contact, *flows.Contact, []*models.ContactURN) {
 	ctx := context.Background()
 


### PR DESCRIPTION
We start calls by requesting a call from an IVR service and it calling us back. We record which flow will be started on the flow start and we load that flow start in the web endpoint that handles the new call. So for now all IVR flow starts need a start in the database.