### PR TITLE
Add event tags to history table and save for message deletion

### DIFF
--- a/core/models/event_test.go
+++ b/core/models/event_test.go
@@ -130,15 +130,15 @@ func TestEventTags(t *testing.T) {
 	tag := models.NewDeletionByUserTag(testdb.Org1.ID, testdb.Ann.UUID, "0197b335-6ded-79a4-95a6-3af85b57f108", oa.UserByID(testdb.Admin.ID))
 	assert.Equal(t, "del", tag.Tag)
 	assert.Equal(t, map[string]any{
-		"created_on": time.Date(2025, time.May, 4, 12, 30, 45, 123456789, time.UTC),
 		"deleted_by": "user",
+		"deleted_on": time.Date(2025, time.May, 4, 12, 30, 45, 123456789, time.UTC),
 		"user":       map[string]any{"name": "Andy Admin", "uuid": assets.UserUUID("e29fdf9f-56ab-422a-b77d-e3ec26091a25")},
 	}, tag.Data)
 
 	tag = models.NewDeletionByContactTag(testdb.Org1.ID, testdb.Ann.UUID, "0197b335-6ded-79a4-95a6-3af85b57f108")
 	assert.Equal(t, "del", tag.Tag)
 	assert.Equal(t, map[string]any{
-		"created_on": time.Date(2025, time.May, 4, 12, 30, 46, 123456789, time.UTC),
 		"deleted_by": "contact",
+		"deleted_on": time.Date(2025, time.May, 4, 12, 30, 46, 123456789, time.UTC),
 	}, tag.Data)
 }

--- a/core/models/event_test.go
+++ b/core/models/event_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/mailroom/core/models"
@@ -16,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEvent(t *testing.T) {
+func TestEventToDynamo(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
 	reset := test.MockUniverse()
@@ -71,4 +74,71 @@ func TestEvent(t *testing.T) {
 		err = os.WriteFile("testdata/event_to_dynamo.json", testJSON, 0600)
 		require.NoError(t, err)
 	}
+}
+
+func TestEventTagToDynamo(t *testing.T) {
+	tcs := []struct {
+		EventUUID flows.EventUUID `json:"event_uuid"`
+		Tag       string          `json:"tag"`
+		Data      map[string]any  `json:"data"`
+		Dynamo    json.RawMessage `json:"dynamo"`
+	}{}
+
+	testJSON := testsuite.ReadFile(t, "testdata/eventtag_to_dynamo.json")
+	jsonx.MustUnmarshal(testJSON, &tcs)
+
+	for i, tc := range tcs {
+		me := &models.EventTag{
+			OrgID:       testdb.Org1.ID,
+			ContactUUID: testdb.Ann.UUID,
+			EventUUID:   tc.EventUUID,
+			Tag:         tc.Tag,
+			Data:        tc.Data,
+		}
+
+		actual := tc
+		actualItem, err := me.MarshalDynamo()
+		assert.NoError(t, err, "%d: error marshaling event to dynamo", i)
+
+		actual.Dynamo, err = attributevalue.MarshalMapJSON(actualItem)
+		assert.NoError(t, err, "%d: error marshaling event to JSON", i)
+
+		if !test.UpdateSnapshots {
+			test.AssertEqualJSON(t, tc.Dynamo, actual.Dynamo, "%d: dynamo mismatch", i)
+		} else {
+			tcs[i] = actual
+		}
+	}
+
+	if test.UpdateSnapshots {
+		testJSON, err := jsonx.MarshalPretty(tcs)
+		require.NoError(t, err)
+
+		err = os.WriteFile("testdata/eventtag_to_dynamo.json", testJSON, 0600)
+		require.NoError(t, err)
+	}
+}
+
+func TestEventTags(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	reset := test.MockUniverse()
+	defer reset()
+
+	oa := testdb.Org1.Load(t, rt)
+
+	tag := models.NewDeletionByUserTag(testdb.Org1.ID, testdb.Ann.UUID, "0197b335-6ded-79a4-95a6-3af85b57f108", oa.UserByID(testdb.Admin.ID))
+	assert.Equal(t, "del", tag.Tag)
+	assert.Equal(t, map[string]any{
+		"created_on": time.Date(2025, time.May, 4, 12, 30, 45, 123456789, time.UTC),
+		"deleted_by": "user",
+		"user":       map[string]any{"name": "Andy Admin", "uuid": assets.UserUUID("e29fdf9f-56ab-422a-b77d-e3ec26091a25")},
+	}, tag.Data)
+
+	tag = models.NewDeletionByContactTag(testdb.Org1.ID, testdb.Ann.UUID, "0197b335-6ded-79a4-95a6-3af85b57f108")
+	assert.Equal(t, "del", tag.Tag)
+	assert.Equal(t, map[string]any{
+		"created_on": time.Date(2025, time.May, 4, 12, 30, 46, 123456789, time.UTC),
+		"deleted_by": "contact",
+	}, tag.Data)
 }

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -900,19 +900,30 @@ func CreateMsgOut(rt *runtime.Runtime, oa *OrgAssets, c *flows.Contact, content 
 const sqlUpdateMsgDeleted = `
    UPDATE msgs_msg
       SET visibility = $3, text = '', attachments = '{}'
-    WHERE org_id = $1 AND uuid = ANY($2) AND direction = 'I'
-RETURNING id`
+	FROM  contacts_contact c
+    WHERE c.id = msgs_msg.contact_id AND msgs_msg.org_id = $1 AND msgs_msg.uuid = ANY($2) AND msgs_msg.direction = 'I' AND msgs_msg.visibility IN ('V', 'A')
+RETURNING msgs_msg.id, msgs_msg.uuid, c.uuid AS contact_uuid`
 
-func DeleteMessages(ctx context.Context, rt *runtime.Runtime, orgID OrgID, uuids []flows.EventUUID, visibility MsgVisibility) error {
-	ids := make([]MsgID, 0, len(uuids))
+func DeleteMessages(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, uuids []flows.EventUUID, visibility MsgVisibility, userID UserID) error {
+	type deletedMsg struct {
+		MsgID       MsgID             `db:"id"`
+		MsgUUID     flows.EventUUID   `db:"uuid"`
+		ContactUUID flows.ContactUUID `db:"contact_uuid"`
+	}
+	deleted := make([]deletedMsg, 0, len(uuids))
 
 	tx, err := rt.DB.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %w", err)
 	}
 
-	if err := tx.SelectContext(ctx, &ids, sqlUpdateMsgDeleted, orgID, pq.Array(uuids), visibility); err != nil {
+	if err := tx.SelectContext(ctx, &deleted, sqlUpdateMsgDeleted, oa.OrgID(), pq.Array(uuids), visibility); err != nil {
 		return fmt.Errorf("error updating message visibility: %w", err)
+	}
+
+	ids := make([]MsgID, 0, len(deleted))
+	for _, d := range deleted {
+		ids = append(ids, d.MsgID)
 	}
 
 	_, err = tx.ExecContext(ctx, `DELETE FROM msgs_msg_labels WHERE msg_id = ANY($1)`, pq.Array(ids))
@@ -922,6 +933,16 @@ func DeleteMessages(ctx context.Context, rt *runtime.Runtime, orgID OrgID, uuids
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	for _, d := range deleted {
+		var hu *EventUpdate
+		if visibility == VisibilityDeletedByUser {
+			hu = NewDeletionByUserUpdate(oa.OrgID(), d.ContactUUID, d.MsgUUID, oa.UserByID(userID))
+		} else {
+			hu = NewDeletionBySenderUpdate(oa.OrgID(), d.ContactUUID, d.MsgUUID)
+		}
+		rt.Writers.History.Queue(hu)
 	}
 
 	return nil

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -942,7 +942,9 @@ func DeleteMessages(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, uui
 		} else {
 			hu = NewDeletionBySenderUpdate(oa.OrgID(), d.ContactUUID, d.MsgUUID)
 		}
-		rt.Writers.History.Queue(hu)
+		if _, err := rt.Writers.History.Queue(hu); err != nil {
+			return fmt.Errorf("error queueing history update: %w", err)
+		}
 	}
 
 	return nil

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -936,11 +936,11 @@ func DeleteMessages(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, uui
 	}
 
 	for _, d := range deleted {
-		var hu *EventUpdate
+		var hu *EventTag
 		if visibility == VisibilityDeletedByUser {
-			hu = NewDeletionByUserUpdate(oa.OrgID(), d.ContactUUID, d.MsgUUID, oa.UserByID(userID))
+			hu = NewDeletionByUserTag(oa.OrgID(), d.ContactUUID, d.MsgUUID, oa.UserByID(userID))
 		} else {
-			hu = NewDeletionBySenderUpdate(oa.OrgID(), d.ContactUUID, d.MsgUUID)
+			hu = NewDeletionByContactTag(oa.OrgID(), d.ContactUUID, d.MsgUUID)
 		}
 		if _, err := rt.Writers.History.Queue(hu); err != nil {
 			return fmt.Errorf("error queueing history update: %w", err)

--- a/core/models/msg_test.go
+++ b/core/models/msg_test.go
@@ -294,6 +294,8 @@ func TestDeleteMessages(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
+	oa := testdb.Org1.Load(t, rt)
+
 	in1 := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hi", models.MsgStatusHandled)
 	in1.Label(rt, testdb.ReportingLabel, testdb.TestingLabel)
 	in2 := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "bye", models.MsgStatusHandled)
@@ -302,20 +304,20 @@ func TestDeleteMessages(t *testing.T) {
 	in4 := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bada-2b39-7cac-9714-827df9ec6b91", testdb.TwilioChannel, testdb.Ann, "4", models.MsgStatusHandled)
 	out1 := testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bb96-3c4c-72f2-bacc-4b6ae4c592b3", testdb.TwilioChannel, testdb.Ann, "hi", nil, models.MsgStatusSent, false)
 
-	err := models.DeleteMessages(ctx, rt, testdb.Org1.ID, []flows.EventUUID{in1.UUID}, models.VisibilityDeletedBySender)
+	err := models.DeleteMessages(ctx, rt, oa, []flows.EventUUID{in1.UUID}, models.VisibilityDeletedBySender, models.NilUserID)
 	assert.NoError(t, err)
 
 	assertdb.Query(t, rt.DB, `SELECT visibility, text FROM msgs_msg WHERE id = $1`, in1.ID).Columns(map[string]any{"visibility": "X", "text": ""})
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg_labels WHERE msg_id = $1`, in1.ID).Returns(0)
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg_labels WHERE msg_id = $1`, in2.ID).Returns(2) // unchanged
 
-	err = models.DeleteMessages(ctx, rt, testdb.Org1.ID, []flows.EventUUID{in3.UUID, in4.UUID}, models.VisibilityDeletedByUser)
+	err = models.DeleteMessages(ctx, rt, oa, []flows.EventUUID{in3.UUID, in4.UUID}, models.VisibilityDeletedByUser, testdb.Admin.ID)
 	assert.NoError(t, err)
 	assertdb.Query(t, rt.DB, `SELECT visibility, text FROM msgs_msg WHERE id = $1`, in3.ID).Columns(map[string]any{"visibility": "D", "text": ""})
 	assertdb.Query(t, rt.DB, `SELECT visibility, text FROM msgs_msg WHERE id = $1`, in4.ID).Columns(map[string]any{"visibility": "D", "text": ""})
 
 	// trying to delete an outgoing message is a noop
-	err = models.DeleteMessages(ctx, rt, testdb.Org1.ID, []flows.EventUUID{out1.UUID}, models.VisibilityDeletedBySender)
+	err = models.DeleteMessages(ctx, rt, oa, []flows.EventUUID{out1.UUID}, models.VisibilityDeletedBySender, models.NilUserID)
 	assert.NoError(t, err)
 
 	assertdb.Query(t, rt.DB, `SELECT visibility, text FROM msgs_msg WHERE id = $1`, out1.ID).Columns(map[string]any{"visibility": "V", "text": "hi"})

--- a/core/models/testdata/eventtag_to_dynamo.json
+++ b/core/models/testdata/eventtag_to_dynamo.json
@@ -3,8 +3,8 @@
         "event_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
         "tag": "del",
         "data": {
-            "created_on": "2025-05-04T12:30:46.123456789Z",
-            "deleted_by": "contact"
+            "deleted_by": "contact",
+            "deleted_on": "2025-05-04T12:30:46.123456789Z"
         },
         "dynamo": {
             "PK": {
@@ -21,7 +21,7 @@
                     "deleted_by": {
                         "S": "contact"
                     },
-                    "created_on": {
+                    "deleted_on": {
                         "S": "2025-05-04T12:30:46.123456789Z"
                     }
                 }
@@ -32,8 +32,8 @@
         "event_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
         "tag": "del",
         "data": {
-            "created_on": "2025-05-04T12:30:46.123456789Z",
             "deleted_by": "user",
+            "deleted_on": "2025-05-04T12:30:46.123456789Z",
             "user": {
                 "name": "Andy Admin",
                 "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -54,6 +54,9 @@
                     "deleted_by": {
                         "S": "user"
                     },
+                    "deleted_on": {
+                        "S": "2025-05-04T12:30:46.123456789Z"
+                    },
                     "user": {
                         "M": {
                             "name": {
@@ -63,9 +66,6 @@
                                 "S": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
                             }
                         }
-                    },
-                    "created_on": {
-                        "S": "2025-05-04T12:30:46.123456789Z"
                     }
                 }
             }

--- a/core/models/testdata/eventtag_to_dynamo.json
+++ b/core/models/testdata/eventtag_to_dynamo.json
@@ -1,0 +1,74 @@
+[
+    {
+        "event_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+        "tag": "del",
+        "data": {
+            "created_on": "2025-05-04T12:30:46.123456789Z",
+            "deleted_by": "contact"
+        },
+        "dynamo": {
+            "PK": {
+                "S": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf"
+            },
+            "SK": {
+                "S": "evt#0197b335-6ded-79a4-95a6-3af85b57f108#del"
+            },
+            "OrgID": {
+                "N": "1"
+            },
+            "Data": {
+                "M": {
+                    "deleted_by": {
+                        "S": "contact"
+                    },
+                    "created_on": {
+                        "S": "2025-05-04T12:30:46.123456789Z"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "event_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+        "tag": "del",
+        "data": {
+            "created_on": "2025-05-04T12:30:46.123456789Z",
+            "deleted_by": "user",
+            "user": {
+                "name": "Andy Admin",
+                "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
+            }
+        },
+        "dynamo": {
+            "PK": {
+                "S": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf"
+            },
+            "SK": {
+                "S": "evt#0197b335-6ded-79a4-95a6-3af85b57f108#del"
+            },
+            "OrgID": {
+                "N": "1"
+            },
+            "Data": {
+                "M": {
+                    "deleted_by": {
+                        "S": "user"
+                    },
+                    "user": {
+                        "M": {
+                            "name": {
+                                "S": "Andy Admin"
+                            },
+                            "uuid": {
+                                "S": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
+                            }
+                        }
+                    },
+                    "created_on": {
+                        "S": "2025-05-04T12:30:46.123456789Z"
+                    }
+                }
+            }
+        }
+    }
+]

--- a/core/tasks/realtime/ctasks/msg_deleted.go
+++ b/core/tasks/realtime/ctasks/msg_deleted.go
@@ -29,7 +29,7 @@ func (t *MsgDeletedTask) UseReadOnly() bool {
 }
 
 func (t *MsgDeletedTask) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact) error {
-	err := models.DeleteMessages(ctx, rt, oa.OrgID(), []flows.EventUUID{t.MsgUUID}, models.VisibilityDeletedBySender)
+	err := models.DeleteMessages(ctx, rt, oa, []flows.EventUUID{t.MsgUUID}, models.VisibilityDeletedBySender, models.NilUserID)
 	if err != nil {
 		return fmt.Errorf("error deleting message by sender: %w", err)
 	}

--- a/core/tasks/realtime/ctasks/msg_deleted_test.go
+++ b/core/tasks/realtime/ctasks/msg_deleted_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMsgDeleted(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo)
 
 	oa := testdb.Org1.Load(t, rt)
 
@@ -34,4 +35,14 @@ func TestMsgDeleted(t *testing.T) {
 		"0199c4cb-f111-7ce8-9ce9-614d61a2c198": "X",
 		"0199c4cf-486a-79af-9892-79254b6ac5b7": "V",
 	})
+
+	items := testsuite.GetHistoryItems(t, rt, false)
+	if assert.Equal(t, 1, len(items)) {
+		assert.Equal(t, "con#a393abc0-283d-4c9b-a1b3-641a035c34bf", items[0].PK)
+		assert.Equal(t, "evt#0199c4cb-f111-7ce8-9ce9-614d61a2c198#del", items[0].SK)
+
+		data, err := items[0].GetData()
+		require.NoError(t, err)
+		assert.Equal(t, "contact", data["deleted_by"])
+	}
 }

--- a/web/msg/delete.go
+++ b/web/msg/delete.go
@@ -23,11 +23,17 @@ func init() {
 //	}
 type deleteRequest struct {
 	OrgID    models.OrgID      `json:"org_id"    validate:"required"`
+	UserID   models.UserID     `json:"user_id"   validate:"required"`
 	MsgUUIDs []flows.EventUUID `json:"msg_uuids" validate:"required"`
 }
 
 func handleDelete(ctx context.Context, rt *runtime.Runtime, r *deleteRequest) (any, int, error) {
-	if err := models.DeleteMessages(ctx, rt, r.OrgID, r.MsgUUIDs, models.VisibilityDeletedByUser); err != nil {
+	oa, err := models.GetOrgAssets(ctx, rt, r.OrgID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error loading org assets: %w", err)
+	}
+
+	if err := models.DeleteMessages(ctx, rt, oa, r.MsgUUIDs, models.VisibilityDeletedByUser, r.UserID); err != nil {
 		return nil, 0, fmt.Errorf("error deleting messages by user: %w", err)
 	}
 

--- a/web/msg/testdata/delete.json
+++ b/web/msg/testdata/delete.json
@@ -51,8 +51,8 @@
                 "SK": "evt#0199bad8-f98d-75a3-b641-2718a25ac3f5#del",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:30:46.123456789Z",
                     "deleted_by": "user",
+                    "deleted_on": "2025-05-04T12:30:46.123456789Z",
                     "user": {
                         "name": "Andy Admin",
                         "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -64,8 +64,8 @@
                 "SK": "evt#0199bad9-9791-770d-a47d-8f4a6ea3ad13#del",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:30:45.123456789Z",
                     "deleted_by": "user",
+                    "deleted_on": "2025-05-04T12:30:45.123456789Z",
                     "user": {
                         "name": "Andy Admin",
                         "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"

--- a/web/msg/testdata/delete.json
+++ b/web/msg/testdata/delete.json
@@ -51,7 +51,7 @@
                 "SK": "evt#0199bad8-f98d-75a3-b641-2718a25ac3f5#del",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:30:45.123456789Z",
+                    "created_on": "2025-05-04T12:30:46.123456789Z",
                     "deleted_by": "user",
                     "user": {
                         "name": "Andy Admin",
@@ -64,7 +64,7 @@
                 "SK": "evt#0199bad9-9791-770d-a47d-8f4a6ea3ad13#del",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:30:46.123456789Z",
+                    "created_on": "2025-05-04T12:30:45.123456789Z",
                     "deleted_by": "user",
                     "user": {
                         "name": "Andy Admin",

--- a/web/msg/testdata/delete.json
+++ b/web/msg/testdata/delete.json
@@ -14,6 +14,7 @@
         "path": "/mi/msg/delete",
         "body": {
             "org_id": 1,
+            "user_id": 3,
             "msg_uuids": [
                 "0199bad8-f98d-75a3-b641-2718a25ac3f5",
                 "0199bad9-9791-770d-a47d-8f4a6ea3ad13"
@@ -41,6 +42,34 @@
                 "columns": {
                     "text": "3",
                     "visibility": "V"
+                }
+            }
+        ],
+        "expected_history": [
+            {
+                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "SK": "evt#0199bad8-f98d-75a3-b641-2718a25ac3f5#del",
+                "OrgID": 1,
+                "Data": {
+                    "created_on": "2025-05-04T12:30:45.123456789Z",
+                    "deleted_by": "user",
+                    "user": {
+                        "name": "Andy Admin",
+                        "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
+                    }
+                }
+            },
+            {
+                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "SK": "evt#0199bad9-9791-770d-a47d-8f4a6ea3ad13#del",
+                "OrgID": 1,
+                "Data": {
+                    "created_on": "2025-05-04T12:30:46.123456789Z",
+                    "deleted_by": "user",
+                    "user": {
+                        "name": "Andy Admin",
+                        "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
+                    }
                 }
             }
         ]


### PR DESCRIPTION
Requires changes on the RP side which currently assumes everything it reads from the history table is an event