### PR TITLE
Stop by modifier

### DIFF
--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -465,24 +465,6 @@ func TestGetContactIDsFromReferences(t *testing.T) {
 	assert.ElementsMatch(t, []models.ContactID{testdb.Cathy.ID, testdb.Bob.ID}, ids)
 }
 
-func TestContactStop(t *testing.T) {
-	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
-	oa := testdb.Org1.Load(rt)
-	contact, _, _ := testdb.Cathy.Load(rt, oa)
-
-	err := contact.Stop(ctx, rt.DB, oa)
-	assert.NoError(t, err)
-	assert.Equal(t, models.ContactStatusStopped, contact.Status())
-	assert.Len(t, contact.Groups(), 0)
-
-	// verify that matches the database state
-	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contact WHERE id = $1`, testdb.Cathy.ID).Returns("S")
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contactgroup_contacts WHERE contact_id = $1`, testdb.Cathy.ID).Returns(1)
-}
-
 func TestUpdateContactLastSeenAndModifiedOn(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/core/models/event.go
+++ b/core/models/event.go
@@ -15,20 +15,21 @@ import (
 )
 
 var eventPersistence = map[string]time.Duration{
-	events.TypeAirtimeTransferred:     -1,                   // forever
-	events.TypeCallCreated:            -1,                   // forever
-	events.TypeCallMissed:             -1,                   // forever
-	events.TypeCallReceived:           -1,                   // forever
-	events.TypeChatStarted:            -1,                   // forever
+	events.TypeAirtimeTransferred:     -1,
+	events.TypeCallCreated:            -1,
+	events.TypeCallMissed:             -1,
+	events.TypeCallReceived:           -1,
+	events.TypeChatStarted:            -1,
 	events.TypeContactFieldChanged:    time.Hour * 24 * 365, // 1 year
 	events.TypeContactGroupsChanged:   time.Hour * 24 * 365, // 1 year
 	events.TypeContactLanguageChanged: time.Hour * 24 * 365, // 1 year
 	events.TypeContactNameChanged:     time.Hour * 24 * 365, // 1 year
+	events.TypeContactStatusChanged:   -1,
 	events.TypeContactURNsChanged:     time.Hour * 24 * 365, // 1 year
-	events.TypeOptInStarted:           -1,                   // forever
-	events.TypeOptInStopped:           -1,                   // forever
-	events.TypeRunEnded:               -1,                   // forever
-	events.TypeRunStarted:             -1,                   // forever
+	events.TypeOptInStarted:           -1,
+	events.TypeOptInStopped:           -1,
+	events.TypeRunEnded:               -1,
+	events.TypeRunStarted:             -1,
 }
 
 const (

--- a/core/runner/handlers/contact_status_changed_test.go
+++ b/core/runner/handlers/contact_status_changed_test.go
@@ -12,7 +12,7 @@ import (
 func TestContactStatusChanged(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetDB)
 
 	tcs := []TestCase{
 		{
@@ -21,13 +21,13 @@ func TestContactStatusChanged(t *testing.T) {
 			},
 			SQLAssertions: []SQLAssertion{
 				{
-					SQL:   `select count(*) from contacts_contact where id = $1 AND status = 'B'`,
+					SQL:   `SELECT count(*) FROM contacts_contact WHERE id = $1 AND status = 'B'`,
 					Args:  []any{testdb.Cathy.ID},
 					Count: 1,
 				},
 			},
 			PersistedEvents: map[flows.ContactUUID][]string{
-				testdb.Cathy.UUID: {"contact_groups_changed"},
+				testdb.Cathy.UUID: {"contact_status_changed", "contact_groups_changed"},
 			},
 		},
 		{
@@ -36,12 +36,12 @@ func TestContactStatusChanged(t *testing.T) {
 			},
 			SQLAssertions: []SQLAssertion{
 				{
-					SQL:   `select count(*) from contacts_contact where id = $1 AND status = 'S'`,
+					SQL:   `SELECT count(*) FROM contacts_contact WHERE id = $1 AND status = 'S'`,
 					Args:  []any{testdb.Cathy.ID},
 					Count: 1,
 				},
 			},
-			PersistedEvents: map[flows.ContactUUID][]string{},
+			PersistedEvents: map[flows.ContactUUID][]string{testdb.Cathy.UUID: {"contact_status_changed"}},
 		},
 		{
 			Modifiers: ContactModifierMap{
@@ -49,17 +49,17 @@ func TestContactStatusChanged(t *testing.T) {
 			},
 			SQLAssertions: []SQLAssertion{
 				{
-					SQL:   `select count(*) from contacts_contact where id = $1 AND status = 'A'`,
+					SQL:   `SELECT count(*) FROM contacts_contact WHERE id = $1 AND status = 'A'`,
 					Args:  []any{testdb.Cathy.ID},
 					Count: 1,
 				},
 				{
-					SQL:   `select count(*) from contacts_contact where id = $1 AND status = 'A'`,
+					SQL:   `SELECT count(*) FROM contacts_contact WHERE id = $1 AND status = 'A'`,
 					Args:  []any{testdb.Cathy.ID},
 					Count: 1,
 				},
 			},
-			PersistedEvents: map[flows.ContactUUID][]string{},
+			PersistedEvents: map[flows.ContactUUID][]string{testdb.Cathy.UUID: {"contact_status_changed"}},
 		},
 	}
 

--- a/core/tasks/realtime/ctasks/event_received_test.go
+++ b/core/tasks/realtime/ctasks/event_received_test.go
@@ -191,7 +191,7 @@ func TestChannelEvents(t *testing.T) {
 			},
 			expectedTriggerType: "",
 			expectedResponse:    "",
-			persistedEvents:     map[flows.ContactUUID][]string{testdb.Cathy.UUID: {"contact_groups_changed"}},
+			persistedEvents:     map[flows.ContactUUID][]string{testdb.Cathy.UUID: {"contact_status_changed", "contact_groups_changed"}},
 		},
 		{ // 9: a task against a deleted contact
 			contact: deleted,

--- a/web/contact/testdata/modify.json
+++ b/web/contact/testdata/modify.json
@@ -238,7 +238,12 @@
                 "query": "SELECT count(*) FROM contacts_contact WHERE id = 10000 AND status = 'B'",
                 "count": 1
             }
-        ]
+        ],
+        "persisted_events": {
+            "6393abc0-283d-4c9b-a1b3-641a035c34bf": [
+                "contact_status_changed"
+            ]
+        }
     },
     {
         "label": "set status to archived",
@@ -285,7 +290,12 @@
                 "query": "SELECT count(*) FROM contacts_contact WHERE id = 10000 AND status = 'V'",
                 "count": 1
             }
-        ]
+        ],
+        "persisted_events": {
+            "6393abc0-283d-4c9b-a1b3-641a035c34bf": [
+                "contact_status_changed"
+            ]
+        }
     },
     {
         "label": "set status to active",
@@ -332,7 +342,12 @@
                 "query": "SELECT count(*) FROM contacts_contact WHERE id = 10000 AND status = 'A'",
                 "count": 1
             }
-        ]
+        ],
+        "persisted_events": {
+            "6393abc0-283d-4c9b-a1b3-641a035c34bf": [
+                "contact_status_changed"
+            ]
+        }
     },
     {
         "label": "set text field with valid value",


### PR DESCRIPTION
So stops from channel events are handled same as status=stopped changes in flows, and generate `contact_status_changed` events