### PR TITLE
Simplify setting of URN and URNID on outgoing messages

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -1351,17 +1351,6 @@ type ContactURNsChanged struct {
 	Flow      *Flow // for logging
 }
 
-func (i *URNID) Scan(value any) error         { return null.ScanInt(value, i) }
-func (i URNID) Value() (driver.Value, error)  { return null.IntValue(i) }
-func (i *URNID) UnmarshalJSON(b []byte) error { return null.UnmarshalInt(b, i) }
-func (i URNID) MarshalJSON() ([]byte, error)  { return null.MarshalInt(i) }
-
-func (i ContactID) String() string                { return strconv.FormatInt(int64(i), 10) }
-func (i *ContactID) Scan(value any) error         { return null.ScanInt(value, i) }
-func (i ContactID) Value() (driver.Value, error)  { return null.IntValue(i) }
-func (i *ContactID) UnmarshalJSON(b []byte) error { return null.UnmarshalInt(b, i) }
-func (i ContactID) MarshalJSON() ([]byte, error)  { return null.MarshalInt(i) }
-
 // ContactStatusChange struct used for our contact status change
 type ContactStatusChange struct {
 	ContactID ContactID
@@ -1487,3 +1476,14 @@ func UnlockContacts(rt *runtime.Runtime, orgID OrgID, locks map[ContactID]string
 func getContactLocker(orgID OrgID, contactID ContactID) *redisx.Locker {
 	return redisx.NewLocker(fmt.Sprintf("lock:c:%d:%d", orgID, contactID), time.Minute*5)
 }
+
+func (i *URNID) Scan(value any) error         { return null.ScanInt(value, i) }
+func (i URNID) Value() (driver.Value, error)  { return null.IntValue(i) }
+func (i *URNID) UnmarshalJSON(b []byte) error { return null.UnmarshalInt(b, i) }
+func (i URNID) MarshalJSON() ([]byte, error)  { return null.MarshalInt(i) }
+
+func (i ContactID) String() string                { return strconv.FormatInt(int64(i), 10) }
+func (i *ContactID) Scan(value any) error         { return null.ScanInt(value, i) }
+func (i ContactID) Value() (driver.Value, error)  { return null.IntValue(i) }
+func (i *ContactID) UnmarshalJSON(b []byte) error { return null.UnmarshalInt(b, i) }
+func (i ContactID) MarshalJSON() ([]byte, error)  { return null.MarshalInt(i) }

--- a/core/models/msg_test.go
+++ b/core/models/msg_test.go
@@ -206,11 +206,7 @@ func TestNewOutgoingFlowMsg(t *testing.T) {
 
 		assert.Equal(t, tc.Contact.ID, msg.ContactID())
 		assert.Equal(t, expectedChannelID, msg.ChannelID())
-		if tc.URNID != models.NilURNID {
-			assert.Equal(t, tc.URNID, *msg.ContactURNID())
-		} else {
-			assert.Nil(t, msg.ContactURNID())
-		}
+		assert.Equal(t, tc.URNID, msg.ContactURNID())
 		assert.Equal(t, tc.Flow.ID, msg.FlowID())
 
 		assert.Equal(t, tc.ExpectedStatus, msg.Status(), "%d: status mismatch", i)

--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -110,7 +110,7 @@ func NewCourierMsg(oa *models.OrgAssets, m *models.Msg, u *models.ContactURN, ch
 		MsgCount:     m.MsgCount(),
 		CreatedOn:    m.CreatedOn(),
 		ContactID:    m.ContactID(),
-		ContactURNID: *m.ContactURNID(),
+		ContactURNID: m.ContactURNID(),
 		ChannelUUID:  ch.UUID(),
 		UserID:       m.CreatedByID(),
 		URN:          u.Identity,
@@ -264,7 +264,7 @@ func QueueCourierMessages(rc redis.Conn, oa *models.OrgAssets, contactID models.
 
 	for _, s := range sends {
 		// sanity check the state of the msg we're about to queue...
-		assert(s.URN != nil && s.Msg.ContactURNID() != nil, "can't queue a message to courier without a URN")
+		assert(s.URN != nil && s.Msg.ContactURNID() != models.NilURNID, "can't queue a message to courier without a URN")
 
 		// if this msg is the same priority, add to current batch, otherwise start new batch
 		if s.Msg.HighPriority() == currentPriority {

--- a/core/msgio/send.go
+++ b/core/msgio/send.go
@@ -45,6 +45,8 @@ func tryToQueue(ctx context.Context, rt *runtime.Runtime, db models.DBorTx, msgs
 	// messages that have been successfully queued
 	queued := make([]*models.Msg, 0, len(msgs))
 
+	// TODO use msg.URN if set
+
 	// fetch URNs and organize by id
 	urnIDs := getMessageURNIDs(msgs)
 	urnsByID := make(map[models.URNID]*models.ContactURN, len(urnIDs))
@@ -64,8 +66,8 @@ func tryToQueue(ctx context.Context, rt *runtime.Runtime, db models.DBorTx, msgs
 	for _, m := range msgs {
 		orgID := m.OrgID()
 		var urn *models.ContactURN
-		if m.ContactURNID() != nil {
-			urn = urnsByID[*m.ContactURNID()]
+		if m.ContactURNID() != models.NilURNID {
+			urn = urnsByID[m.ContactURNID()]
 		}
 		sendsByOrg[orgID] = append(sendsByOrg[orgID], Send{Msg: m, URN: urn})
 	}
@@ -151,8 +153,8 @@ func getMessageURNIDs(msgs []*models.Msg) []models.URNID {
 	ids := make(map[models.URNID]bool, len(msgs))
 	for _, m := range msgs {
 		uid := m.ContactURNID()
-		if uid != nil {
-			ids[*uid] = true
+		if uid != models.NilURNID {
+			ids[uid] = true
 		}
 	}
 	return slices.Collect(maps.Keys(ids))

--- a/core/msgio/send_test.go
+++ b/core/msgio/send_test.go
@@ -33,7 +33,7 @@ func (m *msgSpec) createMsg(t *testing.T, rt *runtime.Runtime, oa *models.OrgAss
 	require.NoError(t, err)
 
 	msg := msgs[0]
-	msg.SetURN(m.Contact.URN)
+	msg.SetURN(m.Contact.URN, m.Contact.URNID)
 
 	// use the channel instances in org assets so they're shared between msg instances
 	if msg.ChannelID() != models.NilChannelID {

--- a/web/android/message.go
+++ b/web/android/message.go
@@ -72,7 +72,7 @@ func handleMessage(ctx context.Context, rt *runtime.Runtime, r *messageRequest) 
 		MsgUUID:       m.UUID(),
 		MsgExternalID: m.ExternalID(),
 		URN:           cu.urn,
-		URNID:         *m.ContactURNID(),
+		URNID:         m.ContactURNID(),
 		Text:          m.Text(),
 		NewContact:    cu.newContact,
 	})

--- a/web/msg/handle.go
+++ b/web/msg/handle.go
@@ -47,11 +47,11 @@ func handleHandle(ctx context.Context, rt *runtime.Runtime, r *handleRequest) (a
 	queuedMsgIDs := make([]models.MsgID, 0, len(r.MsgIDs))
 
 	for _, m := range msgs {
-		if m.Status() != models.MsgStatusPending || m.ContactURNID() == nil {
+		if m.Status() != models.MsgStatusPending || m.ContactURNID() == models.NilURNID {
 			continue
 		}
 
-		urn, err := models.URNForID(ctx, rt.DB, oa, *m.ContactURNID())
+		urn, err := models.URNForID(ctx, rt.DB, oa, m.ContactURNID())
 		if err != nil {
 			return nil, 0, fmt.Errorf("error fetching msg URN: %w", err)
 		}
@@ -67,7 +67,7 @@ func handleHandle(ctx context.Context, rt *runtime.Runtime, r *handleRequest) (a
 			MsgUUID:       m.UUID(),
 			MsgExternalID: m.ExternalID(),
 			URN:           urn,
-			URNID:         *m.ContactURNID(),
+			URNID:         m.ContactURNID(),
 			Text:          m.Text(),
 			Attachments:   attachments,
 			NewContact:    false,


### PR DESCRIPTION
 * Make `Msg.ContactURNID` not a pointer
 * Set `Msg.URN` on messages so courier queuing can use it