### PR TITLE
Add Runtime.Writers 

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	AuthToken        string `help:"the token clients will need to authenticate web requests"`
 	Domain           string `help:"the domain that mailroom is listening on"`
 	AttachmentDomain string `help:"the domain that will be used for relative attachment"`
+	SpoolDir         string `help:"the directory to use for spool files"`
 
 	WorkersRealtime  int     `help:"the number of workers for the realtime task queue"`
 	WorkersBatch     int     `help:"the number of workers for the batch task queue"`
@@ -92,8 +93,9 @@ func NewDefaultConfig() *Config {
 		DBPoolSize: 36,
 		Valkey:     "valkey://localhost:6379/15",
 
-		Address: "localhost",
-		Port:    8090,
+		Address:  "localhost",
+		Port:     8090,
+		SpoolDir: "/var/spool/mailroom",
 
 		WorkersRealtime:  32,
 		WorkersBatch:     8,

--- a/runtime/writers.go
+++ b/runtime/writers.go
@@ -1,0 +1,42 @@
+package runtime
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/nyaruka/gocommon/aws/dynamo"
+)
+
+type Writers struct {
+	Main    *dynamo.Writer
+	History *dynamo.Writer
+	Spool   *dynamo.Spool
+}
+
+func NewWriters(cfg *Config, cl *dynamodb.Client) *Writers {
+	spool := dynamo.NewSpool(cl, cfg.SpoolDir+"/dynamo", 30*time.Second)
+
+	return &Writers{
+		Main:    dynamo.NewWriter(cl, cfg.DynamoTablePrefix+"Main", 250*time.Millisecond, 1000, spool),
+		History: dynamo.NewWriter(cl, cfg.DynamoTablePrefix+"History", 250*time.Millisecond, 1000, spool),
+		Spool:   spool,
+	}
+}
+
+func (w *Writers) Start(wg *sync.WaitGroup) error {
+	if err := w.Spool.Start(wg); err != nil {
+		return fmt.Errorf("error starting dynamo spool: %w", err)
+	}
+
+	w.Main.Start(wg)
+	w.History.Start(wg)
+	return nil
+}
+
+func (w *Writers) Stop() {
+	w.Main.Stop()
+	w.History.Stop()
+	w.Spool.Stop()
+}

--- a/workers_test.go
+++ b/workers_test.go
@@ -50,8 +50,8 @@ func TestForemanAndWorkers(t *testing.T) {
 		q.Push(ctx, vc, "test", 2, &testTask{}, false)
 	}
 
-	fm := mailroom.NewForeman(rt, wg, q, 2)
-	fm.Start()
+	fm := mailroom.NewForeman(rt, q, 2)
+	fm.Start(wg)
 
 	// wait for queue to empty
 	for {


### PR DESCRIPTION
and split mailroom wait group into workers and services groups so tasks are always finished before the services they depend on are stopped