### PR TITLE
Only allow getting org id for active orgs and Replace deprecated dependency

### DIFF
--- a/core/models/org.go
+++ b/core/models/org.go
@@ -273,7 +273,7 @@ func LoadOrg(ctx context.Context, db *sql.DB, orgID OrgID) (*Org, error) {
 // GetOrgIDFromUUID gets an org ID from a UUID (returns NilOrgID if not found)
 func GetOrgIDFromUUID(ctx context.Context, db *sql.DB, orgUUID OrgUUID) (OrgID, error) {
 	var orgID OrgID
-	err := db.QueryRowContext(ctx, `SELECT id FROM orgs_org WHERE uuid = $1`, orgUUID).Scan(&orgID)
+	err := db.QueryRowContext(ctx, `SELECT id FROM orgs_org WHERE is_active = TRUE AND uuid = $1`, orgUUID).Scan(&orgID)
 	if err != nil && err != sql.ErrNoRows {
 		return NilOrgID, fmt.Errorf("error getting org id by uuid: %w", err)
 	}

--- a/core/models/org_test.go
+++ b/core/models/org_test.go
@@ -62,6 +62,25 @@ func TestLoadOrg(t *testing.T) {
 	assert.EqualError(t, err, "no org with id: 99")
 }
 
+func TestGetOrgIDFromUUID(t *testing.T) {
+	ctx, rt := testsuite.Runtime()
+
+	defer testsuite.Reset(testsuite.ResetAll)
+
+	// mark org 2 deleted
+	rt.DB.MustExec(`UPDATE orgs_org SET is_active = FALSE WHERE id = $1`, testdata.Org2.ID)
+	models.FlushCache()
+
+	orgID, err := models.GetOrgIDFromUUID(ctx, rt.DB.DB, models.OrgUUID(testdata.Org1.UUID))
+	require.NoError(t, err)
+	assert.Equal(t, testdata.Org1.ID, orgID)
+
+	orgID2, err := models.GetOrgIDFromUUID(ctx, rt.DB.DB, models.OrgUUID(testdata.Org2.UUID))
+	require.NoError(t, err)
+	assert.Equal(t, orgID2, models.NilOrgID)
+
+}
+
 func TestEmailService(t *testing.T) {
 	ctx, rt := testsuite.Runtime()
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/golang/protobuf v1.5.4
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/generative-ai-go v0.19.0
 	github.com/gorilla/schema v1.4.1
@@ -39,6 +38,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/api v0.230.0
+	google.golang.org/protobuf v1.36.6
 )
 
 require (
@@ -95,6 +95,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
@@ -139,7 +140,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250425173222-7b384671a197 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250425173222-7b384671a197 // indirect
 	google.golang.org/grpc v1.72.0 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/web/org/metrics.go
+++ b/web/org/metrics.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {


### PR DESCRIPTION
This fixes trying to get metrics for org with `is_active = FALSE` to properly return invalid authentication

https://textit.sentry.io/issues/6374553449