### PR TITLE
Add metrics for contact search duration by backend

### DIFF
--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -34,6 +34,11 @@ type Stats struct {
 
 	WebhookCallCount    int           // number of webhook calls
 	WebhookCallDuration time.Duration // total time spent handling webhook calls
+
+	ESContactSearchCount    int           // number of contact searches against Elasticsearch
+	ESContactSearchDuration time.Duration // total time spent searching Elasticsearch
+	OSContactSearchCount    int           // number of contact searches against OpenSearch
+	OSContactSearchDuration time.Duration // total time spent searching OpenSearch
 }
 
 func newStats() *Stats {
@@ -84,6 +89,22 @@ func (s *Stats) ToMetrics(advanced bool) []types.MetricDatum {
 	metrics = append(metrics,
 		cwatch.Datum("WebhookCallCount", float64(s.WebhookCallCount), types.StandardUnitCount),
 		cwatch.Datum("WebhookCallDuration", float64(avgWebhookDuration)/float64(time.Second), types.StandardUnitSeconds),
+	)
+
+	var avgESSearchDuration time.Duration
+	if s.ESContactSearchCount > 0 {
+		avgESSearchDuration = s.ESContactSearchDuration / time.Duration(s.ESContactSearchCount)
+	}
+	var avgOSSearchDuration time.Duration
+	if s.OSContactSearchCount > 0 {
+		avgOSSearchDuration = s.OSContactSearchDuration / time.Duration(s.OSContactSearchCount)
+	}
+
+	metrics = append(metrics,
+		cwatch.Datum("ContactSearchCount", float64(s.ESContactSearchCount), types.StandardUnitCount, cwatch.Dimension("Backend", "es")),
+		cwatch.Datum("ContactSearchDuration", float64(avgESSearchDuration)/float64(time.Second), types.StandardUnitSeconds, cwatch.Dimension("Backend", "es")),
+		cwatch.Datum("ContactSearchCount", float64(s.OSContactSearchCount), types.StandardUnitCount, cwatch.Dimension("Backend", "os")),
+		cwatch.Datum("ContactSearchDuration", float64(avgOSSearchDuration)/float64(time.Second), types.StandardUnitSeconds, cwatch.Dimension("Backend", "os")),
 	)
 
 	if advanced {
@@ -146,6 +167,18 @@ func (c *StatsCollector) RecordWebhookCall(d time.Duration) {
 	c.mutex.Lock()
 	c.stats.WebhookCallCount++
 	c.stats.WebhookCallDuration += d
+	c.mutex.Unlock()
+}
+
+func (c *StatsCollector) RecordContactSearch(backend string, d time.Duration) {
+	c.mutex.Lock()
+	if backend == "os" {
+		c.stats.OSContactSearchCount++
+		c.stats.OSContactSearchDuration += d
+	} else {
+		c.stats.ESContactSearchCount++
+		c.stats.ESContactSearchDuration += d
+	}
 	c.mutex.Unlock()
 }
 

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -25,6 +25,9 @@ func TestStats(t *testing.T) {
 	sc.RecordLLMCall("openai", "gpt-4", 7*time.Second)
 	sc.RecordLLMCall("openai", "gpt-4", 3*time.Second)
 	sc.RecordLLMCall("anthropic", "claude-3.7", 4*time.Second)
+	sc.RecordContactSearch("es", 100*time.Millisecond)
+	sc.RecordContactSearch("es", 200*time.Millisecond)
+	sc.RecordContactSearch("os", 150*time.Millisecond)
 
 	stats := sc.Extract()
 	assert.Equal(t, 2, stats.CronTaskCount["make_foos"])
@@ -33,12 +36,16 @@ func TestStats(t *testing.T) {
 	assert.Equal(t, 10*time.Second, stats.LLMCallDuration[runtime.LLMTypeAndModel{Type: "openai", Model: "gpt-4"}])
 	assert.Equal(t, 1, stats.LLMCallCount[runtime.LLMTypeAndModel{Type: "anthropic", Model: "claude-3.7"}])
 	assert.Equal(t, 4*time.Second, stats.LLMCallDuration[runtime.LLMTypeAndModel{Type: "anthropic", Model: "claude-3.7"}])
+	assert.Equal(t, 2, stats.ESContactSearchCount)
+	assert.Equal(t, 300*time.Millisecond, stats.ESContactSearchDuration)
+	assert.Equal(t, 1, stats.OSContactSearchCount)
+	assert.Equal(t, 150*time.Millisecond, stats.OSContactSearchDuration)
 
 	datums := stats.ToMetrics(true)
-	assert.Len(t, datums, 9)
+	assert.Len(t, datums, 13)
 
 	datums = stats.ToMetrics(false)
-	assert.Len(t, datums, 6)
+	assert.Len(t, datums, 10)
 
 	// no latencies recorded yet
 	latencies, err := runtime.GetCTaskLatencies(rt.VK)

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/core/models"
@@ -71,14 +72,19 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 	}
 
 	// perform our search against ES (source of truth)
+	esStart := time.Now()
 	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, false)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
 	}
+	rt.Stats.RecordContactSearch("es", time.Since(esStart))
 
 	// also search OpenSearch for a proportion of requests and compare results
 	if rt.Config.OSContactsSearchVerify > 0 && rand.Float64() < rt.Config.OSContactsSearchVerify {
+		osStart := time.Now()
 		_, osHits, osTotal, osErr := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
+		rt.Stats.RecordContactSearch("os", time.Since(osStart))
+
 		if osErr != nil {
 			slog.Warn("error searching OpenSearch for comparison", "org_id", r.OrgID, "error", osErr)
 		} else if total != osTotal || !contactIDsEqual(hits, osHits) {


### PR DESCRIPTION
## Summary
- Add CloudWatch metrics (`ContactSearchCount`, `ContactSearchDuration`) with a `Backend` dimension (`es`/`os`) to track average search times for Elasticsearch and OpenSearch
- Instrument the `/contact/search` endpoint to record timing for both ES and OS search calls

## Test plan
- [x] `runtime/stats_test.go` updated with assertions for new metrics
- [ ] Verify metrics appear in CloudWatch after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)