### PR TITLE
Add new tasks for bulk session expires and timeouts

### DIFF
--- a/core/tasks/contacts/bulk_session_expire.go
+++ b/core/tasks/contacts/bulk_session_expire.go
@@ -1,0 +1,59 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/handler"
+	"github.com/nyaruka/mailroom/core/tasks/handler/ctasks"
+	"github.com/nyaruka/mailroom/runtime"
+)
+
+// TypeBulkSessionExpire is the type of the task
+const TypeBulkSessionExpire = "bulk_session_expire"
+
+func init() {
+	tasks.RegisterType(TypeBulkSessionExpire, func() tasks.Task { return &BulkSessionExpireTask{} })
+}
+
+type Expiration struct {
+	ContactID  models.ContactID `json:"contact_id"`
+	SessionID  models.SessionID `json:"session_id"`
+	ModifiedOn time.Time        `json:"modified_on"`
+}
+
+// BulkSessionExpireTask is the payload of the task
+type BulkSessionExpireTask struct {
+	Expirations []*Expiration `json:"expirations"`
+}
+
+func (t *BulkSessionExpireTask) Type() string {
+	return TypeBulkSessionExpire
+}
+
+// Timeout is the maximum amount of time the task can run for
+func (t *BulkSessionExpireTask) Timeout() time.Duration {
+	return time.Hour
+}
+
+func (t *BulkSessionExpireTask) WithAssets() models.Refresh {
+	return models.RefreshNone
+}
+
+// Perform creates the actual task
+func (t *BulkSessionExpireTask) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+	rc := rt.RP.Get()
+	defer rc.Close()
+
+	for _, exp := range t.Expirations {
+		err := handler.QueueTask(rc, oa.OrgID(), exp.ContactID, ctasks.NewWaitExpiration(exp.SessionID, exp.ModifiedOn))
+		if err != nil {
+			return fmt.Errorf("error queuing handle task for expiration on session #%d: %w", exp.SessionID, err)
+		}
+	}
+
+	return nil
+}

--- a/core/tasks/contacts/bulk_session_expire_test.go
+++ b/core/tasks/contacts/bulk_session_expire_test.go
@@ -1,0 +1,44 @@
+package contacts_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/core/tasks/contacts"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBulkSessionExpire(t *testing.T) {
+	_, rt := testsuite.Runtime()
+	defer testsuite.Reset(testsuite.ResetRedis)
+
+	defer dates.SetNowFunc(time.Now)
+	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))
+
+	testsuite.QueueBatchTask(t, rt, testdata.Org1, &contacts.BulkSessionExpireTask{
+		Expirations: []*contacts.Expiration{
+			{
+				ContactID:  testdata.Cathy.ID,
+				SessionID:  123456,
+				ModifiedOn: time.Date(2024, 11, 15, 13, 57, 0, 0, time.UTC),
+			},
+			{
+				ContactID:  testdata.Bob.ID,
+				SessionID:  234567,
+				ModifiedOn: time.Date(2024, 11, 15, 13, 58, 0, 0, time.UTC),
+			},
+		},
+	})
+
+	assert.Equal(t, map[string]int{"bulk_session_expire": 1}, testsuite.FlushTasks(t, rt, "batch", "throttled"))
+
+	testsuite.AssertContactTasks(t, testdata.Org1, testdata.Cathy, []string{
+		`{"type":"expiration_event","task":{"session_id":123456,"modified_on":"2024-11-15T13:57:00Z"},"queued_on":"2024-11-15T13:59:00Z"}`,
+	})
+	testsuite.AssertContactTasks(t, testdata.Org1, testdata.Bob, []string{
+		`{"type":"expiration_event","task":{"session_id":234567,"modified_on":"2024-11-15T13:58:00Z"},"queued_on":"2024-11-15T13:59:00Z"}`,
+	})
+}

--- a/core/tasks/contacts/bulk_session_timeout.go
+++ b/core/tasks/contacts/bulk_session_timeout.go
@@ -1,0 +1,59 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/handler"
+	"github.com/nyaruka/mailroom/core/tasks/handler/ctasks"
+	"github.com/nyaruka/mailroom/runtime"
+)
+
+// TypeBulkSessionTimeout is the type of the task
+const TypeBulkSessionTimeout = "bulk_session_timeout"
+
+func init() {
+	tasks.RegisterType(TypeBulkSessionTimeout, func() tasks.Task { return &BulkSessionTimeoutTask{} })
+}
+
+type Timeout struct {
+	ContactID  models.ContactID `json:"contact_id"`
+	SessionID  models.SessionID `json:"session_id"`
+	ModifiedOn time.Time        `json:"modified_on"`
+}
+
+// BulkSessionTimeoutTask is the payload of the task
+type BulkSessionTimeoutTask struct {
+	Timeouts []*Timeout `json:"timeouts"`
+}
+
+func (t *BulkSessionTimeoutTask) Type() string {
+	return TypeBulkSessionTimeout
+}
+
+// Timeout is the maximum amount of time the task can run for
+func (t *BulkSessionTimeoutTask) Timeout() time.Duration {
+	return time.Hour
+}
+
+func (t *BulkSessionTimeoutTask) WithAssets() models.Refresh {
+	return models.RefreshNone
+}
+
+// Perform creates the actual task
+func (t *BulkSessionTimeoutTask) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+	rc := rt.RP.Get()
+	defer rc.Close()
+
+	for _, exp := range t.Timeouts {
+		err := handler.QueueTask(rc, oa.OrgID(), exp.ContactID, ctasks.NewWaitTimeout(exp.SessionID, exp.ModifiedOn))
+		if err != nil {
+			return fmt.Errorf("error queuing handle task for expiration on session #%d: %w", exp.SessionID, err)
+		}
+	}
+
+	return nil
+}

--- a/core/tasks/contacts/bulk_session_timeout_test.go
+++ b/core/tasks/contacts/bulk_session_timeout_test.go
@@ -1,0 +1,44 @@
+package contacts_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/core/tasks/contacts"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBulkSessionTimeout(t *testing.T) {
+	_, rt := testsuite.Runtime()
+	defer testsuite.Reset(testsuite.ResetRedis)
+
+	defer dates.SetNowFunc(time.Now)
+	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))
+
+	testsuite.QueueBatchTask(t, rt, testdata.Org1, &contacts.BulkSessionTimeoutTask{
+		Timeouts: []*contacts.Timeout{
+			{
+				SessionID:  123456,
+				ContactID:  testdata.Cathy.ID,
+				ModifiedOn: time.Date(2024, 11, 15, 13, 57, 0, 0, time.UTC),
+			},
+			{
+				SessionID:  234567,
+				ContactID:  testdata.Bob.ID,
+				ModifiedOn: time.Date(2024, 11, 15, 13, 58, 0, 0, time.UTC),
+			},
+		},
+	})
+
+	assert.Equal(t, map[string]int{"bulk_session_timeout": 1}, testsuite.FlushTasks(t, rt, "batch", "throttled"))
+
+	testsuite.AssertContactTasks(t, testdata.Org1, testdata.Cathy, []string{
+		`{"type":"timeout_event","task":{"session_id":123456,"modified_on":"2024-11-15T13:57:00Z"},"queued_on":"2024-11-15T13:59:00Z"}`,
+	})
+	testsuite.AssertContactTasks(t, testdata.Org1, testdata.Bob, []string{
+		`{"type":"timeout_event","task":{"session_id":234567,"modified_on":"2024-11-15T13:58:00Z"},"queued_on":"2024-11-15T13:59:00Z"}`,
+	})
+}

--- a/core/tasks/expirations/bulk_expire.go
+++ b/core/tasks/expirations/bulk_expire.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nyaruka/mailroom/runtime"
 )
 
+// TODO replaced by BulkSessionExpireTask
+
 // TypeBulkExpire is the type of the task
 const TypeBulkExpire = "bulk_expire"
 

--- a/core/tasks/expirations/cron_test.go
+++ b/core/tasks/expirations/cron_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/contacts"
 	"github.com/nyaruka/mailroom/core/tasks/expirations"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -55,9 +56,9 @@ func TestExpirations(t *testing.T) {
 	task1, err := tasks.ThrottledQueue.Pop(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, int(testdata.Org1.ID), task1.OwnerID)
-	assert.Equal(t, "bulk_expire", task1.Type)
+	assert.Equal(t, "bulk_session_expire", task1.Type)
 
-	decoded := &expirations.BulkExpireTask{}
+	decoded := &contacts.BulkSessionExpireTask{}
 	jsonx.MustUnmarshal(task1.Task, decoded)
 	assert.Len(t, decoded.Expirations, 1)
 	assert.Equal(t, s2ID, decoded.Expirations[0].SessionID)
@@ -66,11 +67,11 @@ func TestExpirations(t *testing.T) {
 	task2, err := tasks.ThrottledQueue.Pop(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, int(testdata.Org2.ID), task2.OwnerID)
-	assert.Equal(t, "bulk_expire", task2.Type)
+	assert.Equal(t, "bulk_session_expire", task2.Type)
 	task3, err := tasks.ThrottledQueue.Pop(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, int(testdata.Org2.ID), task3.OwnerID)
-	assert.Equal(t, "bulk_expire", task2.Type)
+	assert.Equal(t, "bulk_session_expire", task2.Type)
 
 	// no other
 	task, err := tasks.ThrottledQueue.Pop(rc)

--- a/core/tasks/timeouts/bulk_timeout.go
+++ b/core/tasks/timeouts/bulk_timeout.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nyaruka/mailroom/runtime"
 )
 
+// TODO replaced by BulkSessionTimeoutTask
+
 // TypeBulkTimeout is the type of the task
 const TypeBulkTimeout = "bulk_timeout"
 

--- a/core/tasks/timeouts/cron_test.go
+++ b/core/tasks/timeouts/cron_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/contacts"
 	"github.com/nyaruka/mailroom/core/tasks/timeouts"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -50,9 +51,9 @@ func TestTimeouts(t *testing.T) {
 	task1, err := tasks.ThrottledQueue.Pop(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, int(testdata.Org1.ID), task1.OwnerID)
-	assert.Equal(t, "bulk_timeout", task1.Type)
+	assert.Equal(t, "bulk_session_timeout", task1.Type)
 
-	decoded := &timeouts.BulkTimeoutTask{}
+	decoded := &contacts.BulkSessionTimeoutTask{}
 	jsonx.MustUnmarshal(task1.Task, decoded)
 	assert.Len(t, decoded.Timeouts, 2)
 	assert.Equal(t, s2ID, decoded.Timeouts[0].SessionID)
@@ -62,11 +63,11 @@ func TestTimeouts(t *testing.T) {
 	task2, err := tasks.ThrottledQueue.Pop(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, int(testdata.Org2.ID), task2.OwnerID)
-	assert.Equal(t, "bulk_timeout", task2.Type)
+	assert.Equal(t, "bulk_session_timeout", task2.Type)
 	task3, err := tasks.ThrottledQueue.Pop(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, int(testdata.Org2.ID), task3.OwnerID)
-	assert.Equal(t, "bulk_timeout", task2.Type)
+	assert.Equal(t, "bulk_session_timeout", task2.Type)
 
 	// no other
 	task, err := tasks.ThrottledQueue.Pop(rc)


### PR DESCRIPTION
The existing ones use data structures from the cron tasks.. which we want to replace.