### PR TITLE
Simplify getting the current session of the contact

### DIFF
--- a/core/ivr/ivr.go
+++ b/core/ivr/ivr.go
@@ -317,7 +317,7 @@ func ResumeCall(
 		return fmt.Errorf("error creating flow contact: %w", err)
 	}
 
-	session, err := models.GetWaitingSessionForContact(ctx, rt, oa, mc)
+	session, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	if err != nil {
 		return fmt.Errorf("error loading session for contact #%d and call #%d: %w", mc.ID(), call.ID(), err)
 	}

--- a/core/models/session_test.go
+++ b/core/models/session_test.go
@@ -100,7 +100,7 @@ func TestInsertSessions(t *testing.T) {
 		Columns(map[string]any{"status": "C", "session_type": "M", "current_flow_uuid": nil})
 }
 
-func TestGetWaitingSessionForContact(t *testing.T) {
+func TestGetContactWaitingSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
@@ -112,7 +112,7 @@ func TestGetWaitingSessionForContact(t *testing.T) {
 	oa := testdb.Org1.Load(t, rt)
 	mc, _, _ := testdb.Ann.Load(t, rt, oa)
 
-	session, err := models.GetWaitingSessionForContact(ctx, rt, oa, mc)
+	session, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	assert.NoError(t, err)
 	assert.NotNil(t, session)
 	assert.Equal(t, sessionUUID, session.UUID)

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -196,7 +196,7 @@ func TestSessionWithSubflows(t *testing.T) {
 	})
 
 	mc, contact, _ = testdb.Ann.Load(t, rt, oa)
-	modelSession, err := models.GetWaitingSessionForContact(ctx, rt, oa, mc)
+	modelSession, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	require.NoError(t, err)
 	assert.Equal(t, scene.Session.UUID(), modelSession.UUID)
 	assert.Equal(t, child.UUID, modelSession.CurrentFlowUUID)

--- a/core/tasks/ctasks/msg_received.go
+++ b/core/tasks/ctasks/msg_received.go
@@ -148,7 +148,7 @@ func (t *MsgReceived) handleMsgEvent(ctx context.Context, rt *runtime.Runtime, o
 	var err error
 
 	if scene.DBContact.CurrentSessionUUID() != "" {
-		session, err = models.GetWaitingSessionForContact(ctx, rt, oa, scene.DBContact)
+		session, err = models.GetContactWaitingSession(ctx, rt, oa, scene.DBContact)
 		if err != nil {
 			return fmt.Errorf("error loading waiting session for contact %s: %w", scene.ContactUUID(), err)
 		}

--- a/core/tasks/ctasks/wait_expired.go
+++ b/core/tasks/ctasks/wait_expired.go
@@ -44,7 +44,7 @@ func (t *WaitExpired) Perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 		return fmt.Errorf("error creating flow contact: %w", err)
 	}
 
-	session, err := models.GetWaitingSessionForContact(ctx, rt, oa, mc)
+	session, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	if err != nil {
 		return fmt.Errorf("error loading waiting session for contact #%d: %w", mc.ID(), err)
 	}

--- a/core/tasks/ctasks/wait_timeout.go
+++ b/core/tasks/ctasks/wait_timeout.go
@@ -45,7 +45,7 @@ func (t *WaitTimeout) Perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 		return fmt.Errorf("error creating flow contact: %w", err)
 	}
 
-	session, err := models.GetWaitingSessionForContact(ctx, rt, oa, mc)
+	session, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	if err != nil {
 		return fmt.Errorf("error loading waiting session for contact #%d: %w", mc.ID(), err)
 	}

--- a/testsuite/sessions.go
+++ b/testsuite/sessions.go
@@ -50,7 +50,7 @@ func ResumeSession(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets, cont
 
 	require.NotEqual(t, flows.SessionUUID(""), mc.CurrentSessionUUID(), "contact must have a waiting session")
 
-	modelSession, err := models.GetWaitingSessionForContact(ctx, rt, oa, mc)
+	modelSession, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	require.NoError(t, err)
 
 	scene := runner.NewScene(mc, fc)


### PR DESCRIPTION
And error if we find a contact with `current_session_uuid` set to something that no longer exists