### PR TITLE
Smaller faster flow start batches

### DIFF
--- a/core/runner/start.go
+++ b/core/runner/start.go
@@ -77,6 +77,10 @@ func tryToStartWithLock(ctx context.Context, rt *runtime.Runtime, oa *models.Org
 	scenes := make([]*Scene, 0, len(mcs))
 
 	for _, mc := range mcs {
+		if ctx.Err() != nil {
+			return nil, nil, fmt.Errorf("error starting session: %w", ctx.Err())
+		}
+
 		c, err := mc.EngineContact(oa)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating flow contact: %w", err)

--- a/core/tasks/starts/start_flow.go
+++ b/core/tasks/starts/start_flow.go
@@ -18,7 +18,7 @@ import (
 const (
 	TypeStartFlow = "start_flow"
 
-	startBatchSize = 100
+	startBatchSize = 25
 )
 
 func init() {

--- a/core/tasks/starts/start_flow_batch.go
+++ b/core/tasks/starts/start_flow_batch.go
@@ -40,7 +40,7 @@ func (t *StartFlowBatchTask) Type() string {
 
 // Timeout is the maximum amount of time the task can run for
 func (t *StartFlowBatchTask) Timeout() time.Duration {
-	return time.Minute * 15
+	return time.Minute * 10
 }
 
 func (t *StartFlowBatchTask) WithAssets() models.Refresh {

--- a/core/tasks/starts/start_flow_test.go
+++ b/core/tasks/starts/start_flow_test.go
@@ -58,7 +58,7 @@ func TestStartFlowTask(t *testing.T) {
 			excludeStartedPreviously: true,
 			queue:                    tasks.BatchQueue,
 			expectedContactCount:     121,
-			expectedBatchCount:       2,
+			expectedBatchCount:       5,
 			expectedTotalCount:       121,
 			expectedStatus:           models.StartStatusCompleted,
 			expectedActiveRuns:       map[models.FlowID]int{testdb.Favorites.ID: 122, testdb.PickANumber.ID: 0, testdb.BackgroundFlow.ID: 0},


### PR DESCRIPTION
* Reduce flow start batch size to 25
* Check context in start sessions loop to avoid creating engine sessions after context has ended
* Log to sentry when any task takes 75% of its timeout