### PR TITLE
Reduce webhook service fetch limit to 256KiB

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -98,7 +98,7 @@ func NewDefaultConfig() *Config {
 
 		WebhooksTimeout:              15000,
 		WebhooksMaxRetries:           2,
-		WebhooksMaxBodyBytes:         1024 * 1024, // 1MB
+		WebhooksMaxBodyBytes:         256 * 1024, // 256 KiB
 		WebhooksInitialBackoff:       5000,
 		WebhooksBackoffJitter:        0.5,
 		WebhooksHealthyResponseLimit: 10000,


### PR DESCRIPTION
Dynamo item limit is 400KB...