### PR TITLE
Add optional contact_uuid filter to /msg/search endpoint

### DIFF
--- a/core/search/messages.go
+++ b/core/search/messages.go
@@ -45,11 +45,16 @@ type MessageResult struct {
 
 // SearchMessages searches the OpenSearch messages index for messages matching the given text in the given org,
 // then fetches the corresponding events from DynamoDB.
-func SearchMessages(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, text string) ([]MessageResult, int, error) {
+func SearchMessages(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, text string, contactUUID flows.ContactUUID) ([]MessageResult, int, error) {
 	routing := fmt.Sprintf("%d", orgID)
 
+	must := []elastic.Query{elastic.Term("_routing", routing), elastic.Match("text", text)}
+	if contactUUID != "" {
+		must = append(must, elastic.Term("contact_uuid", contactUUID))
+	}
+
 	src := map[string]any{
-		"query":            elastic.All(elastic.Term("_routing", routing), elastic.Match("text", text)),
+		"query":            elastic.All(must...),
 		"sort":             []any{"_score", map[string]string{"_id": "desc"}},
 		"size":             50,
 		"track_total_hits": true,

--- a/web/msg/search.go
+++ b/web/msg/search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/search"
 	"github.com/nyaruka/mailroom/runtime"
@@ -22,8 +23,9 @@ func init() {
 //	  "text": "hello"
 //	}
 type searchRequest struct {
-	OrgID models.OrgID `json:"org_id" validate:"required"`
-	Text  string       `json:"text"   validate:"required"`
+	OrgID       models.OrgID      `json:"org_id"        validate:"required"`
+	Text        string            `json:"text"          validate:"required"`
+	ContactUUID flows.ContactUUID `json:"contact_uuid"`
 }
 
 func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (any, int, error) {
@@ -36,7 +38,7 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		return nil, 0, fmt.Errorf("error loading org assets: %w", err)
 	}
 
-	results, total, err := search.SearchMessages(ctx, rt, r.OrgID, r.Text)
+	results, total, err := search.SearchMessages(ctx, rt, r.OrgID, r.Text, r.ContactUUID)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching messages: %w", err)
 	}

--- a/web/msg/testdata/search.json
+++ b/web/msg/testdata/search.json
@@ -107,5 +107,32 @@
             "results": [],
             "total": 0
         }
+    },
+    {
+        "label": "search filtered by contact uuid",
+        "method": "POST",
+        "path": "/mi/msg/search",
+        "body": {
+            "org_id": 1,
+            "text": "hello",
+            "contact_uuid": "b699a406-7e44-49be-9f01-1a82893e8a10"
+        },
+        "status": 200,
+        "response": {
+            "results": [
+                {
+                    "contact": {
+                        "uuid": "b699a406-7e44-49be-9f01-1a82893e8a10"
+                    },
+                    "event": {
+                        "created_on": "2025-05-01T13:00:00Z",
+                        "text": "hello there friend",
+                        "type": "msg_received",
+                        "uuid": "01968bee-b880-7000-8000-000000000002"
+                    }
+                }
+            ],
+            "total": 1
+        }
     }
 ]


### PR DESCRIPTION
## Summary

The `/msg/search` endpoint now accepts an optional `contact_uuid` parameter that filters search results to only messages from a specific contact. When provided, the OpenSearch query includes a term filter on the contact UUID field, allowing callers to search within a contact's message history while still matching text patterns.

## Changes

- Updated `SearchMessages()` to accept optional contact UUID parameter and conditionally add term filter to query
- Updated request struct to include optional `contact_uuid` field  
- Added test case verifying filter behavior

## Test plan

- Existing search tests continue to pass (text search without contact filter)
- New test case verifies that searching for "hello" filtered by a specific contact UUID returns only that contact's matching message