### PR TITLE
Mark messages as handled using UUID instead of ID

### DIFF
--- a/core/ivr/resumes.go
+++ b/core/ivr/resumes.go
@@ -115,5 +115,5 @@ func buildMsgResume(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 	}
 
 	// create our msg resume event
-	return &models.MsgInRef{ID: msg.ID(), Handled: true}, resumes.NewMsg(msgEvt), nil, nil
+	return &models.MsgInRef{UUID: msg.UUID(), Handled: true, ID: msg.ID()}, resumes.NewMsg(msgEvt), nil, nil
 }

--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -315,7 +315,6 @@ type fetchAttachmentRequest struct {
 	ChannelUUID assets.ChannelUUID `json:"channel_uuid"`
 	URL         string             `json:"url"`
 	MsgUUID     flows.EventUUID    `json:"msg_uuid"`
-	MsgID       models.MsgID       `json:"msg_id"` // deprecated
 }
 
 type fetchAttachmentResponse struct {
@@ -328,13 +327,12 @@ type fetchAttachmentResponse struct {
 }
 
 // FetchAttachment calls courier to fetch the given attachment
-func FetchAttachment(ctx context.Context, rt *runtime.Runtime, ch *models.Channel, attURL string, msgUUID flows.EventUUID, msgID models.MsgID) (utils.Attachment, clogs.UUID, error) {
+func FetchAttachment(ctx context.Context, rt *runtime.Runtime, ch *models.Channel, attURL string, msgUUID flows.EventUUID) (utils.Attachment, clogs.UUID, error) {
 	payload := jsonx.MustMarshal(&fetchAttachmentRequest{
 		ChannelType: ch.Type(),
 		ChannelUUID: ch.UUID(),
 		URL:         attURL,
 		MsgUUID:     msgUUID,
-		MsgID:       msgID,
 	})
 	req, _ := http.NewRequest("POST", fmt.Sprintf("https://%s/c/_fetch-attachment", rt.Config.Domain), bytes.NewReader(payload))
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.Config.CourierAuthToken))

--- a/core/msgio/courier_test.go
+++ b/core/msgio/courier_test.go
@@ -120,7 +120,7 @@ func TestNewCourierMsg(t *testing.T) {
 		"",
 	), "", "")
 	in1 := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "test", models.MsgStatusHandled)
-	msg2, err := models.NewOutgoingFlowMsg(rt, oa.Org(), twilio, ann, flow, msgEvent2, &models.MsgInRef{ID: in1.ID, ExtID: "EX123"})
+	msg2, err := models.NewOutgoingFlowMsg(rt, oa.Org(), twilio, ann, flow, msgEvent2, &models.MsgInRef{UUID: in1.UUID, ID: in1.ID, ExtID: "EX123"})
 	require.NoError(t, err)
 
 	err = models.InsertMessages(ctx, rt.DB, []*models.Msg{msg2.Msg})
@@ -181,7 +181,7 @@ func TestNewCourierMsg(t *testing.T) {
 	}`, string(jsonx.MustMarshal(msgEvent3.CreatedOn().In(time.UTC))), testdb.Admin.ID, msg3.UUID()))
 
 	optInEvent := events.NewOptInRequested(session.Assets().OptIns().Get(optIn.UUID()).Reference(), twilio.Reference(), "tel:+16055741111")
-	msg4 := models.NewOutgoingOptInMsg(rt, testdb.Org1.ID, ann, flow, optIn, twilio, optInEvent, &models.MsgInRef{ID: in1.ID, ExtID: "EX123"})
+	msg4 := models.NewOutgoingOptInMsg(rt, testdb.Org1.ID, ann, flow, optIn, twilio, optInEvent, &models.MsgInRef{UUID: in1.UUID, ID: in1.ID, ExtID: "EX123"})
 	err = models.InsertMessages(ctx, rt.DB, []*models.Msg{msg4.Msg})
 	require.NoError(t, err)
 

--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -212,7 +212,7 @@ func insertTestMessage(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets, 
 	tch := &testdb.Channel{ID: ch.ID(), UUID: ch.UUID(), Type: ch.Type()}
 
 	m := testdb.InsertIncomingMsg(t, rt, testdb.Org1, flows.NewEventUUID(), tch, c, msg.Text(), models.MsgStatusPending)
-	return &models.MsgInRef{ID: m.ID}
+	return &models.MsgInRef{UUID: m.UUID, ID: m.ID}
 }
 
 // createTestFlow creates a flow that starts with a split by contact id

--- a/core/runner/hooks/update_message_handled.go
+++ b/core/runner/hooks/update_message_handled.go
@@ -41,7 +41,7 @@ func (h *updateMessageHandled) Execute(ctx context.Context, rt *runtime.Runtime,
 			ticket = tks[len(tks)-1]
 		}
 
-		err := models.MarkMessageHandled(ctx, tx, msgIn.ID, models.MsgStatusHandled, visibility, flow, ticket, msgIn.Attachments, msgIn.LogUUIDs)
+		err := models.MarkMessageHandled(ctx, tx, msgIn.UUID, models.MsgStatusHandled, visibility, flow, ticket, msgIn.Attachments, msgIn.LogUUIDs)
 		if err != nil {
 			return fmt.Errorf("error marking message as handled: %w", err)
 		}

--- a/core/tasks/realtime/ctasks/msg_received.go
+++ b/core/tasks/realtime/ctasks/msg_received.go
@@ -63,7 +63,7 @@ func (t *MsgReceivedTask) perform(ctx context.Context, rt *runtime.Runtime, oa *
 			if utils.Attachment(attURL).ContentType() != "" {
 				attachments = append(attachments, utils.Attachment(attURL))
 			} else {
-				attachment, logUUID, err := msgio.FetchAttachment(ctx, rt, channel, attURL, t.MsgUUID, t.MsgID)
+				attachment, logUUID, err := msgio.FetchAttachment(ctx, rt, channel, attURL, t.MsgUUID)
 				if err != nil {
 					return fmt.Errorf("error fetching attachment '%s': %w", attURL, err)
 				}
@@ -121,10 +121,11 @@ func (t *MsgReceivedTask) perform(ctx context.Context, rt *runtime.Runtime, oa *
 
 	scene := runner.NewScene(mc, contact)
 	scene.IncomingMsg = &models.MsgInRef{
-		ID:          t.MsgID,
+		UUID:        t.MsgUUID,
 		ExtID:       t.MsgExternalID,
 		Attachments: attachments,
 		LogUUIDs:    logUUIDs,
+		ID:          t.MsgID, // deprecated
 	}
 	if err := scene.AddEvent(ctx, rt, oa, msgEvent, models.NilUserID); err != nil {
 		return fmt.Errorf("error adding message event to scene: %w", err)


### PR DESCRIPTION
Also stops sending msg ID in requests to courier to fetch attachments which requires https://github.com/nyaruka/courier/pull/941