### PR TITLE
Ordered scene hooks

### DIFF
--- a/core/handlers/contact_field_changed.go
+++ b/core/handlers/contact_field_changed.go
@@ -23,7 +23,7 @@ func handleContactFieldChanged(ctx context.Context, rt *runtime.Runtime, oa *mod
 
 	scene.AttachPreCommitHook(hooks.CommitFieldChangesHook, event)
 	scene.AttachPreCommitHook(hooks.UpdateCampaignEventsHook, event)
-	scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+	scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 
 	return nil
 }

--- a/core/handlers/contact_groups_changed.go
+++ b/core/handlers/contact_groups_changed.go
@@ -38,7 +38,7 @@ func handleContactGroupsChanged(ctx context.Context, rt *runtime.Runtime, oa *mo
 		// add our add event
 		scene.AttachPreCommitHook(hooks.CommitGroupChangesHook, hookEvent)
 		scene.AttachPreCommitHook(hooks.UpdateCampaignEventsHook, hookEvent)
-		scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+		scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 	}
 
 	// add each of our groups
@@ -58,7 +58,7 @@ func handleContactGroupsChanged(ctx context.Context, rt *runtime.Runtime, oa *mo
 
 		scene.AttachPreCommitHook(hooks.CommitGroupChangesHook, hookEvent)
 		scene.AttachPreCommitHook(hooks.UpdateCampaignEventsHook, hookEvent)
-		scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+		scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 	}
 
 	return nil

--- a/core/handlers/contact_language_changed.go
+++ b/core/handlers/contact_language_changed.go
@@ -22,7 +22,7 @@ func handleContactLanguageChanged(ctx context.Context, rt *runtime.Runtime, oa *
 	slog.Debug("contact language changed", "contact", scene.ContactUUID(), "session", scene.SessionUUID(), "language", event.Language)
 
 	scene.AttachPreCommitHook(hooks.CommitLanguageChangesHook, event)
-	scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+	scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 
 	return nil
 }

--- a/core/handlers/contact_name_changed.go
+++ b/core/handlers/contact_name_changed.go
@@ -22,7 +22,7 @@ func handleContactNameChanged(ctx context.Context, rt *runtime.Runtime, oa *mode
 	slog.Debug("contact name changed", "contact", scene.ContactUUID(), "session", scene.SessionUUID(), "name", event.Name)
 
 	scene.AttachPreCommitHook(hooks.CommitNameChangesHook, event)
-	scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+	scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 
 	return nil
 }

--- a/core/handlers/contact_status_changed.go
+++ b/core/handlers/contact_status_changed.go
@@ -22,7 +22,7 @@ func handleContactStatusChanged(ctx context.Context, rt *runtime.Runtime, oa *mo
 	slog.Debug("contact status changed", "contact", scene.ContactUUID(), "session", scene.SessionUUID(), "status", event.Status)
 
 	scene.AttachPreCommitHook(hooks.CommitStatusChangesHook, event)
-	scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+	scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 
 	return nil
 }

--- a/core/handlers/contact_urns_changed.go
+++ b/core/handlers/contact_urns_changed.go
@@ -35,7 +35,7 @@ func handleContactURNsChanged(ctx context.Context, rt *runtime.Runtime, oa *mode
 	}
 
 	scene.AttachPreCommitHook(hooks.CommitURNChangesHook, change)
-	scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+	scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 
 	return nil
 }

--- a/core/handlers/sprint_ended.go
+++ b/core/handlers/sprint_ended.go
@@ -43,7 +43,7 @@ func handleSprintEnded(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 	// if current flow has changed then we need to update modified_on, but also if this is a new session
 	// then flow history may have changed too in a way that won't be captured by a flow_entered event
 	if currentFlowChanged || !event.Resumed {
-		scene.AttachPostCommitHook(hooks.ContactModifiedHook, event)
+		scene.AttachPreCommitHook(hooks.ContactModifiedHook, event)
 	}
 
 	return nil

--- a/core/hooks/commit_added_labels.go
+++ b/core/hooks/commit_added_labels.go
@@ -15,6 +15,8 @@ var CommitAddedLabelsHook models.SceneCommitHook = &commitAddedLabelsHook{}
 
 type commitAddedLabelsHook struct{}
 
+func (h *commitAddedLabelsHook) Order() int { return 1 }
+
 // Apply applies our input labels added, committing them in a single batch
 func (h *commitAddedLabelsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// build our list of msg label adds, we dedupe these so we never double add in the same transaction

--- a/core/hooks/commit_field_changes.go
+++ b/core/hooks/commit_field_changes.go
@@ -19,6 +19,8 @@ var CommitFieldChangesHook models.SceneCommitHook = &commitFieldChangesHook{}
 
 type commitFieldChangesHook struct{}
 
+func (h *commitFieldChangesHook) Order() int { return 1 }
+
 // Apply squashes and writes all the field updates for the contacts
 func (h *commitFieldChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// our list of updates

--- a/core/hooks/commit_group_changes.go
+++ b/core/hooks/commit_group_changes.go
@@ -15,6 +15,8 @@ var CommitGroupChangesHook models.SceneCommitHook = &commitGroupChangesHook{}
 
 type commitGroupChangesHook struct{}
 
+func (h *commitGroupChangesHook) Order() int { return 1 }
+
 // Apply squashes and adds or removes all our contact groups
 func (h *commitGroupChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// build up our list of all adds and removes

--- a/core/hooks/commit_ivr.go
+++ b/core/hooks/commit_ivr.go
@@ -15,6 +15,8 @@ var CommitIVRHook models.SceneCommitHook = &commitIVRHook{}
 
 type commitIVRHook struct{}
 
+func (h *commitIVRHook) Order() int { return 1 }
+
 // Apply takes care of inserting all the messages in the passed in scene.
 func (h *commitIVRHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	msgs := make([]*models.Msg, 0, len(scenes))

--- a/core/hooks/commit_language_changes.go
+++ b/core/hooks/commit_language_changes.go
@@ -15,6 +15,8 @@ var CommitLanguageChangesHook models.SceneCommitHook = &commitLanguageChangesHoo
 
 type commitLanguageChangesHook struct{}
 
+func (h *commitLanguageChangesHook) Order() int { return 1 }
+
 // Apply applies our contact language change before our commit
 func (h *commitLanguageChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// build up our list of pairs of contact id and language name

--- a/core/hooks/commit_messages.go
+++ b/core/hooks/commit_messages.go
@@ -15,6 +15,8 @@ var CommitMessagesHook models.SceneCommitHook = &commitMessagesHook{}
 
 type commitMessagesHook struct{}
 
+func (h *commitMessagesHook) Order() int { return 1 }
+
 type MsgAndURN struct {
 	Msg *models.Msg
 	URN urns.URN

--- a/core/hooks/commit_name_changes.go
+++ b/core/hooks/commit_name_changes.go
@@ -16,6 +16,8 @@ var CommitNameChangesHook models.SceneCommitHook = &commitNameChangesHook{}
 
 type commitNameChangesHook struct{}
 
+func (h *commitNameChangesHook) Order() int { return 1 }
+
 // Apply commits our contact name changes as a bulk update for the passed in map of scene
 func (h *commitNameChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// build up our list of pairs of contact id and contact name

--- a/core/hooks/commit_session_changes.go
+++ b/core/hooks/commit_session_changes.go
@@ -14,6 +14,8 @@ var CommitSessionChangesHook models.SceneCommitHook = &commitSessionChangesHook{
 
 type commitSessionChangesHook struct{}
 
+func (h *commitSessionChangesHook) Order() int { return 1 }
+
 // Apply commits our contact current_flow changes as a bulk update for the passed in map of scene
 func (h *commitSessionChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	updates := make([]CurrentSessionUpdate, 0, len(scenes))

--- a/core/hooks/commit_status_changes.go
+++ b/core/hooks/commit_status_changes.go
@@ -16,6 +16,8 @@ var CommitStatusChangesHook models.SceneCommitHook = &commitStatusChangesHook{}
 
 type commitStatusChangesHook struct{}
 
+func (h *commitStatusChangesHook) Order() int { return 1 }
+
 // Apply commits our contact status change
 func (h *commitStatusChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 

--- a/core/hooks/commit_urn_changes.go
+++ b/core/hooks/commit_urn_changes.go
@@ -17,6 +17,8 @@ var CommitURNChangesHook models.SceneCommitHook = &commitURNChangesHook{}
 
 type commitURNChangesHook struct{}
 
+func (h *commitURNChangesHook) Order() int { return 1 }
+
 // Apply adds all our URNS in a batch
 func (h *commitURNChangesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	var flowUUID assets.FlowUUID

--- a/core/hooks/contact_last_seen.go
+++ b/core/hooks/contact_last_seen.go
@@ -16,6 +16,8 @@ var ContactLastSeenHook models.SceneCommitHook = &contactLastSeenHook{}
 
 type contactLastSeenHook struct{}
 
+func (h *contactLastSeenHook) Order() int { return 1 }
+
 // Apply squashes and updates modified_on on all the contacts passed in
 func (h *contactLastSeenHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 

--- a/core/hooks/contact_modified.go
+++ b/core/hooks/contact_modified.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
-
-	"github.com/jmoiron/sqlx"
 )
 
 // ContactModifiedHook is our hook for contact changes that require an update to modified_on
 var ContactModifiedHook models.SceneCommitHook = &contactModifiedHook{}
 
 type contactModifiedHook struct{}
+
+func (h *contactModifiedHook) Order() int { return 1000 } // run after all other hooks
 
 // Apply squashes and updates modified_on on all the contacts passed in
 func (h *contactModifiedHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {

--- a/core/hooks/create_broadcasts.go
+++ b/core/hooks/create_broadcasts.go
@@ -17,6 +17,8 @@ var CreateBroadcastsHook models.SceneCommitHook = &createBroadcastsHook{}
 
 type createBroadcastsHook struct{}
 
+func (h *createBroadcastsHook) Order() int { return 1 }
+
 // Apply queues up our broadcasts for sending
 func (h *createBroadcastsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	rc := rt.RP.Get()

--- a/core/hooks/create_starts.go
+++ b/core/hooks/create_starts.go
@@ -18,6 +18,8 @@ var CreateStartsHook models.SceneCommitHook = &createStartsHook{}
 
 type createStartsHook struct{}
 
+func (h *createStartsHook) Order() int { return 1 }
+
 // Apply queues up our flow starts
 func (h *createStartsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	rc := rt.RP.Get()

--- a/core/hooks/insert_airtime_transfers.go
+++ b/core/hooks/insert_airtime_transfers.go
@@ -15,6 +15,8 @@ var InsertAirtimeTransfersHook models.SceneCommitHook = &insertAirtimeTransfersH
 
 type insertAirtimeTransfersHook struct{}
 
+func (h *insertAirtimeTransfersHook) Order() int { return 1 }
+
 // Apply inserts all the airtime transfers that were created
 func (h *insertAirtimeTransfersHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// gather all our transfers

--- a/core/hooks/insert_http_logs.go
+++ b/core/hooks/insert_http_logs.go
@@ -15,6 +15,8 @@ var InsertHTTPLogsHook models.SceneCommitHook = &insertHTTPLogsHook{}
 
 type insertHTTPLogsHook struct{}
 
+func (h *insertHTTPLogsHook) Order() int { return 1 }
+
 // Apply inserts all the classifier logs that were created
 func (h *insertHTTPLogsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// gather all our logs

--- a/core/hooks/insert_tickets.go
+++ b/core/hooks/insert_tickets.go
@@ -20,6 +20,8 @@ var InsertTicketsHook models.SceneCommitHook = &insertTicketsHook{}
 
 type insertTicketsHook struct{}
 
+func (h *insertTicketsHook) Order() int { return 1 }
+
 // Apply inserts all the airtime transfers that were created
 func (h *insertTicketsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// gather all our tickets and notes

--- a/core/hooks/insert_webhook_event.go
+++ b/core/hooks/insert_webhook_event.go
@@ -15,6 +15,8 @@ var InsertWebhookEventHook models.SceneCommitHook = &insertWebhookEventHook{}
 
 type insertWebhookEventHook struct{}
 
+func (h *insertWebhookEventHook) Order() int { return 1 }
+
 // Apply inserts all the webook events that were created
 func (h *insertWebhookEventHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	events := make([]*models.WebhookEvent, 0, len(scenes))

--- a/core/hooks/monitor_webhooks.go
+++ b/core/hooks/monitor_webhooks.go
@@ -20,6 +20,8 @@ var MonitorWebhooks models.SceneCommitHook = &monitorWebhooks{}
 
 type monitorWebhooks struct{}
 
+func (h *monitorWebhooks) Order() int { return 1 }
+
 func (h *monitorWebhooks) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// organize events by nodes
 	eventsByNode := make(map[flows.NodeUUID][]*events.WebhookCalledEvent)

--- a/core/hooks/send_messages.go
+++ b/core/hooks/send_messages.go
@@ -14,6 +14,8 @@ var SendMessagesHook models.SceneCommitHook = &sendMessagesHook{}
 
 type sendMessagesHook struct{}
 
+func (h *sendMessagesHook) Order() int { return 1 }
+
 // Apply sends all non-android messages to courier
 func (h *sendMessagesHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	msgs := make([]*models.Msg, 0, 1)

--- a/core/hooks/unsubscribe_resthook.go
+++ b/core/hooks/unsubscribe_resthook.go
@@ -15,6 +15,8 @@ var UnsubscribeResthookHook models.SceneCommitHook = &unsubscribeResthookHook{}
 
 type unsubscribeResthookHook struct{}
 
+func (h *unsubscribeResthookHook) Order() int { return 1 }
+
 // Apply squashes and applies all our resthook unsubscriptions
 func (h *unsubscribeResthookHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scene map[*models.Scene][]any) error {
 	// gather all our unsubscribes

--- a/core/hooks/update_campaign_events.go
+++ b/core/hooks/update_campaign_events.go
@@ -17,6 +17,8 @@ var UpdateCampaignEventsHook models.SceneCommitHook = &updateCampaignEventsHook{
 
 type updateCampaignEventsHook struct{}
 
+func (h *updateCampaignEventsHook) Order() int { return 500 }
+
 // Apply will update all the campaigns for the passed in scene, minimizing the number of queries to do so
 func (h *updateCampaignEventsHook) Apply(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*models.Scene][]any) error {
 	// the contact fires to be deleted and inserted


### PR DESCRIPTION
 * Add ordering to scene hooks
 * Always attach contact modified on hook as pre-commit hook, ordered last

Goal is post-commit hooks only being for things like message queuing and not making database changes