### PR TITLE
Limit crediting of modifier events to users based on types

### DIFF
--- a/core/runner/modifiers.go
+++ b/core/runner/modifiers.go
@@ -8,9 +8,24 @@ import (
 	"slices"
 
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/events"
+	"github.com/nyaruka/goflow/flows/modifiers"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
 )
+
+// mapping of modifier types to the event type they generate that should be credited to the user
+var modifierUserEvents = map[string]string{
+	modifiers.TypeField:          events.TypeContactFieldChanged,
+	modifiers.TypeGroups:         events.TypeContactGroupsChanged,
+	modifiers.TypeLanguage:       events.TypeContactLanguageChanged,
+	modifiers.TypeName:           events.TypeContactNameChanged,
+	modifiers.TypeStatus:         events.TypeContactStatusChanged,
+	modifiers.TypeTicket:         events.TypeTicketOpened,
+	modifiers.TypeTicketAssignee: events.TypeTicketAssigneeChanged,
+	modifiers.TypeTicketNote:     events.TypeTicketNoteAdded,
+	modifiers.TypeTicketTopic:    events.TypeTicketTopicChanged,
+}
 
 // BulkModify bulk modifies contacts by applying modifiers and processing the resultant events.
 //

--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -225,10 +225,15 @@ func (s *Scene) ApplyModifier(ctx context.Context, rt *runtime.Runtime, oa *mode
 		modifiers.Apply(eng, env, oa.SessionAssets(), s.Contact, nil, mod, evtLog)
 	}
 
-	// TODO limit user crediting to only the first event? We might have contact_groups_changed events here from changing contact fields etc.
+	userEventType := modifierUserEvents[mod.Type()]
 
 	for _, e := range evts {
-		if err := s.AddEvent(ctx, rt, oa, e, userID); err != nil {
+		creditUserID := models.NilUserID
+		if userEventType != "" && e.Type() == userEventType {
+			creditUserID = userID
+		}
+
+		if err := s.AddEvent(ctx, rt, oa, e, creditUserID); err != nil {
 			return nil, fmt.Errorf("error adding modifier events for contact %s: %w", s.Contact.UUID(), err)
 		}
 	}


### PR DESCRIPTION
Otherwise once we start displaying who did what in chat history, changes that trigger other changes (i.e. query group membership), would lead to those other changes being credited to the user.