### PR TITLE
Use filter context instead of must in contact search

### DIFF
--- a/core/search/search.go
+++ b/core/search/search.go
@@ -45,7 +45,7 @@ func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 }
 
 func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, os bool) elastic.Query {
-	// use filter context for all clauses since we sort by id, not relevance score, and filter clauses
+	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
 	filter := []elastic.Query{
 		elastic.Term("org_id", oa.OrgID()),

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -45,30 +45,33 @@ func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 }
 
 func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, os bool) elastic.Query {
-	must := []elastic.Query{
+	// use filter context for all clauses since we sort by id, not relevance score, and filter clauses
+	// are cacheable and skip scoring
+	filter := []elastic.Query{
 		elastic.Term("org_id", oa.OrgID()),
 	}
 
 	// Elastic has is_active field, OpenSearch only indexes active contacts
 	if !os {
-		must = append(must, elastic.Term("is_active", true))
+		filter = append(filter, elastic.Term("is_active", true))
 	}
 
 	if group != nil {
-		must = append(must, elastic.Term("group_ids", group.ID()))
+		filter = append(filter, elastic.Term("group_ids", group.ID()))
 	}
 
 	if status != models.NilContactStatus {
-		must = append(must, elastic.Term("status", status))
+		filter = append(filter, elastic.Term("status", status))
 	}
 
 	if query != nil {
-		must = append(must, es.ToElasticQuery(oa.Env(), assetMapper, query))
+		filter = append(filter, es.ToElasticQuery(oa.Env(), assetMapper, query))
 	}
 
-	not := []elastic.Query{}
+	bq := map[string]any{"filter": filter}
 
 	if len(excludeIDs) > 0 {
+		not := []elastic.Query{}
 		if os {
 			// OpenSearch uses db_id for the database contact ID
 			ids := make([]int64, len(excludeIDs))
@@ -84,9 +87,10 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 			}
 			not = append(not, elastic.Ids(ids...))
 		}
+		bq["must_not"] = not
 	}
 
-	return elastic.Bool(must, not)
+	return elastic.Query{"bool": bq}
 }
 
 // GetContactTotal returns the total count of matching contacts for the given query


### PR DESCRIPTION
## Changes

- Refactor `buildContactQuery()` to use filter context instead of must clauses for all search conditions
- Filter clauses are cacheable and skip scoring, which is more efficient since results are sorted by ID, not relevance score
- Move exclude IDs logic into conditional block to only construct `must_not` when needed
- Update query construction to use explicit bool query map structure

## Benefits

- Improved query performance through filter clause caching
- Eliminated unnecessary scoring calculations
- Cleaner conditional logic for exclude IDs handling