### PR TITLE
Add endpoint to schedule fires for a new campaign event

### DIFF
--- a/web/campaign/base_test.go
+++ b/web/campaign/base_test.go
@@ -1,0 +1,21 @@
+package campaign_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdata"
+)
+
+func TestSchedule_event(t *testing.T) {
+	ctx, rt := testsuite.Runtime()
+
+	defer testsuite.Reset(testsuite.ResetData | testsuite.ResetRedis)
+
+	testsuite.RunWebTests(t, ctx, rt, "testdata/schedule_event.json", map[string]string{
+		"event1_id": fmt.Sprint(testdata.RemindersEvent1.ID),
+	})
+
+	testsuite.AssertBatchTasks(t, testdata.Org1.ID, map[string]int{"schedule_campaign_event": 1})
+}

--- a/web/campaign/schedule_event.go
+++ b/web/campaign/schedule_event.go
@@ -1,0 +1,46 @@
+package campaign
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/campaigns"
+	"github.com/nyaruka/mailroom/runtime"
+	"github.com/nyaruka/mailroom/web"
+)
+
+func init() {
+	web.RegisterRoute(http.MethodPost, "/mr/campaign/schedule_event", web.RequireAuthToken(web.JSONPayload(handleScheduleEvent)))
+}
+
+// Request to schedule a campaign event. Triggers a background task to create the fires and returns immediately.
+//
+//	{
+//	  "org_id": 1,
+//	  "event_id": 123456
+//	}
+type scheduleEventRequest struct {
+	OrgID   models.OrgID           `json:"org_id"   validate:"required"`
+	EventID models.CampaignEventID `json:"event_id" validate:"required"`
+}
+
+func handleScheduleEvent(ctx context.Context, rt *runtime.Runtime, r *scheduleEventRequest) (any, int, error) {
+	// dwe don't actual need the org assets in this function but load them to validate the org id is valid
+	// and they'll probably still be cached by the time the task starts
+	if _, err := models.GetOrgAssets(ctx, rt, r.OrgID); err != nil {
+		return nil, 0, fmt.Errorf("unable to load org assets: %w", err)
+	}
+
+	task := &campaigns.ScheduleCampaignEventTask{CampaignEventID: r.EventID}
+
+	rc := rt.RP.Get()
+	defer rc.Close()
+	if err := tasks.Queue(rc, tasks.BatchQueue, r.OrgID, task, true); err != nil {
+		return nil, 0, fmt.Errorf("error queuing schedule campaign event task: %w", err)
+	}
+
+	return map[string]any{}, http.StatusOK, nil
+}

--- a/web/campaign/testdata/schedule_event.json
+++ b/web/campaign/testdata/schedule_event.json
@@ -1,0 +1,35 @@
+[
+    {
+        "label": "illegal method",
+        "method": "GET",
+        "path": "/mr/campaign/schedule_event",
+        "status": 405,
+        "response": {
+            "error": "illegal method: GET"
+        }
+    },
+    {
+        "label": "invalid org_id",
+        "method": "POST",
+        "path": "/mr/campaign/schedule_event",
+        "body": {
+            "org_id": 1234,
+            "event_id": 2345
+        },
+        "status": 500,
+        "response": {
+            "error": "unable to load org assets: error loading environment for org 1234: no org with id: 1234"
+        }
+    },
+    {
+        "label": "response is empty on success",
+        "method": "POST",
+        "path": "/mr/campaign/schedule_event",
+        "body": {
+            "org_id": 1,
+            "event_id": $event1_id$
+        },
+        "status": 200,
+        "response": {}
+    }
+]

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -20,7 +20,7 @@ func TestSend(t *testing.T) {
 	cathyTicket := testdata.InsertOpenTicket(rt, testdata.Org1, testdata.Cathy, testdata.DefaultTopic, time.Date(2015, 1, 1, 12, 30, 45, 0, time.UTC), nil)
 
 	testsuite.RunWebTests(t, ctx, rt, "testdata/send.json", map[string]string{
-		"cathy_ticket_id": fmt.Sprintf("%d", cathyTicket.ID),
+		"cathy_ticket_id": fmt.Sprint(cathyTicket.ID),
 	})
 
 	testsuite.AssertCourierQueues(t, map[string][]int{"msgs:74729f45-7f29-4868-9dc4-90e491e3c7d8|10/1": {1, 1, 1, 1}})
@@ -36,9 +36,9 @@ func TestHandle(t *testing.T) {
 	cathyOut := testdata.InsertOutgoingMsg(rt, testdata.Org1, testdata.TwilioChannel, testdata.Cathy, "how can we help", nil, models.MsgStatusSent, false)
 
 	testsuite.RunWebTests(t, ctx, rt, "testdata/handle.json", map[string]string{
-		"cathy_msgin1_id": fmt.Sprintf("%d", cathyIn1.ID),
-		"cathy_msgin2_id": fmt.Sprintf("%d", cathyIn2.ID),
-		"cathy_msgout_id": fmt.Sprintf("%d", cathyOut.ID),
+		"cathy_msgin1_id": fmt.Sprint(cathyIn1.ID),
+		"cathy_msgin2_id": fmt.Sprint(cathyIn2.ID),
+		"cathy_msgout_id": fmt.Sprint(cathyOut.ID),
 	})
 
 	orgTasks := testsuite.CurrentTasks(t, rt, "handler")[testdata.Org1.ID]
@@ -58,10 +58,10 @@ func TestResend(t *testing.T) {
 	rt.DB.MustExec(`UPDATE msgs_msg SET contact_urn_id = NULL WHERE id = $1`, georgeOut.ID)
 
 	testsuite.RunWebTests(t, ctx, rt, "testdata/resend.json", map[string]string{
-		"cathy_msgin_id":   fmt.Sprintf("%d", cathyIn.ID),
-		"cathy_msgout_id":  fmt.Sprintf("%d", cathyOut.ID),
-		"bob_msgout_id":    fmt.Sprintf("%d", bobOut.ID),
-		"george_msgout_id": fmt.Sprintf("%d", georgeOut.ID),
+		"cathy_msgin_id":   fmt.Sprint(cathyIn.ID),
+		"cathy_msgout_id":  fmt.Sprint(cathyOut.ID),
+		"bob_msgout_id":    fmt.Sprint(bobOut.ID),
+		"george_msgout_id": fmt.Sprint(georgeOut.ID),
 	})
 }
 
@@ -82,7 +82,7 @@ func TestBroadcast(t *testing.T) {
 	createRun(testdata.Org1, testdata.George, "a52a9e6d-34bb-4be1-8034-99e33d0862c6")
 
 	testsuite.RunWebTests(t, ctx, rt, "testdata/broadcast.json", map[string]string{
-		"polls_id": fmt.Sprintf("%d", polls.ID),
+		"polls_id": fmt.Sprint(polls.ID),
 	})
 
 	testsuite.AssertBatchTasks(t, testdata.Org1.ID, map[string]int{"send_broadcast": 2})

--- a/web/msg/broadcast.go
+++ b/web/msg/broadcast.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -121,9 +120,9 @@ func handleBroadcast(ctx context.Context, rt *runtime.Runtime, r *broadcastReque
 
 		rc := rt.RP.Get()
 		defer rc.Close()
-		err = tasks.Queue(rc, tasks.BatchQueue, bcast.OrgID, task, true)
-		if err != nil {
-			slog.Error("error queueing broadcast task", "error", err)
+
+		if err := tasks.Queue(rc, tasks.BatchQueue, bcast.OrgID, task, true); err != nil {
+			return nil, 0, fmt.Errorf("error queuing send broadcast task: %w", err)
 		}
 	}
 


### PR DESCRIPTION
One day it would be nice if RP knows nothing about mailroom task queuing