### PR TITLE
Run contact search against both ES and OpenSearch, log mismatches

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -55,9 +55,10 @@ type Config struct {
 	ElasticPassword      string `help:"the password for ElasticSearch if using basic auth"`
 	ElasticContactsIndex string `help:"the name of index alias for contacts"`
 
-	OSEndpoint      string `name:"os_endpoint"       validate:"url" help:"the URL of your OpenSearch endpoint"`
-	OSMessagesIndex string `name:"os_messages_index"                help:"the base name for monthly message indexes (e.g. messages -> messages-2026-02)"`
-	OSContactsIndex string `name:"os_contacts_index"                help:"the name of the index for contacts (e.g. contacts)"`
+	OSEndpoint             string  `name:"os_endpoint"              validate:"url" help:"the URL of your OpenSearch endpoint"`
+	OSMessagesIndex        string  `name:"os_messages_index"                      help:"the base name for monthly message indexes (e.g. messages -> messages-2026-02)"`
+	OSContactsIndex        string  `name:"os_contacts_index"                      help:"the name of the index for contacts (e.g. contacts)"`
+	OSContactsSearchVerify float64 `name:"os_contacts_search_verify"              help:"proportion of contact searches to also run against OpenSearch for comparison (0.0 to 1.0)"`
 
 	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
 	AWSSecretAccessKey string `help:"secret access key to use for AWS services"`
@@ -123,9 +124,10 @@ func NewDefaultConfig() *Config {
 		ElasticPassword:      "",
 		ElasticContactsIndex: "contacts",
 
-		OSEndpoint:      "http://opensearch:9200",
-		OSMessagesIndex: "messages-v1",
-		OSContactsIndex: "contacts",
+		OSEndpoint:             "http://opensearch:9200",
+		OSMessagesIndex:        "messages-v1",
+		OSContactsIndex:        "contacts",
+		OSContactsSearchVerify: 0,
 
 		AWSAccessKeyID:     "",
 		AWSSecretAccessKey: "",

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -3,6 +3,7 @@ package contact
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/nyaruka/goflow/contactql"
@@ -68,10 +69,28 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		r.Limit = 50
 	}
 
-	// perform our search
+	// perform our search against ES (source of truth)
 	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, false)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
+	}
+
+	// also search OpenSearch and compare results
+	_, osHits, osTotal, osErr := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
+	if osErr != nil {
+		slog.Warn("error searching OpenSearch for comparison", "org_id", r.OrgID, "error", osErr)
+	} else if total != osTotal || !contactIDsEqual(hits, osHits) {
+		example := findMismatchExample(hits, osHits)
+		slog.Error("ES/OpenSearch search mismatch",
+			"org_id", r.OrgID,
+			"group_id", r.GroupID,
+			"query", r.Query,
+			"es_total", total,
+			"os_total", osTotal,
+			"es_page_count", len(hits),
+			"os_page_count", len(osHits),
+			"example_contact", example,
+		)
 	}
 
 	// normalize and inspect the query
@@ -92,4 +111,42 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 	}
 
 	return response, http.StatusOK, nil
+}
+
+// contactIDsEqual returns true if two slices contain the same contact IDs in the same order
+func contactIDsEqual(a, b []models.ContactID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// findMismatchExample returns a description of the first contact ID that differs between ES and OS results
+func findMismatchExample(esIDs, osIDs []models.ContactID) string {
+	osSet := make(map[models.ContactID]bool, len(osIDs))
+	for _, id := range osIDs {
+		osSet[id] = true
+	}
+	for _, id := range esIDs {
+		if !osSet[id] {
+			return fmt.Sprintf("contact %d in ES but not OS", id)
+		}
+	}
+
+	esSet := make(map[models.ContactID]bool, len(esIDs))
+	for _, id := range esIDs {
+		esSet[id] = true
+	}
+	for _, id := range osIDs {
+		if !esSet[id] {
+			return fmt.Sprintf("contact %d in OS but not ES", id)
+		}
+	}
+
+	return "same IDs but different order"
 }

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 
 	"github.com/nyaruka/goflow/contactql"
@@ -75,22 +76,24 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
 	}
 
-	// also search OpenSearch and compare results
-	_, osHits, osTotal, osErr := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
-	if osErr != nil {
-		slog.Warn("error searching OpenSearch for comparison", "org_id", r.OrgID, "error", osErr)
-	} else if total != osTotal || !contactIDsEqual(hits, osHits) {
-		example := findMismatchExample(hits, osHits)
-		slog.Error("ES/OpenSearch search mismatch",
-			"org_id", r.OrgID,
-			"group_id", r.GroupID,
-			"query", r.Query,
-			"es_total", total,
-			"os_total", osTotal,
-			"es_page_count", len(hits),
-			"os_page_count", len(osHits),
-			"example_contact", example,
-		)
+	// also search OpenSearch for a proportion of requests and compare results
+	if rt.Config.OSContactsSearchVerify > 0 && rand.Float64() < rt.Config.OSContactsSearchVerify {
+		_, osHits, osTotal, osErr := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
+		if osErr != nil {
+			slog.Warn("error searching OpenSearch for comparison", "org_id", r.OrgID, "error", osErr)
+		} else if total != osTotal || !contactIDsEqual(hits, osHits) {
+			example := findMismatchExample(hits, osHits)
+			slog.Error("ES/OpenSearch search mismatch",
+				"org_id", r.OrgID,
+				"group_id", r.GroupID,
+				"query", r.Query,
+				"es_total", total,
+				"os_total", osTotal,
+				"es_page_count", len(hits),
+				"os_page_count", len(osHits),
+				"example_contact", example,
+			)
+		}
 	}
 
 	// normalize and inspect the query


### PR DESCRIPTION
To validate the ES→OpenSearch migration, the /contact/search endpoint now queries both backends and logs an error when results differ, including an example contact that matched in one but not the other.