### PR TITLE
Don't include db-trigger maintained status groups in engine assets

### DIFF
--- a/core/models/assets.go
+++ b/core/models/assets.go
@@ -224,7 +224,7 @@ func NewOrgAssets(ctx context.Context, rt *runtime.Runtime, orgID OrgID, prev *O
 		oa.groups = make([]assets.Group, 0, len(groups))
 		oa.groupsByID = make(map[GroupID]*Group, len(groups))
 		oa.groupsByUUID = make(map[assets.GroupUUID]*Group, len(groups))
-		for _, g := range oa.groups {
+		for _, g := range groups {
 			group := g.(*Group)
 			oa.groupsByID[group.ID()] = group
 			oa.groupsByUUID[group.UUID()] = group

--- a/core/models/contacts.go
+++ b/core/models/contacts.go
@@ -265,8 +265,8 @@ func (c *Contact) FlowContact(oa *OrgAssets) (*flows.Contact, error) {
 	// convert our groups to a list of references
 	groups := make([]*assets.GroupReference, 0, len(c.groups))
 	for _, g := range c.groups {
-		// exclude the db-trigger based status groups for now
-		if g.Type() == GroupTypeManual || g.Type() == GroupTypeSmart {
+		// exclude the db-trigger based status groups
+		if g.Visible() {
 			groups = append(groups, assets.NewGroupReference(g.UUID(), g.Name()))
 		}
 	}

--- a/core/models/contacts_test.go
+++ b/core/models/contacts_test.go
@@ -478,9 +478,7 @@ func TestContactStop(t *testing.T) {
 	err := contact.Stop(ctx, rt.DB, oa)
 	assert.NoError(t, err)
 	assert.Equal(t, models.ContactStatusStopped, contact.Status())
-	if assert.Len(t, contact.Groups(), 1) {
-		assert.Equal(t, "Stopped", contact.Groups()[0].Name())
-	}
+	assert.Len(t, contact.Groups(), 0)
 
 	// verify that matches the database state
 	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contact WHERE id = $1`, testdata.Cathy.ID).Returns("S")

--- a/core/models/fields_test.go
+++ b/core/models/fields_test.go
@@ -17,6 +17,13 @@ func TestFields(t *testing.T) {
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
 	require.NoError(t, err)
 
+	fields, err := oa.Fields()
+	require.NoError(t, err)
+	assert.Len(t, fields, 6) // excludes the proxy fields
+	assert.Equal(t, "age", fields[0].Key())
+	assert.Equal(t, "Age", fields[0].Name())
+	assert.Equal(t, assets.FieldTypeNumber, fields[0].Type())
+
 	expectedFields := []struct {
 		field     testdata.Field
 		key       string

--- a/core/models/groups.go
+++ b/core/models/groups.go
@@ -27,9 +27,12 @@ const (
 type GroupType string
 
 const (
-	GroupTypeManual    = GroupType("M")
-	GroupTypeSmart     = GroupType("Q")
-	GroupTypeDBStopped = GroupType("S")
+	GroupTypeDBActive   = GroupType("A")
+	GroupTypeDBBlocked  = GroupType("B")
+	GroupTypeDBStopped  = GroupType("S")
+	GroupTypeDBArchived = GroupType("V")
+	GroupTypeManual     = GroupType("M")
+	GroupTypeSmart      = GroupType("Q")
 )
 
 // Group is our mailroom type for contact groups
@@ -59,6 +62,9 @@ func (g *Group) Status() GroupStatus { return g.Status_ }
 
 // Type returns the type of this group
 func (g *Group) Type() GroupType { return g.Type_ }
+
+// Visible returns whether this group is visible to the engine (status groups are not)
+func (g *Group) Visible() bool { return g.Type_ == GroupTypeManual || g.Type_ == GroupTypeSmart }
 
 // loads the groups for the passed in org
 func loadGroups(ctx context.Context, db *sql.DB, orgID OrgID) ([]assets.Group, error) {

--- a/core/models/groups_test.go
+++ b/core/models/groups_test.go
@@ -3,7 +3,6 @@ package models_test
 import (
 	"testing"
 
-	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -19,29 +18,26 @@ func TestLoadGroups(t *testing.T) {
 
 	groups, err := oa.Groups()
 	require.NoError(t, err)
+	assert.Len(t, groups, 3) // excludes the status groups
+	assert.Equal(t, testdata.DoctorsGroup.UUID, groups[0].UUID())
+	assert.Equal(t, "Doctors", groups[0].Name())
 
 	tcs := []struct {
-		id            models.GroupID
-		uuid          assets.GroupUUID
+		group         *testdata.Group
 		name          string
 		query         string
 		expectedCount int
 	}{
-		{testdata.ActiveGroup.ID, testdata.ActiveGroup.UUID, "Active", "", 124},
-		{testdata.ArchivedGroup.ID, testdata.ArchivedGroup.UUID, "Archived", "", 0},
-		{testdata.BlockedGroup.ID, testdata.BlockedGroup.UUID, "Blocked", "", 0},
-		{testdata.DoctorsGroup.ID, testdata.DoctorsGroup.UUID, "Doctors", "", 121},
-		{testdata.OpenTicketsGroup.ID, testdata.OpenTicketsGroup.UUID, "Open Tickets", "tickets > 0", 0},
-		{testdata.StoppedGroup.ID, testdata.StoppedGroup.UUID, "Stopped", "", 0},
-		{testdata.TestersGroup.ID, testdata.TestersGroup.UUID, "Testers", "", 10},
+		{testdata.ActiveGroup, "Active", "", 124},
+		{testdata.BlockedGroup, "Blocked", "", 0},
+		{testdata.DoctorsGroup, "Doctors", "", 121},
+		{testdata.OpenTicketsGroup, "Open Tickets", "tickets > 0", 0},
 	}
 
-	assert.Equal(t, 7, len(groups))
-
-	for i, tc := range tcs {
-		group := groups[i].(*models.Group)
-		assert.Equal(t, tc.uuid, group.UUID())
-		assert.Equal(t, tc.id, group.ID())
+	for _, tc := range tcs {
+		group := oa.GroupByUUID(tc.group.UUID)
+		assert.Equal(t, tc.group.UUID, group.UUID())
+		assert.Equal(t, tc.group.ID, group.ID())
 		assert.Equal(t, tc.name, group.Name())
 		assert.Equal(t, tc.query, group.Query())
 


### PR DESCRIPTION
See https://github.com/nyaruka/rapidpro/issues/5529

And converts searches based on status groups to use a status condition instead.