### PR TITLE
Rework session interruption

### DIFF
--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -148,14 +148,14 @@ func (s *Scene) addSprint(ctx context.Context, rt *runtime.Runtime, oa *models.O
 }
 
 func (s *Scene) InterruptWaiting(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, status flows.SessionStatus) error {
-	return addInterruptEvents(ctx, rt, oa, []*Scene{s}, status)
+	return addInterruptEvents(ctx, rt, oa, []*Scene{s}, nil, status)
 }
 
 // StartSession starts a new session.
 func (s *Scene) StartSession(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, trigger flows.Trigger, interrupt bool) error {
 	// interrupting supported from here as a convenience
 	if interrupt {
-		if err := addInterruptEvents(ctx, rt, oa, []*Scene{s}, flows.SessionStatusInterrupted); err != nil {
+		if err := addInterruptEvents(ctx, rt, oa, []*Scene{s}, nil, flows.SessionStatusInterrupted); err != nil {
 			return fmt.Errorf("error interrupting existing session: %w", err)
 		}
 	}

--- a/core/runner/start.go
+++ b/core/runner/start.go
@@ -23,7 +23,7 @@ func StartWithLock(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 	defer unlock() // contacts are unlocked whatever happens
 
 	if interrupt {
-		if err := addInterruptEvents(ctx, rt, oa, scenes, flows.SessionStatusInterrupted); err != nil {
+		if err := addInterruptEvents(ctx, rt, oa, scenes, nil, flows.SessionStatusInterrupted); err != nil {
 			return nil, nil, fmt.Errorf("error interrupting existing sessions: %w", err)
 		}
 	}


### PR DESCRIPTION
So that...
 * It can differentiate between "interrupt whatever session is currently waiting" and "interrupt this specific session if it's still the waiting one"
 * It doesn't need to fetch contact when updating sessions (we probably won't update sessions when they move to DynamoDB)