### PR TITLE
Fix PIT leak on error and enforce limit in paginated contact search

### DIFF
--- a/core/search/search.go
+++ b/core/search/search.go
@@ -270,7 +270,9 @@ func getContactIDsForQueryES(ctx context.Context, rt *runtime.Runtime, oa *model
 		return nil, fmt.Errorf("error creating ES point-in-time: %w", err)
 	}
 	defer func() {
-		if _, err := rt.ES.ClosePointInTime().Id(pit.Id).Do(ctx); err != nil {
+		cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := rt.ES.ClosePointInTime().Id(pit.Id).Do(cctx); err != nil {
 			slog.Error("error closing ES point-in-time", "error", err)
 		}
 	}()
@@ -350,7 +352,9 @@ func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *model
 		return nil, fmt.Errorf("error creating OS point-in-time: %w", err)
 	}
 	defer func() {
-		if _, err := rt.OS.Client.PointInTime.Delete(ctx, opensearchapi.PointInTimeDeleteReq{
+		cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := rt.OS.Client.PointInTime.Delete(cctx, opensearchapi.PointInTimeDeleteReq{
 			PitID: []string{pit.PitID},
 		}); err != nil {
 			slog.Error("error closing OS point-in-time", "error", err)

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -269,6 +269,11 @@ func getContactIDsForQueryES(ctx context.Context, rt *runtime.Runtime, oa *model
 	if err != nil {
 		return nil, fmt.Errorf("error creating ES point-in-time: %w", err)
 	}
+	defer func() {
+		if _, err := rt.ES.ClosePointInTime().Id(pit.Id).Do(ctx); err != nil {
+			slog.Error("error closing ES point-in-time", "error", err)
+		}
+	}()
 
 	src := map[string]any{
 		"_source":          false,
@@ -291,12 +296,18 @@ func getContactIDsForQueryES(ctx context.Context, rt *runtime.Runtime, oa *model
 
 		ids = appendIDsFromESHits(ids, results.Hits.Hits)
 
+		if limit != -1 && len(ids) >= limit {
+			ids = ids[:limit]
+			break
+		}
+		if limit != -1 {
+			if remaining := limit - len(ids); remaining < 10_000 {
+				src["size"] = remaining
+			}
+		}
+
 		lastHit := results.Hits.Hits[len(results.Hits.Hits)-1]
 		src["search_after"] = lastHit.Sort
-	}
-
-	if _, err := rt.ES.ClosePointInTime().Id(pit.Id).Do(ctx); err != nil {
-		return nil, fmt.Errorf("error closing ES point-in-time: %w", err)
 	}
 
 	return ids, nil
@@ -338,6 +349,13 @@ func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *model
 	if err != nil {
 		return nil, fmt.Errorf("error creating OS point-in-time: %w", err)
 	}
+	defer func() {
+		if _, err := rt.OS.Client.PointInTime.Delete(ctx, opensearchapi.PointInTimeDeleteReq{
+			PitID: []string{pit.PitID},
+		}); err != nil {
+			slog.Error("error closing OS point-in-time", "error", err)
+		}
+	}()
 
 	src := map[string]any{
 		"_source":          []string{"db_id"},
@@ -362,14 +380,18 @@ func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *model
 
 		ids = appendIDsFromOSHits(ids, resp.Hits.Hits)
 
+		if limit != -1 && len(ids) >= limit {
+			ids = ids[:limit]
+			break
+		}
+		if limit != -1 {
+			if remaining := limit - len(ids); remaining < 10_000 {
+				src["size"] = remaining
+			}
+		}
+
 		lastHit := resp.Hits.Hits[len(resp.Hits.Hits)-1]
 		src["search_after"] = lastHit.Sort
-	}
-
-	if _, err := rt.OS.Client.PointInTime.Delete(ctx, opensearchapi.PointInTimeDeleteReq{
-		PitID: []string{pit.PitID},
-	}); err != nil {
-		return nil, fmt.Errorf("error closing OS point-in-time: %w", err)
 	}
 
 	return ids, nil


### PR DESCRIPTION
## Summary
- Close PIT via `defer` immediately after creation in both `getContactIDsForQueryES` and `getContactIDsForQueryOS`, so it's cleaned up on all return paths (including search errors in the pagination loop). Errors from the deferred close are logged rather than returned since the search results are still valid.
- Enforce the `limit` argument in PIT pagination loops by breaking early when `len(ids) >= limit` and adjusting the page size for the final request. Previously, callers requesting e.g. 20k contacts would receive all matches instead of being capped.

## Test plan
- [x] `go test ./core/search/...` passes (existing test creates 10,003 contacts to exercise PIT pagination)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)