### PR TITLE
Disable retrying of webhook calls

### DIFF
--- a/core/goflow/engine.go
+++ b/core/goflow/engine.go
@@ -60,10 +60,10 @@ func Engine(rt *runtime.Runtime) flows.Engine {
 			"X-Mailroom-Mode": "normal",
 		}
 
-		httpClient, httpRetries, httpAccess := HTTP(rt.Config)
+		httpClient, httpAccess := HTTP(rt.Config)
 
 		eng = engine.NewBuilder().
-			WithWebhookServiceFactory(webhooks.NewServiceFactory(httpClient, httpRetries, httpAccess, webhookHeaders, rt.Config.WebhooksMaxBodyBytes)).
+			WithWebhookServiceFactory(webhooks.NewServiceFactory(httpClient, nil, httpAccess, webhookHeaders, rt.Config.WebhooksMaxBodyBytes)).
 			WithClassificationServiceFactory(classificationFactory(rt)).
 			WithLLMServiceFactory(llmFactory(rt)).
 			WithEmailServiceFactory(emailFactory(rt)).
@@ -87,7 +87,7 @@ func Simulator(ctx context.Context, rt *runtime.Runtime) flows.Engine {
 			"X-Mailroom-Mode": "simulation",
 		}
 
-		httpClient, _, httpAccess := HTTP(rt.Config) // don't do retries in simulator
+		httpClient, httpAccess := HTTP(rt.Config) // don't do retries in simulator
 
 		simulator = engine.NewBuilder().
 			WithWebhookServiceFactory(webhooks.NewServiceFactory(httpClient, nil, httpAccess, webhookHeaders, rt.Config.WebhooksMaxBodyBytes)).

--- a/core/goflow/http.go
+++ b/core/goflow/http.go
@@ -13,11 +13,10 @@ import (
 var httpInit sync.Once
 
 var httpClient *http.Client
-var httpRetries *httpx.RetryConfig
 var httpAccess *httpx.AccessConfig
 
 // HTTP returns the configuration objects for HTTP calls from the engine and its services
-func HTTP(cfg *runtime.Config) (*http.Client, *httpx.RetryConfig, *httpx.AccessConfig) {
+func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
 	httpInit.Do(func() {
 		// customize the default golang transport
 		t := http.DefaultTransport.(*http.Transport).Clone()
@@ -33,14 +32,8 @@ func HTTP(cfg *runtime.Config) (*http.Client, *httpx.RetryConfig, *httpx.AccessC
 			Timeout:   time.Duration(cfg.WebhooksTimeout) * time.Millisecond,
 		}
 
-		httpRetries = httpx.NewExponentialRetries(
-			time.Duration(cfg.WebhooksInitialBackoff)*time.Millisecond,
-			cfg.WebhooksMaxRetries,
-			cfg.WebhooksBackoffJitter,
-		)
-
 		disallowedIPs, disallowedNets, _ := cfg.ParseDisallowedNetworks()
 		httpAccess = httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
 	})
-	return httpClient, httpRetries, httpAccess
+	return httpClient, httpAccess
 }

--- a/core/models/classifier.go
+++ b/core/models/classifier.go
@@ -84,7 +84,7 @@ func (c *Classifier) Type() string { return c.Type_ }
 
 // AsService builds the corresponding ClassificationService for the passed in Classifier
 func (c *Classifier) AsService(cfg *runtime.Config, classifier *flows.Classifier) (flows.ClassificationService, error) {
-	httpClient, httpRetries, _ := goflow.HTTP(cfg)
+	httpClient, _ := goflow.HTTP(cfg)
 
 	switch c.Type() {
 	case ClassifierTypeWit:
@@ -92,7 +92,7 @@ func (c *Classifier) AsService(cfg *runtime.Config, classifier *flows.Classifier
 		if accessToken == "" {
 			return nil, fmt.Errorf("missing %s for Wit classifier: %s", WitConfigAccessToken, c.UUID())
 		}
-		return wit.NewService(httpClient, httpRetries, classifier, accessToken), nil
+		return wit.NewService(httpClient, nil, classifier, accessToken), nil
 
 	default:
 		return nil, fmt.Errorf("unknown classifier type '%s' for classifier: %s", c.Type(), c.UUID())

--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -40,7 +40,7 @@ func RegisterLLMService(typ string, fn func(*LLM, *http.Client) (flows.LLMServic
 }
 
 func llmServiceFactory(rt *runtime.Runtime) engine.LLMServiceFactory {
-	httpClient, _, _ := goflow.HTTP(rt.Config)
+	httpClient, _ := goflow.HTTP(rt.Config)
 
 	return func(llm *flows.LLM) (flows.LLMService, error) {
 		return llm.Asset().(*LLM).AsService(httpClient)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -97,10 +97,7 @@ func NewDefaultConfig() *Config {
 		HandlerWorkers: 32,
 
 		WebhooksTimeout:              15000,
-		WebhooksMaxRetries:           2,
 		WebhooksMaxBodyBytes:         256 * 1024, // 256 KiB
-		WebhooksInitialBackoff:       5000,
-		WebhooksBackoffJitter:        0.5,
 		WebhooksHealthyResponseLimit: 10000,
 
 		SMTPServer:           "",


### PR DESCRIPTION
We currently support 15 sec timeouts, 2 retries, and 5 second waits between.. meaning one webhook call can lock up flow processing for up to 55 seconds. It's debatable how useful retries with such a short backoff time are anyways.