### PR TITLE
Rewrite sql queries that use temp tables with named parameters

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -1225,9 +1225,9 @@ func FilterContactIDsByNotInFlow(ctx context.Context, db *sqlx.DB, contacts []Co
 
 const sqlUpdateContactURNPriorityAndChannel = `
 UPDATE contacts_contacturn u
-   SET channel_id = r.channel_id::int, priority = r.priority::int
-  FROM (VALUES(:id, :channel_id, :priority)) AS r(id, channel_id, priority)
- WHERE u.id = r.id::int`
+   SET channel_id = r.channel_id, priority = r.priority
+  FROM (VALUES(:id::int, :channel_id::int, :priority::int)) AS r(id, channel_id, priority)
+ WHERE u.id = r.id`
 
 // UpdateURNPriorityAndChannel updates the passed in URNs in our database (only priority and channel)
 func UpdateURNPriorityAndChannel(ctx context.Context, db DBorTx, urnz []*ContactURN) error {
@@ -1305,15 +1305,7 @@ func UpdateContactStatus(ctx context.Context, db DBorTx, changes []*ContactStatu
 }
 
 const sqlUpdateContactStatus = `
-UPDATE
-	contacts_contact c
-SET
-	status = r.status,
-	modified_on = NOW()
-FROM (
-	VALUES(:id, :status)
-) AS
-	r(id, status)
-WHERE
-	c.id = r.id::int
-`
+UPDATE contacts_contact c
+   SET status = r.status, modified_on = NOW()
+  FROM (VALUES(:id::int, :status)) AS r(id, status)
+ WHERE c.id = r.id`

--- a/core/models/contact_fire.go
+++ b/core/models/contact_fire.go
@@ -131,8 +131,8 @@ type FireDelete struct {
 // note that : is escaped as \x3A to stop sqlx mistakenly treating it as a named variable
 const sqlDeleteCampaignContactFires = `
 DELETE FROM contacts_contactfire WHERE id IN (
-    SELECT cf.id FROM contacts_contactfire cf, (VALUES(:contact_id, :event_id, :fire_version)) AS f(contact_id, event_id, fire_version)
-     WHERE cf.contact_id = f.contact_id::int AND fire_type = 'C' AND cf.scope = f.event_id || E'\x3A' || f.fire_version
+    SELECT cf.id FROM contacts_contactfire cf, (VALUES(:contact_id::int, :event_id::int, :fire_version)) AS f(contact_id, event_id, fire_version)
+     WHERE cf.contact_id = f.contact_id AND fire_type = 'C' AND cf.scope = f.event_id || E'\x3A' || f.fire_version
 )`
 
 // DeleteCampaignFires deletes *specific* campaign fires for the given contacts

--- a/core/models/group.go
+++ b/core/models/group.go
@@ -97,20 +97,12 @@ type GroupRemove struct {
 }
 
 const removeContactsFromGroupsSQL = `
-DELETE FROM
-	contacts_contactgroup_contacts
-WHERE 
-	id
-IN (
-	SELECT 
-		c.id 
-	FROM 
-		contacts_contactgroup_contacts c,
-		(VALUES(:contact_id, :group_id)) AS g(contact_id, group_id)
-	WHERE
-		c.contact_id = g.contact_id::int AND c.contactgroup_id = g.group_id::int
-);
-`
+DELETE FROM contacts_contactgroup_contacts
+WHERE id IN (
+	SELECT c.id 
+	FROM contacts_contactgroup_contacts c, (VALUES(:contact_id::int, :group_id::int)) AS g(contact_id, group_id)
+	WHERE c.contact_id = g.contact_id AND c.contactgroup_id = g.group_id
+);`
 
 // AddContactsToGroups fires a bulk SQL query to remove all the contacts in the passed in groups
 func AddContactsToGroups(ctx context.Context, tx DBorTx, adds []*GroupAdd) error {

--- a/core/models/resthook.go
+++ b/core/models/resthook.go
@@ -69,6 +69,6 @@ UPDATE api_resthooksubscriber
  WHERE id = ANY(
     SELECT s.id 
       FROM api_resthooksubscriber s
-      JOIN api_resthook r ON s.resthook_id = r.id, (VALUES(:org_id, :slug, :url)) AS u(org_id, slug, url)
-     WHERE s.is_active = TRUE AND r.org_id = u.org_id::int AND r.slug = u.slug AND s.target_url = u.url
+      JOIN api_resthook r ON s.resthook_id = r.id, (VALUES(:org_id::int, :slug, :url)) AS u(org_id, slug, url)
+     WHERE s.is_active = TRUE AND r.org_id = u.org_id AND r.slug = u.slug AND s.target_url = u.url
 )`

--- a/core/models/run.go
+++ b/core/models/run.go
@@ -119,19 +119,19 @@ UPDATE
 	flows_flowrun fr
 SET
 	status = r.status,
-	exited_on = r.exited_on::timestamptz,
-	responded = r.responded::bool,
+	exited_on = r.exited_on,
+	responded = r.responded,
 	results = r.results,
-	path_nodes = r.path_nodes::uuid[],
-	path_times = r.path_times::timestamptz[],
-	current_node_uuid = r.current_node_uuid::uuid,
+	path_nodes = r.path_nodes,
+	path_times = r.path_times,
+	current_node_uuid = r.current_node_uuid,
 	modified_on = NOW()
 FROM (
-	VALUES(:uuid, :status, :exited_on, :responded, :results, :path_nodes, :path_times, :current_node_uuid)
+	VALUES(:uuid::uuid, :status, :exited_on::timestamptz, :responded::bool, :results, :path_nodes::uuid[], :path_times::timestamptz[], :current_node_uuid::uuid)
 ) AS
 	r(uuid, status, exited_on, responded, results, path_nodes, path_times, current_node_uuid)
 WHERE
-	fr.uuid = r.uuid::uuid`
+	fr.uuid = r.uuid`
 
 func UpdateRuns(ctx context.Context, tx *sqlx.Tx, runs []*FlowRun) error {
 	if err := BulkQuery(ctx, "update runs", tx, sqlUpdateRun, runs); err != nil {

--- a/core/models/ticket.go
+++ b/core/models/ticket.go
@@ -187,13 +187,13 @@ func UpdateTicketLastActivity(ctx context.Context, db DBorTx, tickets []*Ticket)
 const sqlUpdateTicket = `
 UPDATE tickets_ticket t
    SET status = r.status,
-       assignee_id = r.assignee_id::int,
-       topic_id = r.topic_id::int,
-       last_activity_on = r.last_activity_on::timestamptz,
-	   closed_on = r.closed_on::timestamptz,
+       assignee_id = r.assignee_id,
+       topic_id = r.topic_id,
+       last_activity_on = r.last_activity_on,
+	   closed_on = r.closed_on,
        modified_on = NOW()
-  FROM (VALUES(:id, :status, :assignee_id, :topic_id, :last_activity_on, :closed_on)) AS r(id, status, assignee_id, topic_id, last_activity_on, closed_on)
- WHERE t.id = r.id::int`
+  FROM (VALUES(:id::int, :status, :assignee_id::int, :topic_id::int, :last_activity_on::timestamptz, :closed_on::timestamptz)) AS r(id, status, assignee_id, topic_id, last_activity_on, closed_on)
+ WHERE t.id = r.id`
 
 // UpdateTickets updates the passed in tickets in the database
 func UpdateTickets(ctx context.Context, tx DBorTx, tickets []*Ticket) error {

--- a/core/runner/hooks/update_contact_fields.go
+++ b/core/runner/hooks/update_contact_fields.go
@@ -99,12 +99,12 @@ type FieldValue struct {
 
 const sqlUpdateContactFields = `
 UPDATE contacts_contact c
-   SET fields = COALESCE(fields,'{}'::jsonb) || r.updates::jsonb
-  FROM (VALUES(:contact_id, :updates)) AS r(contact_id, updates)
- WHERE c.id = r.contact_id::int`
+   SET fields = COALESCE(fields,'{}'::jsonb) || r.updates
+  FROM (VALUES(:contact_id::int, :updates::jsonb)) AS r(contact_id, updates)
+ WHERE c.id = r.contact_id`
 
 const sqlDeleteContactFields = `
 UPDATE contacts_contact c
    SET fields = fields - r.field_uuid
-  FROM (VALUES(:contact_id, :field_uuid)) AS r(contact_id, field_uuid)
- WHERE c.id = r.contact_id::int`
+  FROM (VALUES(:contact_id::int, :field_uuid)) AS r(contact_id, field_uuid)
+ WHERE c.id = r.contact_id`

--- a/core/runner/hooks/update_contact_language.go
+++ b/core/runner/hooks/update_contact_language.go
@@ -40,5 +40,5 @@ type languageUpdate struct {
 const sqlUpdateContactLanguage = `
 UPDATE contacts_contact c
    SET language = r.language
-  FROM (VALUES(:id, :language)) AS r(id, language)
- WHERE c.id = r.id::int`
+  FROM (VALUES(:id::int, :language)) AS r(id, language)
+ WHERE c.id = r.id`

--- a/core/runner/hooks/update_contact_name.go
+++ b/core/runner/hooks/update_contact_name.go
@@ -40,5 +40,5 @@ type nameUpdate struct {
 const sqlUpdateContactName = `
 UPDATE contacts_contact c
    SET name = r.name
-  FROM (VALUES(:id, :name)) AS r(id, name)
- WHERE c.id = r.id::int`
+  FROM (VALUES(:id::int, :name)) AS r(id, name)
+ WHERE c.id = r.id`

--- a/core/runner/hooks/update_contact_session.go
+++ b/core/runner/hooks/update_contact_session.go
@@ -38,6 +38,6 @@ type CurrentSessionUpdate struct {
 
 const sqlUpdateContactCurrentSession = `
 UPDATE contacts_contact c
-   SET current_session_uuid = r.current_session_uuid::uuid, current_flow_id = r.current_flow_id::int
-  FROM (VALUES(:id, :current_session_uuid, :current_flow_id)) AS r(id, current_session_uuid, current_flow_id)
- WHERE c.id = r.id::int`
+   SET current_session_uuid = r.current_session_uuid, current_flow_id = r.current_flow_id
+  FROM (VALUES(:id::int, :current_session_uuid::uuid, :current_flow_id::int)) AS r(id, current_session_uuid, current_flow_id)
+ WHERE c.id = r.id`


### PR DESCRIPTION
`jmoiron/sqlx` couldn't parse something like `:contact_id::int` but `vinovest/sqlx` fixed that.. and putting the casts in the `VALUES` clause feels cleaner and appears to be necessary if using pgx.