### PR TITLE
Fix GetContactIDsPage passing NilContactID as NULL to SQL

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -393,7 +393,7 @@ const sqlSelectContactIDsPage = `SELECT id FROM contacts_contact WHERE org_id = 
 
 // GetContactIDsPage returns a page of contact IDs for the given org using cursor-based pagination.
 func GetContactIDsPage(ctx context.Context, db Queryer, orgID OrgID, afterID ContactID, limit int) ([]ContactID, error) {
-	return queryContactIDs(ctx, db, sqlSelectContactIDsPage, orgID, afterID, limit)
+	return queryContactIDs(ctx, db, sqlSelectContactIDsPage, orgID, int(afterID), limit)
 }
 
 type ContactURN struct {

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -419,6 +419,27 @@ func TestGetContactIDsFromReferences(t *testing.T) {
 	assert.ElementsMatch(t, []models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, ids)
 }
 
+func TestGetContactIDsPage(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	// first page should return contacts
+	ids, err := models.GetContactIDsPage(ctx, rt.DB, testdb.Org1.ID, models.NilContactID, 3)
+	require.NoError(t, err)
+	assert.Len(t, ids, 3)
+	assert.Contains(t, ids, testdb.Ann.ID)
+	assert.Contains(t, ids, testdb.Bob.ID)
+	assert.Contains(t, ids, testdb.Cat.ID)
+
+	// second page using last ID as cursor
+	ids2, err := models.GetContactIDsPage(ctx, rt.DB, testdb.Org1.ID, ids[len(ids)-1], 3)
+	require.NoError(t, err)
+
+	// should not overlap with first page
+	for _, id := range ids2 {
+		assert.NotContains(t, ids, id)
+	}
+}
+
 func TestUpdateContactLastSeenAndModifiedOn(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 


### PR DESCRIPTION
## Changes

- **core/models/contact.go**: Cast `afterID` parameter to `int` when calling `queryContactIDs()` to prevent `NilContactID` from being passed as NULL to the SQL query
- **core/models/contact_test.go**: Add `TestGetContactIDsPage()` test to verify cursor-based pagination works correctly and pages don't overlap

## Why

The `NilContactID` constant was being passed directly to the SQL query, which resulted in NULL being used instead of the proper integer value, breaking pagination logic.