### PR TITLE
Add endpoint to de-index specific contacts

### DIFF
--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -30,6 +30,20 @@ func TestCreate(t *testing.T) {
 	testsuite.RunWebTests(t, ctx, rt, "testdata/create.json", nil)
 }
 
+func TestDeindex(t *testing.T) {
+	ctx, rt := testsuite.Runtime()
+
+	defer func() {
+		rt.DB.MustExec(`UPDATE contacts_contact SET is_active = true, modified_on = NOW() WHERE id IN ($1, $2)`, testdata.Bob.ID, testdata.George.ID)
+
+		testsuite.Reset(testsuite.ResetElastic)
+	}()
+
+	rt.DB.MustExec(`UPDATE contacts_contact SET is_active = false, modified_on = NOW() WHERE id IN ($1, $2)`, testdata.Bob.ID, testdata.George.ID)
+
+	testsuite.RunWebTests(t, ctx, rt, "testdata/deindex.json", nil)
+}
+
 func TestExport(t *testing.T) {
 	ctx, rt := testsuite.Runtime()
 

--- a/web/contact/deindex.go
+++ b/web/contact/deindex.go
@@ -1,0 +1,47 @@
+package contact
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/lib/pq"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/search"
+	"github.com/nyaruka/mailroom/runtime"
+	"github.com/nyaruka/mailroom/web"
+)
+
+func init() {
+	web.RegisterRoute(http.MethodPost, "/mr/contact/deindex", web.RequireAuthToken(web.JSONPayload(handleDeindex)))
+}
+
+// Requests de-indexing of the given contacts from Elastic indexes.
+//
+//	{
+//	  "org_id": 1,
+//	  "contact_ids": [12345, 23456]
+//	}
+type deindexRequest struct {
+	OrgID      models.OrgID       `json:"org_id"  validate:"required"`
+	ContactIDs []models.ContactID `json:"contact_ids" validate:"required"`
+}
+
+// handles a request to resend the given messages
+func handleDeindex(ctx context.Context, rt *runtime.Runtime, r *deindexRequest) (any, int, error) {
+	// check that org exists and is not active
+	var count int
+	if err := rt.DB.Get(&count, `SELECT count(*) FROM contacts_contact WHERE id = ANY($1) AND org_id = $2 AND NOT is_active`, pq.Array(r.ContactIDs), r.OrgID); err != nil {
+		return nil, 0, fmt.Errorf("error querying contacts to be de-indexed in org #%d: %w", r.OrgID, err)
+	}
+	if count != len(r.ContactIDs) {
+		return nil, 0, fmt.Errorf("some contacts to be de-indexed in org #%d are active or don't exist", r.OrgID)
+	}
+
+	deindexed, err := search.DeindexContactsByID(ctx, rt, r.OrgID, r.ContactIDs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error de-indexing contacts in org #%d: %w", r.OrgID, err)
+	}
+
+	return map[string]any{"deindexed": deindexed}, http.StatusOK, nil
+}

--- a/web/contact/testdata/deindex.json
+++ b/web/contact/testdata/deindex.json
@@ -1,0 +1,57 @@
+[
+    {
+        "label": "illegal method",
+        "method": "GET",
+        "path": "/mr/contact/deindex",
+        "status": 405,
+        "response": {
+            "error": "illegal method: GET"
+        }
+    },
+    {
+        "label": "invalid contact id",
+        "method": "POST",
+        "path": "/mr/contact/deindex",
+        "body": {
+            "org_id": 1,
+            "contact_ids": [
+                100000000
+            ]
+        },
+        "status": 500,
+        "response": {
+            "error": "some contacts to be de-indexed in org #1 are active or don't exist"
+        }
+    },
+    {
+        "label": "contact that is still active",
+        "method": "POST",
+        "path": "/mr/contact/deindex",
+        "body": {
+            "org_id": 1,
+            "contact_ids": [
+                10000
+            ]
+        },
+        "status": 500,
+        "response": {
+            "error": "some contacts to be de-indexed in org #1 are active or don't exist"
+        }
+    },
+    {
+        "label": "contacts that are inactive",
+        "method": "POST",
+        "path": "/mr/contact/deindex",
+        "body": {
+            "org_id": 1,
+            "contact_ids": [
+                10001,
+                10002
+            ]
+        },
+        "status": 200,
+        "response": {
+            "deindexed": 2
+        }
+    }
+]


### PR DESCRIPTION
Want mailroom to take over indexing of contacts... but mailroom generally only knows about active contacts.

So thinking of a two step process where first step is that mailroom takes over de-indexing deleted contacts, rp-indexer starts ignoring deleted contacts.