### PR TITLE
Remove unneeded calls to models.FlushCache

### DIFF
--- a/core/crons/throttle_queue_test.go
+++ b/core/crons/throttle_queue_test.go
@@ -33,8 +33,6 @@ func TestThrottleQueue(t *testing.T) {
 	// make it look like org 1 has 20,000 messages in its outbox
 	rt.DB.MustExec(`INSERT INTO orgs_itemcount(org_id, scope, count, is_squashed) VALUES ($1, 'msgs:folder:O', 10050, FALSE)`, testdb.Org1.ID)
 
-	models.FlushCache()
-
 	res, err = cron.Run(ctx, rt)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"paused": 1, "resumed": 0}, res)

--- a/core/models/org_test.go
+++ b/core/models/org_test.go
@@ -70,7 +70,6 @@ func TestGetOrgIDFromUUID(t *testing.T) {
 
 	// mark org 2 deleted
 	rt.DB.MustExec(`UPDATE orgs_org SET is_active = FALSE WHERE id = $1`, testdb.Org2.ID)
-	models.FlushCache()
 
 	orgID, err := models.GetOrgIDFromUUID(ctx, rt.DB.DB, models.OrgUUID(testdb.Org1.UUID))
 	require.NoError(t, err)
@@ -89,7 +88,6 @@ func TestEmailService(t *testing.T) {
 
 	// make org 2 a child of org 1
 	rt.DB.MustExec(`UPDATE orgs_org SET parent_id = $2 WHERE id = $1`, testdb.Org2.ID, testdb.Org1.ID)
-	models.FlushCache()
 
 	org1, err := models.LoadOrg(ctx, rt.Config, rt.DB.DB, testdb.Org1.ID)
 	require.NoError(t, err)

--- a/core/runner/handlers/optin_requested_test.go
+++ b/core/runner/handlers/optin_requested_test.go
@@ -20,7 +20,6 @@ func TestOptinRequested(t *testing.T) {
 	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Jokes")
-	models.FlushCache()
 
 	rt.DB.MustExec(`UPDATE contacts_contacturn SET identity = 'facebook:12345', scheme='facebook', path='12345' WHERE contact_id = $1`, testdb.Ann.ID)
 	rt.DB.MustExec(`UPDATE contacts_contacturn SET identity = 'facebook:23456', scheme='facebook', path='23456' WHERE contact_id = $1`, testdb.Cat.ID)

--- a/core/tasks/realtime/ctasks/ticket_closed_test.go
+++ b/core/tasks/realtime/ctasks/ticket_closed_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/goflow/flows/events"
-	"github.com/nyaruka/mailroom/core/models"
 	_ "github.com/nyaruka/mailroom/core/runner/handlers"
 	"github.com/nyaruka/mailroom/core/tasks"
 	"github.com/nyaruka/mailroom/core/tasks/realtime"
@@ -24,7 +23,6 @@ func TestTicketClosed(t *testing.T) {
 
 	// add a ticket closed trigger
 	testdb.InsertTicketClosedTrigger(t, rt, testdb.Org1, testdb.Favorites)
-	models.FlushCache()
 
 	testdb.InsertClosedTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.DefaultTopic, nil)
 	evt := events.NewTicketClosed("01992f54-5ab6-717a-a39e-e8ca91fb7262")

--- a/services/llm/anthropic/service_test.go
+++ b/services/llm/anthropic/service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/mailroom/core/ai"
-	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/services/llm/anthropic"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
@@ -20,7 +19,6 @@ func TestService(t *testing.T) {
 
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "anthropic", "claude", "Bad Config", map[string]any{})
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "anthropic", "claude", "Good", map[string]any{"api_key": "sesame"})
-	models.FlushCache()
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/deepseek/service_test.go
+++ b/services/llm/deepseek/service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/mailroom/core/ai"
-	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/services/llm/deepseek"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
@@ -20,7 +19,6 @@ func TestService(t *testing.T) {
 
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "deepseek", "chat", "Bad Config", map[string]any{})
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "deepseek", "chat", "Good", map[string]any{"api_key": "sesame"})
-	models.FlushCache()
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/google/service_test.go
+++ b/services/llm/google/service_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/services/llm/google"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
@@ -18,7 +17,6 @@ func TestService(t *testing.T) {
 
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "google", "gemini", "Bad Config", map[string]any{})
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "google", "gemini", "Good", map[string]any{"api_key": "sesame"})
-	models.FlushCache()
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/openai/service_test.go
+++ b/services/llm/openai/service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/mailroom/core/ai"
-	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/services/llm/openai"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
@@ -20,7 +19,6 @@ func TestService(t *testing.T) {
 
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai", "gpt-4", "Bad Config", map[string]any{})
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai", "gpt-4", "Good", map[string]any{"api_key": "sesame"})
-	models.FlushCache()
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/openai_azure/service_test.go
+++ b/services/llm/openai_azure/service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/mailroom/core/ai"
-	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/services/llm/openai_azure"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
@@ -20,7 +19,6 @@ func TestService(t *testing.T) {
 
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai_azure", "gpt-4", "Bad Config", map[string]any{})
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai_azure", "gpt-4", "Good", map[string]any{"endpoint": "http://azure.com/ai", "api_key": "sesame"})
-	models.FlushCache()
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -138,7 +138,6 @@ func TestPopulateGroup(t *testing.T) {
 	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetElastic)
 
 	testdb.InsertContactGroup(t, rt, testdb.Org1, "", "Dynamic", "age > 18")
-	models.FlushCache()
 
 	testsuite.RunWebTests(t, rt, "testdata/populate_group.json")
 }


### PR DESCRIPTION
Because this is done by a `t.Cleanup` set at end of `testsuite.Runtime`