### PR TITLE
Exclude IVR messages from OpenSearch indexing

### DIFF
--- a/core/runner/handlers/msg_created.go
+++ b/core/runner/handlers/msg_created.go
@@ -59,8 +59,8 @@ func handleMsgCreated(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAs
 
 	scene.OutgoingMsgs = append(scene.OutgoingMsgs, msg)
 
-	// index message to OpenSearch if it's not from a broadcast or flow
-	if event.BroadcastUUID == "" && userID != models.NilUserID && len(event.Msg.Text()) >= search.MessageTextMinLength {
+	// index message to OpenSearch if it's not from a broadcast, flow, or IVR
+	if event.BroadcastUUID == "" && userID != models.NilUserID && scene.Call == nil && len(event.Msg.Text()) >= search.MessageTextMinLength {
 		scene.AttachPostCommitHook(hooks.IndexMessages, &search.MessageDoc{
 			CreatedOn:   event.CreatedOn(),
 			OrgID:       oa.OrgID(),

--- a/core/runner/handlers/msg_received.go
+++ b/core/runner/handlers/msg_received.go
@@ -28,8 +28,8 @@ func handleMsgReceived(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 		scene.AttachPreCommitHook(hooks.UpdateMessageHandled, event)
 	}
 
-	// index message to OpenSearch if it has sufficient text
-	if len(event.Msg.Text()) >= search.MessageTextMinLength {
+	// index message to OpenSearch if it's not IVR and has sufficient text
+	if scene.Call == nil && len(event.Msg.Text()) >= search.MessageTextMinLength {
 		scene.AttachPostCommitHook(hooks.IndexMessages, &search.MessageDoc{
 			CreatedOn:   event.CreatedOn(),
 			OrgID:       oa.OrgID(),


### PR DESCRIPTION
## Summary
- Exclude incoming and outgoing messages from being indexed to OpenSearch when they occur during an IVR call
- Added `scene.Call == nil` check in both `handleMsgReceived` and `handleMsgCreated` handlers

## Test plan
- Existing message indexing tests continue to pass (non-IVR scenarios)
- IVR messages will no longer be indexed to OpenSearch