### PR TITLE
Use `/mi/` prefix for internal endpoints

### DIFF
--- a/web/android/testdata/event.json
+++ b/web/android/testdata/event.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/android/event",
+        "path": "/mi/android/event",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/android/event",
+        "path": "/mi/android/event",
         "body": {
             "org_id": 1234,
             "channel_id": 12,
@@ -28,7 +28,7 @@
     {
         "label": "event created in database",
         "method": "POST",
-        "path": "/mr/android/event",
+        "path": "/mi/android/event",
         "body": {
             "org_id": 1,
             "channel_id": 10000,
@@ -51,7 +51,7 @@
     {
         "label": "event created in database and queued for handling",
         "method": "POST",
-        "path": "/mr/android/event",
+        "path": "/mi/android/event",
         "body": {
             "org_id": 1,
             "channel_id": 10000,

--- a/web/android/testdata/message.json
+++ b/web/android/testdata/message.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/android/message",
+        "path": "/mi/android/message",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/android/message",
+        "path": "/mi/android/message",
         "body": {
             "org_id": 1234,
             "channel_id": 12,
@@ -27,7 +27,7 @@
     {
         "label": "message from existing contact created in database",
         "method": "POST",
-        "path": "/mr/android/message",
+        "path": "/mi/android/message",
         "body": {
             "org_id": 1,
             "channel_id": 10000,
@@ -55,7 +55,7 @@
     {
         "label": "message from new contact created in database",
         "method": "POST",
-        "path": "/mr/android/message",
+        "path": "/mi/android/message",
         "body": {
             "org_id": 1,
             "channel_id": 10000,
@@ -83,7 +83,7 @@
     {
         "label": "duplicate message ignored",
         "method": "POST",
-        "path": "/mr/android/message",
+        "path": "/mi/android/message",
         "body": {
             "org_id": 1,
             "channel_id": 10000,
@@ -106,7 +106,7 @@
     {
         "label": "invalid phone number creates 422 response",
         "method": "POST",
-        "path": "/mr/android/message",
+        "path": "/mi/android/message",
         "body": {
             "org_id": 1,
             "channel_id": 10000,

--- a/web/android/testdata/sync.json
+++ b/web/android/testdata/sync.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/android/sync",
+        "path": "/mi/android/sync",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid channel_id",
         "method": "POST",
-        "path": "/mr/android/sync",
+        "path": "/mi/android/sync",
         "body": {
             "channel_id": 5000
         },
@@ -23,7 +23,7 @@
     {
         "label": "valid channel sync",
         "method": "POST",
-        "path": "/mr/android/sync",
+        "path": "/mi/android/sync",
         "body": {
             "channel_id": 30000
         },

--- a/web/campaign/testdata/schedule.json
+++ b/web/campaign/testdata/schedule.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/campaign/schedule",
+        "path": "/mi/campaign/schedule",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/campaign/schedule",
+        "path": "/mi/campaign/schedule",
         "body": {
             "org_id": 1234,
             "point_id": 2345
@@ -24,7 +24,7 @@
     {
         "label": "response is empty on success",
         "method": "POST",
-        "path": "/mr/campaign/schedule",
+        "path": "/mi/campaign/schedule",
         "body": {
             "org_id": 1,
             "point_id": 10000

--- a/web/channel/testdata/interrupt.json
+++ b/web/channel/testdata/interrupt.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/channel/interrupt",
+        "path": "/mi/channel/interrupt",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "response is empty on success",
         "method": "POST",
-        "path": "/mr/channel/interrupt",
+        "path": "/mi/channel/interrupt",
         "body": {
             "org_id": 1,
             "channel_id": 10000

--- a/web/contact/testdata/create.json
+++ b/web/contact/testdata/create.json
@@ -2,7 +2,7 @@
     {
         "label": "error if contact not provided",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 3
@@ -21,7 +21,7 @@
     {
         "label": "create empty contact",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 1,
@@ -47,7 +47,7 @@
     {
         "label": "create contact with all properties",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -100,7 +100,7 @@
     {
         "label": "error if try to create contact with invalid language",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -117,7 +117,7 @@
     {
         "label": "error if try to create contact with invalid URN",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -141,7 +141,7 @@
     {
         "label": "error if try to create contact with taken URN",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -165,7 +165,7 @@
     {
         "label": "though ok to take an orphaned URN",
         "method": "POST",
-        "path": "/mr/contact/create",
+        "path": "/mi/contact/create",
         "body": {
             "org_id": 1,
             "user_id": 3,

--- a/web/contact/testdata/deindex.json
+++ b/web/contact/testdata/deindex.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/contact/deindex",
+        "path": "/mi/contact/deindex",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "contacts that are inactive",
         "method": "POST",
-        "path": "/mr/contact/deindex",
+        "path": "/mi/contact/deindex",
         "body": {
             "org_id": 1,
             "contact_ids": [

--- a/web/contact/testdata/export.json
+++ b/web/contact/testdata/export.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "error if group doesn't exist",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 1,
             "group_id": 1234567,
@@ -26,7 +26,7 @@
     {
         "label": "system group without query",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 1,
             "group_id": 10000,
@@ -165,7 +165,7 @@
     {
         "label": "user group without query",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 1,
             "group_id": 10005,
@@ -301,7 +301,7 @@
     {
         "label": "system group with query",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 1,
             "group_id": 10000,
@@ -318,7 +318,7 @@
     {
         "label": "system group with query (org 2)",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 2,
             "group_id": 20000,
@@ -334,7 +334,7 @@
     {
         "label": "user group with query",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 1,
             "group_id": 10005,
@@ -350,7 +350,7 @@
     {
         "label": "invalid query",
         "method": "POST",
-        "path": "/mr/contact/export",
+        "path": "/mi/contact/export",
         "body": {
             "org_id": 1,
             "group_id": 10000,

--- a/web/contact/testdata/export_preview.json
+++ b/web/contact/testdata/export_preview.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "error if group doesn't exist",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 1,
             "group_id": 1234567,
@@ -26,7 +26,7 @@
     {
         "label": "system group without query",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 1,
             "group_id": 10000,
@@ -40,7 +40,7 @@
     {
         "label": "user group without query",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 1,
             "group_id": 10005,
@@ -54,7 +54,7 @@
     {
         "label": "system group with query",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 1,
             "group_id": 10000,
@@ -68,7 +68,7 @@
     {
         "label": "system group with query (org 2)",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 2,
             "group_id": 20000,
@@ -82,7 +82,7 @@
     {
         "label": "user group with query",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 1,
             "group_id": 10005,
@@ -96,7 +96,7 @@
     {
         "label": "invalid query",
         "method": "POST",
-        "path": "/mr/contact/export_preview",
+        "path": "/mi/contact/export_preview",
         "body": {
             "org_id": 1,
             "group_id": 10000,

--- a/web/contact/testdata/import.json
+++ b/web/contact/testdata/import.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/import",
+        "path": "/mi/contact/import",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "creates tasks for all batches",
         "method": "POST",
-        "path": "/mr/contact/import",
+        "path": "/mi/contact/import",
         "body": {
             "org_id": 1,
             "import_id": 30000

--- a/web/contact/testdata/inspect.json
+++ b/web/contact/testdata/inspect.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/inspect",
+        "path": "/mi/contact/inspect",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "return info by id",
         "method": "POST",
-        "path": "/mr/contact/inspect",
+        "path": "/mi/contact/inspect",
         "body": {
             "org_id": 1,
             "contact_ids": [

--- a/web/contact/testdata/interrupt.json
+++ b/web/contact/testdata/interrupt.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/interrupt",
+        "path": "/mi/contact/interrupt",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "interrupts a single contact synchronously",
         "method": "POST",
-        "path": "/mr/contact/interrupt",
+        "path": "/mi/contact/interrupt",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -42,7 +42,7 @@
     {
         "label": "noop if contact doesn't have a waiting session",
         "method": "POST",
-        "path": "/mr/contact/interrupt",
+        "path": "/mi/contact/interrupt",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -72,7 +72,7 @@
     {
         "label": "queues interrupt task for multiple contacts",
         "method": "POST",
-        "path": "/mr/contact/interrupt",
+        "path": "/mi/contact/interrupt",
         "body": {
             "org_id": 1,
             "user_id": 3,

--- a/web/contact/testdata/modify.json
+++ b/web/contact/testdata/modify.json
@@ -2,7 +2,7 @@
     {
         "label": "noop",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -38,7 +38,7 @@
     {
         "label": "set name",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 1,
@@ -86,7 +86,7 @@
     {
         "label": "set name",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -134,7 +134,7 @@
     {
         "label": "clear name",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -181,7 +181,7 @@
     {
         "label": "set status to blocked",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -228,7 +228,7 @@
     {
         "label": "set status to archived",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -275,7 +275,7 @@
     {
         "label": "set status to active",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -322,7 +322,7 @@
     {
         "label": "set text field with valid value",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -384,7 +384,7 @@
     {
         "label": "set numeric field with valid value",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -476,7 +476,7 @@
     {
         "label": "set date field with valid value",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -547,7 +547,7 @@
     {
         "label": "set state field with valid value",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -622,7 +622,7 @@
     {
         "label": "clear fields",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -750,7 +750,7 @@
     {
         "label": "add group",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -814,7 +814,7 @@
     {
         "label": "add group contact already in",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -866,7 +866,7 @@
     {
         "label": "remove group",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -924,7 +924,7 @@
     {
         "label": "remove group contact isn't part of",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -970,7 +970,7 @@
     {
         "label": "set contact language",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1018,7 +1018,7 @@
     {
         "label": "add URN",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1074,7 +1074,7 @@
     {
         "label": "add an invalid URN",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1128,7 +1128,7 @@
     {
         "label": "add URNs, one of which already exists",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1187,7 +1187,7 @@
     {
         "label": "remove a URN",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1247,7 +1247,7 @@
     {
         "label": "set URNs",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1318,7 +1318,7 @@
     {
         "label": "clear URNs",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1379,7 +1379,7 @@
     {
         "label": "open ticket",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1468,7 +1468,7 @@
     {
         "label": "multiple modifiers of different types",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -1581,7 +1581,7 @@
     {
         "label": "locked contacts are skipped",
         "method": "POST",
-        "path": "/mr/contact/modify",
+        "path": "/mi/contact/modify",
         "body": {
             "org_id": 1,
             "user_id": 3,

--- a/web/contact/testdata/parse_query.json
+++ b/web/contact/testdata/parse_query.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/contact/parse_query",
+        "path": "/mi/contact/parse_query",
         "body": "",
         "status": 405,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "query that is syntactically invalid",
         "method": "POST",
-        "path": "/mr/contact/parse_query",
+        "path": "/mi/contact/parse_query",
         "body": {
             "org_id": 1,
             "query": "$"
@@ -26,7 +26,7 @@
     {
         "label": "query with invalid property",
         "method": "POST",
-        "path": "/mr/contact/parse_query",
+        "path": "/mi/contact/parse_query",
         "body": {
             "org_id": 1,
             "query": "birthday = tomorrow"
@@ -43,7 +43,7 @@
     {
         "label": "query with invalid property but parse_only = true",
         "method": "POST",
-        "path": "/mr/contact/parse_query",
+        "path": "/mi/contact/parse_query",
         "body": {
             "org_id": 1,
             "query": "birthday = tomorrow AND tel = 12345",
@@ -71,7 +71,7 @@
     {
         "label": "valid query without group",
         "method": "POST",
-        "path": "/mr/contact/parse_query",
+        "path": "/mi/contact/parse_query",
         "body": {
             "org_id": 1,
             "query": "AGE>10"
@@ -96,7 +96,7 @@
     {
         "label": "valid query with group in query",
         "method": "POST",
-        "path": "/mr/contact/parse_query",
+        "path": "/mi/contact/parse_query",
         "body": {
             "org_id": 1,
             "query": "group = \"Testers\""

--- a/web/contact/testdata/populate_group.json
+++ b/web/contact/testdata/populate_group.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/contact/populate_group",
+        "path": "/mi/contact/populate_group",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "error if group doesn't exist",
         "method": "POST",
-        "path": "/mr/contact/populate_group",
+        "path": "/mi/contact/populate_group",
         "body": {
             "org_id": 1,
             "group_id": 1234567
@@ -24,7 +24,7 @@
     {
         "label": "response is empty on success",
         "method": "POST",
-        "path": "/mr/contact/populate_group",
+        "path": "/mi/contact/populate_group",
         "body": {
             "org_id": 1,
             "group_id": 30000

--- a/web/contact/testdata/search.json
+++ b/web/contact/testdata/search.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "query error if property not resolveable",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "birthday = tomorrow",
@@ -30,7 +30,7 @@
     {
         "label": "query error if property not convertable",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "age > tomorrow",
@@ -48,7 +48,7 @@
     {
         "label": "valid unstructured query",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "Cathy",
@@ -75,7 +75,7 @@
     {
         "label": "can exclude specific contacts",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "Cathy OR George",
@@ -106,7 +106,7 @@
     {
         "label": "valid search on two fields",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "AGE = 10 and gender = M",
@@ -138,7 +138,7 @@
     {
         "label": "empty query on different group",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "",
@@ -165,7 +165,7 @@
     {
         "label": "empty query on different group with limit",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "",
@@ -188,7 +188,7 @@
     {
         "label": "empty query on different group with limit and sort",
         "method": "POST",
-        "path": "/mr/contact/search",
+        "path": "/mi/contact/search",
         "body": {
             "org_id": 1,
             "query": "",

--- a/web/contact/testdata/urns.json
+++ b/web/contact/testdata/urns.json
@@ -2,7 +2,7 @@
     {
         "label": "error if fields not provided",
         "method": "POST",
-        "path": "/mr/contact/urns",
+        "path": "/mi/contact/urns",
         "body": {},
         "status": 400,
         "response": {
@@ -12,7 +12,7 @@
     {
         "label": "normalizes, validates and resolves urns",
         "method": "POST",
-        "path": "/mr/contact/urns",
+        "path": "/mi/contact/urns",
         "body": {
             "org_id": 1,
             "urns": [

--- a/web/flow/testdata/change_language.json
+++ b/web/flow/testdata/change_language.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/change_language",
+        "path": "/mi/flow/change_language",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "uses all base text values if translation doesn't exist in flow",
         "method": "POST",
-        "path": "/mr/flow/change_language",
+        "path": "/mi/flow/change_language",
         "body": {
             "language": "kin",
             "flow": {
@@ -357,7 +357,7 @@
     {
         "label": "mixes base text and translation values if translation is incomplete",
         "method": "POST",
-        "path": "/mr/flow/change_language",
+        "path": "/mi/flow/change_language",
         "body": {
             "language": "ara",
             "flow": {
@@ -682,7 +682,7 @@
     {
         "label": "uses only translation values if translation complete",
         "method": "POST",
-        "path": "/mr/flow/change_language",
+        "path": "/mi/flow/change_language",
         "body": {
             "language": "spa",
             "flow": {

--- a/web/flow/testdata/clone.json
+++ b/web/flow/testdata/clone.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/clone",
+        "path": "/mi/flow/clone",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "clone valid flow",
         "method": "POST",
-        "path": "/mr/flow/clone",
+        "path": "/mi/flow/clone",
         "body": {
             "dependency_mapping": {
                 "8f107d42-7416-4cf2-9a51-9490361ad517": "1cf84575-ee14-4253-88b6-e3675c04a066",
@@ -121,7 +121,7 @@
     {
         "label": "clone structurally invalid flow",
         "method": "POST",
-        "path": "/mr/flow/clone",
+        "path": "/mi/flow/clone",
         "body": {
             "dependency_mapping": {
                 "8f107d42-7416-4cf2-9a51-9490361ad517": "1cf84575-ee14-4253-88b6-e3675c04a066",
@@ -157,7 +157,7 @@
     {
         "label": "clone flow with missing dependency mapping",
         "method": "POST",
-        "path": "/mr/flow/clone",
+        "path": "/mi/flow/clone",
         "body": {
             "dependency_mapping": {
                 "8f107d42-7416-4cf2-9a51-9490361ad517": "1cf84575-ee14-4253-88b6-e3675c04a066"

--- a/web/flow/testdata/inspect.json
+++ b/web/flow/testdata/inspect.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "inspect valid legacy flow",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "org_id": 1,
             "flow": {
@@ -82,7 +82,7 @@
     {
         "label": "inspect legacy flow with missing dependencies",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "org_id": 1,
             "flow": {
@@ -183,7 +183,7 @@
     {
         "label": "inspect valid v13 flow",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "dependency_mapping": {
                 "8f107d42-7416-4cf2-9a51-9490361ad517": "1cf84575-ee14-4253-88b6-e3675c04a066",
@@ -260,7 +260,7 @@
     {
         "label": "inspect structurally invalid flow",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "org_id": 1,
             "flow": {
@@ -306,7 +306,7 @@
     {
         "label": "inspect legacy single message flow with refresh",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "org_id": 1,
             "flow": {
@@ -360,7 +360,7 @@
     {
         "label": "inspect legacy single message flow",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "org_id": 1,
             "flow": {
@@ -413,7 +413,7 @@
     {
         "label": "inspect flow with invalid base language",
         "method": "POST",
-        "path": "/mr/flow/inspect",
+        "path": "/mi/flow/inspect",
         "body": {
             "org_id": 1,
             "dependency_mapping": {},

--- a/web/flow/testdata/interrupt.json
+++ b/web/flow/testdata/interrupt.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/interrupt",
+        "path": "/mi/flow/interrupt",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "response is empty on success",
         "method": "POST",
-        "path": "/mr/flow/interrupt",
+        "path": "/mi/flow/interrupt",
         "body": {
             "org_id": 1,
             "flow_id": 10000

--- a/web/flow/testdata/migrate.json
+++ b/web/flow/testdata/migrate.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/migrate",
+        "path": "/mi/flow/migrate",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "migrate minimal legacy flow",
         "method": "POST",
-        "path": "/mr/flow/migrate",
+        "path": "/mi/flow/migrate",
         "body": {
             "flow": {
                 "base_language": "eng",
@@ -91,7 +91,7 @@
     {
         "label": "migrate minimal v13 flow",
         "method": "POST",
-        "path": "/mr/flow/migrate",
+        "path": "/mi/flow/migrate",
         "body": {
             "flow": {
                 "uuid": "42362831-f376-4df1-b6d9-a80b102821d9",
@@ -177,7 +177,7 @@
     {
         "label": "migrate legacy flow to specific version",
         "method": "POST",
-        "path": "/mr/flow/migrate",
+        "path": "/mi/flow/migrate",
         "body": {
             "flow": {
                 "base_language": "eng",
@@ -258,7 +258,7 @@
     {
         "label": "migrate invalid v13 flow",
         "method": "POST",
-        "path": "/mr/flow/migrate",
+        "path": "/mi/flow/migrate",
         "body": {
             "flow": {
                 "uuid": "42362831-f376-4df1-b6d9-a80b102821d9",

--- a/web/flow/testdata/start.json
+++ b/web/flow/testdata/start.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/start",
+        "path": "/mi/flow/start",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "missing required fields",
         "method": "POST",
-        "path": "/mr/flow/start",
+        "path": "/mi/flow/start",
         "body": {},
         "status": 400,
         "response": {
@@ -21,7 +21,7 @@
     {
         "label": "error if no recipients",
         "method": "POST",
-        "path": "/mr/flow/start",
+        "path": "/mi/flow/start",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -42,7 +42,7 @@
     {
         "label": "create flow start and return id",
         "method": "POST",
-        "path": "/mr/flow/start",
+        "path": "/mi/flow/start",
         "body": {
             "org_id": 1,
             "user_id": 4,

--- a/web/flow/testdata/start_preview.json
+++ b/web/flow/testdata/start_preview.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "missing org or flow id",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {},
         "status": 400,
         "response": {
@@ -21,7 +21,7 @@
     {
         "label": "no inclusions or exclusions",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,
@@ -36,7 +36,7 @@
     {
         "label": "manual inclusions, no exclusions",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,
@@ -61,7 +61,7 @@
     {
         "label": "query inclusion, no exclusions",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,
@@ -80,7 +80,7 @@
     {
         "label": "manual inclusions, all exclusions",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,
@@ -111,7 +111,7 @@
     {
         "label": "query inclusion, all exclusions",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,
@@ -134,7 +134,7 @@
     {
         "label": "invalid query inclusion (bad syntax)",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,
@@ -152,7 +152,7 @@
     {
         "label": "invalid query inclusion (missing field)",
         "method": "POST",
-        "path": "/mr/flow/start_preview",
+        "path": "/mi/flow/start_preview",
         "body": {
             "org_id": 1,
             "flow_id": 10001,

--- a/web/llm/testdata/translate.json
+++ b/web/llm/testdata/translate.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/llm/translate",
+        "path": "/mi/llm/translate",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/llm/translate",
+        "path": "/mi/llm/translate",
         "body": {
             "org_id": 1234,
             "llm_id": 10002,
@@ -27,7 +27,7 @@
     {
         "label": "invalid llm_id",
         "method": "POST",
-        "path": "/mr/llm/translate",
+        "path": "/mi/llm/translate",
         "body": {
             "org_id": 1,
             "llm_id": 6789,
@@ -43,7 +43,7 @@
     {
         "label": "eng to spa using test LLM",
         "method": "POST",
-        "path": "/mr/llm/translate",
+        "path": "/mi/llm/translate",
         "body": {
             "org_id": 1,
             "llm_id": 10002,
@@ -60,7 +60,7 @@
     {
         "label": "und to spa using test LLM",
         "method": "POST",
-        "path": "/mr/llm/translate",
+        "path": "/mi/llm/translate",
         "body": {
             "org_id": 1,
             "llm_id": 10002,
@@ -77,7 +77,7 @@
     {
         "label": "trigger failure by LLM",
         "method": "POST",
-        "path": "/mr/llm/translate",
+        "path": "/mi/llm/translate",
         "body": {
             "org_id": 1,
             "llm_id": 10002,

--- a/web/msg/testdata/broadcast.json
+++ b/web/msg/testdata/broadcast.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "missing required fields",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {},
         "status": 400,
         "response": {
@@ -21,7 +21,7 @@
     {
         "label": "error if no recipients",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -46,7 +46,7 @@
     {
         "label": "create broadcast and return id",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -100,7 +100,7 @@
     {
         "label": "create broadcast for flow node uuid",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -131,7 +131,7 @@
     {
         "label": "create a one off scheduled broadcast",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -167,7 +167,7 @@
     {
         "label": "create a daily repeating scheduled broadcast",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -203,7 +203,7 @@
     {
         "label": "create a weekly repeating scheduled broadcast",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -240,7 +240,7 @@
     {
         "label": "create a monthly repeating scheduled broadcast",
         "method": "POST",
-        "path": "/mr/msg/broadcast",
+        "path": "/mi/msg/broadcast",
         "body": {
             "org_id": 1,
             "user_id": 4,

--- a/web/msg/testdata/broadcast_preview.json
+++ b/web/msg/testdata/broadcast_preview.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "missing org id",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {},
         "status": 400,
         "response": {
@@ -21,7 +21,7 @@
     {
         "label": "no inclusions or exclusions",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {}
@@ -35,7 +35,7 @@
     {
         "label": "manual inclusions, no exclusions",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {
@@ -59,7 +59,7 @@
     {
         "label": "query inclusion, no exclusions",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {
@@ -77,7 +77,7 @@
     {
         "label": "manual inclusions, all exclusions",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {
@@ -110,7 +110,7 @@
     {
         "label": "query inclusion, all exclusions",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {
@@ -131,7 +131,7 @@
     {
         "label": "invalid query inclusion (bad syntax)",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {
@@ -148,7 +148,7 @@
     {
         "label": "invalid query inclusion (missing field)",
         "method": "POST",
-        "path": "/mr/msg/broadcast_preview",
+        "path": "/mi/msg/broadcast_preview",
         "body": {
             "org_id": 1,
             "include": {

--- a/web/msg/testdata/handle.json
+++ b/web/msg/testdata/handle.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/msg/handle",
+        "path": "/mi/msg/handle",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/msg/handle",
+        "path": "/mi/msg/handle",
         "body": {
             "org_id": 1234,
             "msg_ids": [
@@ -26,7 +26,7 @@
     {
         "label": "response is the ids of the messages that were actually queued for handling",
         "method": "POST",
-        "path": "/mr/msg/handle",
+        "path": "/mi/msg/handle",
         "body": {
             "org_id": 1,
             "msg_ids": [

--- a/web/msg/testdata/resend.json
+++ b/web/msg/testdata/resend.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/msg/resend",
+        "path": "/mi/msg/resend",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/msg/resend",
+        "path": "/mi/msg/resend",
         "body": {
             "org_id": 1234,
             "msg_ids": [
@@ -26,7 +26,7 @@
     {
         "label": "response is the ids of the messages that were actually resent",
         "method": "POST",
-        "path": "/mr/msg/resend",
+        "path": "/mi/msg/resend",
         "body": {
             "org_id": 1,
             "msg_ids": [

--- a/web/msg/testdata/send.json
+++ b/web/msg/testdata/send.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "body": {
             "org_id": 1234,
             "user_id": 2,
@@ -26,7 +26,7 @@
     {
         "label": "invalid contact_id",
         "method": "POST",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "body": {
             "org_id": 1,
             "user_id": 2,
@@ -41,7 +41,7 @@
     {
         "label": "text only message",
         "method": "POST",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "body": {
             "org_id": 1,
             "user_id": 2,
@@ -77,7 +77,7 @@
     {
         "label": "attachments only message",
         "method": "POST",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "body": {
             "org_id": 1,
             "user_id": 2,
@@ -113,7 +113,7 @@
     {
         "label": "ticket reply",
         "method": "POST",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "body": {
             "org_id": 1,
             "user_id": 4,
@@ -154,7 +154,7 @@
     {
         "label": "text message with quick replies",
         "method": "POST",
-        "path": "/mr/msg/send",
+        "path": "/mi/msg/send",
         "body": {
             "org_id": 1,
             "user_id": 2,

--- a/web/org/testdata/deindex.json
+++ b/web/org/testdata/deindex.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/org/deindex",
+        "path": "/mi/org/deindex",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "invalid org_id",
         "method": "POST",
-        "path": "/mr/org/deindex",
+        "path": "/mi/org/deindex",
         "body": {
             "org_id": 1234
         },
@@ -23,7 +23,7 @@
     {
         "label": "org is still active",
         "method": "POST",
-        "path": "/mr/org/deindex",
+        "path": "/mi/org/deindex",
         "body": {
             "org_id": 2
         },
@@ -35,7 +35,7 @@
     {
         "label": "org is inactive",
         "method": "POST",
-        "path": "/mr/org/deindex",
+        "path": "/mi/org/deindex",
         "body": {
             "org_id": 1
         },

--- a/web/po/testdata/export.json
+++ b/web/po/testdata/export.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/po/export",
+        "path": "/mi/po/export",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "export POT from single flow",
         "method": "POST",
-        "path": "/mr/po/export",
+        "path": "/mi/po/export",
         "body": {
             "org_id": 1,
             "flow_ids": [
@@ -24,7 +24,7 @@
     {
         "label": "export Spanish PO from multiple flows",
         "method": "POST",
-        "path": "/mr/po/export",
+        "path": "/mi/po/export",
         "body": {
             "org_id": 1,
             "flow_ids": [

--- a/web/po/testdata/import.json
+++ b/web/po/testdata/import.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "GET",
-        "path": "/mr/po/import",
+        "path": "/mi/po/import",
         "status": 405,
         "response": {
             "error": "illegal method: GET"
@@ -11,7 +11,7 @@
     {
         "label": "import PO into single flow",
         "method": "POST",
-        "path": "/mr/po/import",
+        "path": "/mi/po/import",
         "body": [
             {
                 "name": "org_id",

--- a/web/server.go
+++ b/web/server.go
@@ -37,6 +37,9 @@ func PublicRoute(method string, pattern string, handler Handler) {
 
 // InternalRoute registers a route that handles internal requests between components
 func InternalRoute(method string, pattern string, handler Handler) {
+	routes = append(routes, &route{method, "/mi" + pattern, requireAuthToken(handler)})
+
+	// for backwards compatibility
 	routes = append(routes, &route{method, "/mr" + pattern, requireAuthToken(handler)})
 }
 
@@ -67,7 +70,6 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	router.NotFound(handle404)
 	router.MethodNotAllowed(handle405)
 	router.Get("/", s.WrapHandler(handleIndex))
-	router.Get("/mr/", s.WrapHandler(handleIndex))
 
 	// and all registered routes
 	for _, route := range routes {

--- a/web/system/testdata/errors.json
+++ b/web/system/testdata/errors.json
@@ -2,7 +2,7 @@
     {
         "label": "test errors endpoint noop without params",
         "method": "POST",
-        "path": "/mr/system/errors",
+        "path": "/mi/system/errors",
         "body": {},
         "status": 200,
         "response": {}
@@ -10,7 +10,7 @@
     {
         "label": "test errors endpoint with logged error",
         "method": "POST",
-        "path": "/mr/system/errors",
+        "path": "/mi/system/errors",
         "body": {
             "log": "this is a logged error"
         },
@@ -20,7 +20,7 @@
     {
         "label": "test errors endpoint with an error response",
         "method": "POST",
-        "path": "/mr/system/errors",
+        "path": "/mi/system/errors",
         "body": {
             "return": "this is an error response"
         },
@@ -32,7 +32,7 @@
     {
         "label": "test errors endpoint with a panic",
         "method": "POST",
-        "path": "/mr/system/errors",
+        "path": "/mi/system/errors",
         "body": {
             "panic": "this is a panic"
         },

--- a/web/system/testdata/queues.json
+++ b/web/system/testdata/queues.json
@@ -2,7 +2,7 @@
     {
         "label": "illegal method",
         "method": "POST",
-        "path": "/mr/system/queues",
+        "path": "/mi/system/queues",
         "status": 405,
         "response": {
             "error": "illegal method: POST"
@@ -11,7 +11,7 @@
     {
         "label": "returns queue information",
         "method": "GET",
-        "path": "/mr/system/queues",
+        "path": "/mi/system/queues",
         "body": {},
         "status": 200,
         "response": {

--- a/web/testdata/server.json
+++ b/web/testdata/server.json
@@ -27,25 +27,5 @@
             "url": "/",
             "version": "Dev"
         }
-    },
-    {
-        "label": "illegal method if POST to /mr/",
-        "method": "POST",
-        "path": "/mr/",
-        "status": 405,
-        "response": {
-            "error": "illegal method: POST"
-        }
-    },
-    {
-        "label": "status page if GET /mr/",
-        "method": "GET",
-        "path": "/mr/",
-        "status": 200,
-        "response": {
-            "component": "mailroom",
-            "url": "/mr/",
-            "version": "Dev"
-        }
     }
 ]

--- a/web/ticket/testdata/add_note.json
+++ b/web/ticket/testdata/add_note.json
@@ -2,7 +2,7 @@
     {
         "label": "error if topic not specified",
         "method": "POST",
-        "path": "/mr/ticket/add_note",
+        "path": "/mi/ticket/add_note",
         "body": {
             "org_id": 1,
             "user_id": 2,
@@ -19,7 +19,7 @@
     {
         "label": "adds a note to the given tickets",
         "method": "POST",
-        "path": "/mr/ticket/add_note",
+        "path": "/mi/ticket/add_note",
         "body": {
             "org_id": 1,
             "user_id": 2,

--- a/web/ticket/testdata/assign.json
+++ b/web/ticket/testdata/assign.json
@@ -2,7 +2,7 @@
     {
         "label": "assigns the given tickets to the given user",
         "method": "POST",
-        "path": "/mr/ticket/assign",
+        "path": "/mi/ticket/assign",
         "body": {
             "org_id": 1,
             "user_id": 3,
@@ -34,7 +34,7 @@
     {
         "label": "unassigns the given tickets if user is null",
         "method": "POST",
-        "path": "/mr/ticket/assign",
+        "path": "/mi/ticket/assign",
         "body": {
             "org_id": 1,
             "user_id": 3,

--- a/web/ticket/testdata/change_topic.json
+++ b/web/ticket/testdata/change_topic.json
@@ -2,7 +2,7 @@
     {
         "label": "error if topic not specified",
         "method": "POST",
-        "path": "/mr/ticket/change_topic",
+        "path": "/mi/ticket/change_topic",
         "body": {
             "org_id": 1,
             "user_id": 2,
@@ -19,7 +19,7 @@
     {
         "label": "changes the topic of the given tickets",
         "method": "POST",
-        "path": "/mr/ticket/change_topic",
+        "path": "/mi/ticket/change_topic",
         "body": {
             "org_id": 1,
             "user_id": 2,

--- a/web/ticket/testdata/close.json
+++ b/web/ticket/testdata/close.json
@@ -2,7 +2,7 @@
     {
         "label": "closes the given tickets",
         "method": "POST",
-        "path": "/mr/ticket/close",
+        "path": "/mi/ticket/close",
         "body": {
             "org_id": 1,
             "user_id": 2,

--- a/web/ticket/testdata/reopen.json
+++ b/web/ticket/testdata/reopen.json
@@ -2,7 +2,7 @@
     {
         "label": "reopens the given tickets",
         "method": "POST",
-        "path": "/mr/ticket/reopen",
+        "path": "/mi/ticket/reopen",
         "body": {
             "org_id": 1,
             "user_id": 2,
@@ -37,7 +37,7 @@
         "label": "reopen fails when contact already has open ticket",
         "http_mocks": {},
         "method": "POST",
-        "path": "/mr/ticket/reopen",
+        "path": "/mi/ticket/reopen",
         "body": {
             "org_id": 1,
             "user_id": 2,


### PR DESCRIPTION
with `/mr/` maintained as well for now for backwards compatibility