### PR TITLE
Deindex contacts from OpenSearch as well as Elastic

### DIFF
--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/shopspring/decimal"
 )
 
@@ -173,27 +174,46 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 	return nil
 }
 
-// DeindexContactsByID de-indexes the contacts with the given IDs from Elastic
-func DeindexContactsByID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactIDs []models.ContactID) (int, error) {
+// DeindexContactsByID de-indexes the contacts with the given IDs from Elastic and OpenSearch
+func DeindexContactsByID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactIDs []models.ContactID) (int, int, error) {
 	cmds := &bytes.Buffer{}
 	for _, id := range contactIDs {
 		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": id.String()}}))
 		cmds.WriteString("\n")
 	}
+	body := cmds.Bytes()
 
-	resp, err := rt.ES.Bulk().Index(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(cmds.Bytes())).Do(ctx)
+	resp, err := rt.ES.Bulk().Index(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(body)).Do(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("error deindexing deleted contacts from elastic: %w", err)
+		return 0, 0, fmt.Errorf("error deindexing deleted contacts from elastic: %w", err)
 	}
 
-	deleted := 0
+	esDeleted := 0
 	for _, r := range resp.Items {
 		if r[operationtype.Delete].Status == 200 {
-			deleted++
+			esDeleted++
 		}
 	}
 
-	return deleted, nil
+	osResp, err := rt.OS.Client.Bulk(ctx, opensearchapi.BulkReq{
+		Index: rt.Config.OSContactsIndex,
+		Body:  bytes.NewReader(body),
+		Params: opensearchapi.BulkParams{
+			Routing: orgID.String(),
+		},
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("error deindexing deleted contacts from opensearch: %w", err)
+	}
+
+	osDeleted := 0
+	for _, item := range osResp.Items {
+		if d, ok := item["delete"]; ok && d.Status == 200 {
+			osDeleted++
+		}
+	}
+
+	return esDeleted, osDeleted, nil
 }
 
 // DeindexContactsByOrg de-indexes all contacts in the given org from Elastic

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -132,16 +132,17 @@ func TestDeindexContacts(t *testing.T) {
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
-	deindexed, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
+	esDeindexed, osDeindexed, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, deindexed)
+	assert.Equal(t, 2, esDeindexed)
+	assert.Equal(t, 0, osDeindexed)
 
 	refreshElastic()
 
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 122)
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
-	deindexed, err = search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
+	deindexed, err := search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 100, deindexed)
 

--- a/web/contact/deindex.go
+++ b/web/contact/deindex.go
@@ -24,12 +24,12 @@ func init() {
 //	}
 type deindexRequest struct {
 	OrgID        models.OrgID        `json:"org_id"        validate:"required"`
-	ContactUUIDs []flows.ContactUUID `json:"contact_uuids" validate:"required"`
-	ContactIDs   []models.ContactID  `json:"contact_ids"   validate:"required"` // still needed for Elastic
+	ContactIDs   []models.ContactID  `json:"contact_ids"   validate:"required"`
+	ContactUUIDs []flows.ContactUUID `json:"contact_uuids" validate:"required"` // needed for message de-indexing
 }
 
 func handleDeindex(ctx context.Context, rt *runtime.Runtime, r *deindexRequest) (any, int, error) {
-	deindexed, err := search.DeindexContactsByID(ctx, rt, r.OrgID, r.ContactIDs)
+	esDeleted, osDeleted, err := search.DeindexContactsByID(ctx, rt, r.OrgID, r.ContactIDs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error de-indexing contacts in org #%d: %w", r.OrgID, err)
 	}
@@ -38,5 +38,5 @@ func handleDeindex(ctx context.Context, rt *runtime.Runtime, r *deindexRequest) 
 		return nil, 0, fmt.Errorf("error de-indexing messages in org #%d: %w", r.OrgID, err)
 	}
 
-	return map[string]any{"deindexed": deindexed}, http.StatusOK, nil
+	return map[string]any{"es_deindexed": esDeleted, "os_deindexed": osDeleted}, http.StatusOK, nil
 }

--- a/web/contact/testdata/deindex.json
+++ b/web/contact/testdata/deindex.json
@@ -25,7 +25,8 @@
         },
         "status": 200,
         "response": {
-            "deindexed": 2
+            "es_deindexed": 2,
+            "os_deindexed": 0
         }
     }
 ]


### PR DESCRIPTION
## Summary
- `DeindexContactsByID` now performs a bulk delete against the OS contacts index in addition to ES
- Returns separate counts for ES and OS deletions (`es_deindexed`, `os_deindexed`)
- Updated web handler response and test fixtures to reflect the new return values

## Test plan
- [x] `TestDeindexContacts` passes
- [x] `TestDeindex` (web handler) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)