### PR TITLE
Use database ID as _id in OpenSearch contacts index

### DIFF
--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -40,10 +40,10 @@ type ContactDocURN struct {
 	Path   string `json:"path"`
 }
 
-// ContactDoc represents a contact document in the OpenSearch contacts index. UUID is used as the document _id.
+// ContactDoc represents a contact document in the OpenSearch contacts index. DBID is used as the document _id.
 type ContactDoc struct {
-	UUID           flows.ContactUUID    `json:"-"` // used as _id
-	DBID           models.ContactID     `json:"db_id"`
+	DBID           models.ContactID     `json:"db_id"` // also used as _id
+	UUID           flows.ContactUUID    `json:"uuid"`
 	OrgID          models.OrgID         `json:"org_id"`
 	Name           string               `json:"name,omitempty"`
 	Status         models.ContactStatus `json:"status"`
@@ -163,7 +163,7 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 
 		rt.OS.Writer.Queue(&osearch.Document{
 			Index:   rt.Config.OSContactsIndex,
-			ID:      string(doc.UUID),
+			ID:      doc.DBID.String(),
 			Routing: doc.OrgID.String(),
 			Version: dates.Now().UnixNano(),
 			Body:    body,

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -42,7 +42,7 @@ type ContactDocURN struct {
 
 // ContactDoc represents a contact document in the OpenSearch contacts index. DBID is used as the document _id.
 type ContactDoc struct {
-	DBID           models.ContactID     `json:"db_id"` // also used as _id
+	DBID           models.ContactID     `json:"id"` // also used as _id
 	UUID           flows.ContactUUID    `json:"uuid"`
 	OrgID          models.OrgID         `json:"org_id"`
 	Name           string               `json:"name,omitempty"`

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -3,7 +3,6 @@ package search
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -155,7 +154,6 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	if os {
 		src := map[string]any{
 			"_source":          false,
-			"docvalue_fields":  []string{"db_id"},
 			"query":            eq,
 			"sort":             []any{fieldSort},
 			"from":             offset,
@@ -309,14 +307,13 @@ func getContactIDsForQueryES(ctx context.Context, rt *runtime.Runtime, oa *model
 func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, eq elastic.Query, limit int) ([]models.ContactID, error) {
 	index := rt.Config.OSContactsIndex
 	routing := oa.OrgID().String()
-	sort := elastic.SortBy("db_id", true)
+	sort := elastic.SortBy("id", true)
 	ids := make([]models.ContactID, 0, 100)
 
 	// if limit provided that can be done with single search, do that
 	if limit >= 0 && limit <= 10_000 {
 		src := map[string]any{
 			"_source":          false,
-			"docvalue_fields":  []string{"db_id"},
 			"query":            eq,
 			"sort":             []any{sort},
 			"from":             0,
@@ -355,7 +352,6 @@ func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *model
 
 	src := map[string]any{
 		"_source":          false,
-		"docvalue_fields":  []string{"db_id"},
 		"query":            eq,
 		"sort":             []any{sort},
 		"pit":              map[string]any{"id": pit.PitID, "keep_alive": "1m"},
@@ -405,14 +401,12 @@ func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.Cont
 	return ids
 }
 
-// appendIDsFromOSHits extracts contact IDs from OpenSearch hits using the db_id docvalue field
+// appendIDsFromOSHits extracts contact IDs from OpenSearch hits where _id is the database contact ID
 func appendIDsFromOSHits(ids []models.ContactID, hits []opensearchapi.SearchHit) []models.ContactID {
 	for _, hit := range hits {
-		var fields struct {
-			DBID []models.ContactID `json:"db_id"`
-		}
-		if err := json.Unmarshal(hit.Fields, &fields); err == nil && len(fields.DBID) > 0 {
-			ids = append(ids, fields.DBID[0])
+		id, err := strconv.Atoi(hit.ID)
+		if err == nil {
+			ids = append(ids, models.ContactID(id))
 		}
 	}
 	return ids

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -3,7 +3,6 @@ package search
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -71,23 +70,11 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 	bq := map[string]any{"filter": filter}
 
 	if len(excludeIDs) > 0 {
-		not := []elastic.Query{}
-		if os {
-			// OpenSearch uses db_id for the database contact ID
-			ids := make([]int64, len(excludeIDs))
-			for i := range excludeIDs {
-				ids[i] = int64(excludeIDs[i])
-			}
-			not = append(not, elastic.Query{"terms": map[string]any{"db_id": ids}})
-		} else {
-			// Elastic uses _id for the database contact ID
-			ids := make([]string, len(excludeIDs))
-			for i := range excludeIDs {
-				ids[i] = fmt.Sprintf("%d", excludeIDs[i])
-			}
-			not = append(not, elastic.Ids(ids...))
+		ids := make([]string, len(excludeIDs))
+		for i := range excludeIDs {
+			ids[i] = fmt.Sprintf("%d", excludeIDs[i])
 		}
-		bq["must_not"] = not
+		bq["must_not"] = []elastic.Query{elastic.Ids(ids...)}
 	}
 
 	return elastic.Query{"bool": bq}
@@ -165,10 +152,8 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	}
 
 	if os {
-		fieldSort = adaptSortForOS(fieldSort)
-
 		src := map[string]any{
-			"_source":          []string{"db_id"},
+			"_source":          false,
 			"query":            eq,
 			"sort":             []any{fieldSort},
 			"from":             offset,
@@ -328,7 +313,7 @@ func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *model
 	// if limit provided that can be done with single search, do that
 	if limit >= 0 && limit <= 10_000 {
 		src := map[string]any{
-			"_source":          []string{"db_id"},
+			"_source":          false,
 			"query":            eq,
 			"sort":             []any{sort},
 			"from":             0,
@@ -366,7 +351,7 @@ func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *model
 	}()
 
 	src := map[string]any{
-		"_source":          []string{"db_id"},
+		"_source":          false,
 		"query":            eq,
 		"sort":             []any{sort},
 		"pit":              map[string]any{"id": pit.PitID, "keep_alive": "1m"},
@@ -416,28 +401,13 @@ func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.Cont
 	return ids
 }
 
-// appendIDsFromOSHits extracts contact IDs from OpenSearch hits using the db_id source field
+// appendIDsFromOSHits extracts contact IDs from OpenSearch hits where _id is the database contact ID
 func appendIDsFromOSHits(ids []models.ContactID, hits []opensearchapi.SearchHit) []models.ContactID {
 	for _, hit := range hits {
-		var doc struct {
-			DBID models.ContactID `json:"db_id"`
-		}
-		if err := json.Unmarshal(hit.Source, &doc); err == nil && doc.DBID != models.NilContactID {
-			ids = append(ids, doc.DBID)
+		id, err := strconv.Atoi(hit.ID)
+		if err == nil {
+			ids = append(ids, models.ContactID(id))
 		}
 	}
 	return ids
-}
-
-// adaptSortForOS replaces "id" with "db_id" in sort specs for OpenSearch
-func adaptSortForOS(s elastic.Sort) elastic.Sort {
-	adapted := make(elastic.Sort, len(s))
-	for k, v := range s {
-		if k == "id" {
-			adapted["db_id"] = v
-		} else {
-			adapted[k] = v
-		}
-	}
-	return adapted
 }

--- a/testsuite/testdata/os_contacts.json
+++ b/testsuite/testdata/os_contacts.json
@@ -69,12 +69,16 @@
         }
     },
     "mappings": {
+        "dynamic": "strict",
         "_routing": {
             "required": true
         },
         "properties": {
             "db_id": {
-                "type": "long"
+                "type": "integer"
+            },
+            "uuid": {
+                "type": "keyword"
             },
             "org_id": {
                 "type": "integer"

--- a/testsuite/testdata/os_contacts.json
+++ b/testsuite/testdata/os_contacts.json
@@ -74,8 +74,8 @@
             "required": true
         },
         "properties": {
-            "db_id": {
-                "type": "integer"
+            "id": {
+                "type": "long"
             },
             "uuid": {
                 "type": "keyword"


### PR DESCRIPTION
## Changes

- Changed OpenSearch contacts index to use database ID (DBID) as the document `_id` instead of UUID
- Updated `ContactDoc` struct to mark DBID as the document ID and UUID as a stored field
- Simplified contact ID extraction from search results by reading `_id` field directly instead of parsing source documents
- Removed `adaptSortForOS()` function and related OpenSearch-specific sorting logic
- Updated index mapping to store UUID as keyword field instead of db_id
- Unified the contact ID query logic between Elasticsearch and OpenSearch implementations

## Benefits

- Simplifies ID handling across both search engines
- Reduces document parsing overhead
- Aligns OpenSearch document structure with Elasticsearch conventions