### PR TITLE
Tweak task names used for wait expirations and timeouts

### DIFF
--- a/core/tasks/contacts/bulk_wait_expire_test.go
+++ b/core/tasks/contacts/bulk_wait_expire_test.go
@@ -18,8 +18,8 @@ func TestBulkSessionExpire(t *testing.T) {
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))
 
-	testsuite.QueueBatchTask(t, rt, testdata.Org1, &contacts.BulkSessionExpireTask{
-		Expirations: []*contacts.Expiration{
+	testsuite.QueueBatchTask(t, rt, testdata.Org1, &contacts.BulkWaitExpireTask{
+		Expirations: []*contacts.WaitExpiration{
 			{
 				ContactID:   testdata.Cathy.ID,
 				SessionUUID: "8e2786dc-e6d0-4a6a-bbc5-4ec321d60516",
@@ -33,7 +33,7 @@ func TestBulkSessionExpire(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, map[string]int{"bulk_session_expire": 1}, testsuite.FlushTasks(t, rt, "batch", "throttled"))
+	assert.Equal(t, map[string]int{"bulk_wait_expire": 1}, testsuite.FlushTasks(t, rt, "batch", "throttled"))
 
 	testsuite.AssertContactTasks(t, testdata.Org1, testdata.Cathy, []string{
 		`{"type":"wait_expired","task":{"session_uuid":"8e2786dc-e6d0-4a6a-bbc5-4ec321d60516","sprint_uuid":"babdfd9e-241d-4d32-be5f-d821d1ecab31"},"queued_on":"2024-11-15T13:59:00Z"}`,

--- a/core/tasks/contacts/bulk_wait_timeout_test.go
+++ b/core/tasks/contacts/bulk_wait_timeout_test.go
@@ -18,8 +18,8 @@ func TestBulkSessionTimeout(t *testing.T) {
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))
 
-	testsuite.QueueBatchTask(t, rt, testdata.Org1, &contacts.BulkSessionTimeoutTask{
-		Timeouts: []*contacts.Timeout{
+	testsuite.QueueBatchTask(t, rt, testdata.Org1, &contacts.BulkWaitTimeoutTask{
+		Timeouts: []*contacts.WaitTimeout{
 			{
 				ContactID:   testdata.Cathy.ID,
 				SessionUUID: "8e2786dc-e6d0-4a6a-bbc5-4ec321d60516",
@@ -33,7 +33,7 @@ func TestBulkSessionTimeout(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, map[string]int{"bulk_session_timeout": 1}, testsuite.FlushTasks(t, rt, "batch", "throttled"))
+	assert.Equal(t, map[string]int{"bulk_wait_timeout": 1}, testsuite.FlushTasks(t, rt, "batch", "throttled"))
 
 	testsuite.AssertContactTasks(t, testdata.Org1, testdata.Cathy, []string{
 		`{"type":"wait_timeout","task":{"session_uuid":"8e2786dc-e6d0-4a6a-bbc5-4ec321d60516","sprint_uuid":"babdfd9e-241d-4d32-be5f-d821d1ecab31"},"queued_on":"2024-11-15T13:59:00Z"}`,

--- a/core/tasks/contacts/cron_test.go
+++ b/core/tasks/contacts/cron_test.go
@@ -56,11 +56,11 @@ func TestFiresCron(t *testing.T) {
 	assert.Equal(t, int(testdata.Org1.ID), ts[0].OwnerID)
 	assert.Equal(t, "bulk_campaign_trigger", ts[0].Type)
 	assert.Equal(t, int(testdata.Org1.ID), ts[1].OwnerID)
-	assert.Equal(t, "bulk_session_expire", ts[1].Type)
+	assert.Equal(t, "bulk_wait_expire", ts[1].Type)
 	assert.Equal(t, int(testdata.Org1.ID), ts[2].OwnerID)
-	assert.Equal(t, "bulk_session_timeout", ts[2].Type)
+	assert.Equal(t, "bulk_wait_timeout", ts[2].Type)
 	assert.Equal(t, int(testdata.Org2.ID), ts[3].OwnerID)
-	assert.Equal(t, "bulk_session_timeout", ts[3].Type)
+	assert.Equal(t, "bulk_wait_timeout", ts[3].Type)
 
 	decoded1 := &campaigns.BulkCampaignTriggerTask{}
 	jsonx.MustUnmarshal(ts[0].Task, decoded1)
@@ -68,13 +68,13 @@ func TestFiresCron(t *testing.T) {
 	assert.Equal(t, testdata.Alexandria.ID, decoded1.ContactIDs[0])
 	assert.Equal(t, models.CampaignEventID(6789), decoded1.EventID)
 
-	decoded2 := &contacts.BulkSessionExpireTask{}
+	decoded2 := &contacts.BulkWaitExpireTask{}
 	jsonx.MustUnmarshal(ts[1].Task, decoded2)
 	assert.Len(t, decoded2.Expirations, 2)
 	assert.Equal(t, flows.SessionUUID("4010a3b2-d1f2-42ae-9051-47d41a3ef923"), decoded2.Expirations[0].SessionUUID)
 	assert.Equal(t, flows.SessionUUID("f72b48df-5f6d-4e4f-955a-f5fb29ccb97b"), decoded2.Expirations[1].SessionUUID)
 
-	decoded3 := &contacts.BulkSessionTimeoutTask{}
+	decoded3 := &contacts.BulkWaitTimeoutTask{}
 	jsonx.MustUnmarshal(ts[2].Task, decoded3)
 	assert.Len(t, decoded3.Timeouts, 1)
 	assert.Equal(t, flows.SessionUUID("5c1248e3-f669-4a72-83f4-a29292fdad4d"), decoded3.Timeouts[0].SessionUUID)


### PR DESCRIPTION
Because `bulk_session_expire` would be the name of a task that handles the overall expiry of a session.. not just a wait within it.. and I think we're going to add that.