### PR TITLE
Add urn_added and urn_removed contact tasks

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -896,61 +896,26 @@ func CreateOrClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID C
 	return urn, nil
 }
 
-// ClaimURN claims the given URN for the given contact, stealing it from any other contact if necessary.
-// Returns the ID of the previous owner if the URN was stolen, or NilContactID.
-func ClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (ContactID, error) {
-	// look for an existing URN with this identity
-	var existingID URNID
-	var existingContactID ContactID
+// ClaimURN creates the given URN for the given contact, or claims it if it exists but is orphaned.
+// Returns true if the URN was created or claimed, false if it already belongs to another contact.
+func ClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (bool, error) {
+	urn := &ContactURN{
+		OrgID:     oa.OrgID(),
+		ContactID: contactID,
+		Scheme:    u.Scheme(),
+		Identity:  u.Identity(),
+		Path:      u.Path(),
+		Display:   null.String(u.Display()),
+		Priority:  defaultURNPriority,
+	}
 
-	rows, err := db.QueryContext(ctx, `SELECT id, COALESCE(contact_id, 0) FROM contacts_contacturn WHERE identity = $1 AND org_id = $2`, u.Identity(), oa.OrgID())
+	res, err := db.NamedExecContext(ctx, sqlInsertContactURN, urn)
 	if err != nil {
-		return NilContactID, fmt.Errorf("error looking up URN: %w", err)
-	}
-	defer rows.Close()
-
-	found := rows.Next()
-	if found {
-		if err := rows.Scan(&existingID, &existingContactID); err != nil {
-			return NilContactID, fmt.Errorf("error scanning URN: %w", err)
-		}
-	}
-	rows.Close()
-
-	if !found {
-		// URN doesn't exist, create it
-		urn := &ContactURN{
-			OrgID:     oa.OrgID(),
-			ContactID: contactID,
-			Scheme:    u.Scheme(),
-			Identity:  u.Identity(),
-			Path:      u.Path(),
-			Display:   null.String(u.Display()),
-			Priority:  defaultURNPriority,
-		}
-		if _, err := db.NamedExecContext(ctx, sqlInsertContactURN, urn); err != nil {
-			return NilContactID, fmt.Errorf("error inserting new urn: %s: %w", u, err)
-		}
-		return NilContactID, nil
+		return false, fmt.Errorf("error claiming urn: %s: %w", u, err)
 	}
 
-	// already owned by this contact
-	if existingContactID == contactID {
-		return NilContactID, nil
-	}
-
-	oldOwnerID := existingContactID
-
-	// reassign to this contact (works for both orphaned and stealing)
-	_, err = db.ExecContext(ctx,
-		`UPDATE contacts_contacturn SET contact_id = $1 WHERE id = $2`,
-		contactID, existingID,
-	)
-	if err != nil {
-		return NilContactID, fmt.Errorf("error claiming urn: %w", err)
-	}
-
-	return oldOwnerID, nil
+	rows, _ := res.RowsAffected()
+	return rows > 0, nil
 }
 
 // DetachContactURN detaches a specific URN from a contact by setting contact_id to NULL.

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -896,6 +896,75 @@ func CreateOrClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID C
 	return urn, nil
 }
 
+// ClaimURN claims the given URN for the given contact, stealing it from any other contact if necessary.
+// Returns the ID of the previous owner if the URN was stolen, or NilContactID.
+func ClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (ContactID, error) {
+	// look for an existing URN with this identity
+	var existingID URNID
+	var existingContactID ContactID
+
+	rows, err := db.QueryContext(ctx, `SELECT id, COALESCE(contact_id, 0) FROM contacts_contacturn WHERE identity = $1 AND org_id = $2`, u.Identity(), oa.OrgID())
+	if err != nil {
+		return NilContactID, fmt.Errorf("error looking up URN: %w", err)
+	}
+	defer rows.Close()
+
+	found := rows.Next()
+	if found {
+		if err := rows.Scan(&existingID, &existingContactID); err != nil {
+			return NilContactID, fmt.Errorf("error scanning URN: %w", err)
+		}
+	}
+	rows.Close()
+
+	if !found {
+		// URN doesn't exist, create it
+		urn := &ContactURN{
+			OrgID:     oa.OrgID(),
+			ContactID: contactID,
+			Scheme:    u.Scheme(),
+			Identity:  u.Identity(),
+			Path:      u.Path(),
+			Display:   null.String(u.Display()),
+			Priority:  defaultURNPriority,
+		}
+		if _, err := db.NamedExecContext(ctx, sqlInsertContactURN, urn); err != nil {
+			return NilContactID, fmt.Errorf("error inserting new urn: %s: %w", u, err)
+		}
+		return NilContactID, nil
+	}
+
+	// already owned by this contact
+	if existingContactID == contactID {
+		return NilContactID, nil
+	}
+
+	oldOwnerID := existingContactID
+
+	// reassign to this contact (works for both orphaned and stealing)
+	_, err = db.ExecContext(ctx,
+		`UPDATE contacts_contacturn SET contact_id = $1 WHERE id = $2`,
+		contactID, existingID,
+	)
+	if err != nil {
+		return NilContactID, fmt.Errorf("error claiming urn: %w", err)
+	}
+
+	return oldOwnerID, nil
+}
+
+// DetachContactURN detaches a specific URN from a contact by setting contact_id to NULL.
+func DetachContactURN(ctx context.Context, db DBorTx, orgID OrgID, contactID ContactID, urnIdentity urns.URN) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE contacts_contacturn SET contact_id = NULL WHERE contact_id = $1 AND identity = $2 AND org_id = $3`,
+		contactID, urnIdentity, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("error detaching urn: %w", err)
+	}
+	return nil
+}
+
 // CalculateDynamicGroups recalculates all the dynamic groups for the passed in contact, recalculating
 // campaigns as necessary based on those group changes.
 func CalculateDynamicGroups(ctx context.Context, db DBorTx, oa *OrgAssets, contacts []*flows.Contact) error {

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -919,10 +919,10 @@ func ClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID
 }
 
 // DetachContactURN detaches a specific URN from a contact by setting contact_id to NULL.
-func DetachContactURN(ctx context.Context, db DBorTx, orgID OrgID, contactID ContactID, urnIdentity urns.URN) error {
+func DetachContactURN(ctx context.Context, db DBorTx, orgID OrgID, contactID ContactID, identity urns.URN) error {
 	_, err := db.ExecContext(ctx,
 		`UPDATE contacts_contacturn SET contact_id = NULL WHERE contact_id = $1 AND identity = $2 AND org_id = $3`,
-		contactID, urnIdentity, orgID,
+		contactID, identity, orgID,
 	)
 	if err != nil {
 		return fmt.Errorf("error detaching urn: %w", err)

--- a/core/tasks/ctasks/reindex.go
+++ b/core/tasks/ctasks/reindex.go
@@ -1,0 +1,31 @@
+package ctasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/search"
+	"github.com/nyaruka/mailroom/runtime"
+)
+
+func reindexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contactIDs []models.ContactID) error {
+	contacts, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
+	if err != nil {
+		return fmt.Errorf("error loading contacts for reindex: %w", err)
+	}
+
+	flowContacts := make([]*flows.Contact, 0, len(contacts))
+	currentFlows := make(map[models.ContactID]models.FlowID, len(contacts))
+	for _, c := range contacts {
+		fc, err := c.EngineContact(oa)
+		if err != nil {
+			return fmt.Errorf("error creating engine contact: %w", err)
+		}
+		flowContacts = append(flowContacts, fc)
+		currentFlows[c.ID()] = c.CurrentFlowID()
+	}
+
+	return search.IndexContacts(ctx, rt, oa, flowContacts, currentFlows)
+}

--- a/core/tasks/ctasks/urn_added.go
+++ b/core/tasks/ctasks/urn_added.go
@@ -1,0 +1,76 @@
+package ctasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/search"
+	"github.com/nyaruka/mailroom/runtime"
+)
+
+const TypeURNAdded = "urn_added"
+
+func init() {
+	RegisterType(TypeURNAdded, func() Task { return &URNAdded{} })
+}
+
+type URNAdded struct {
+	URN urns.URN `json:"urn"`
+}
+
+func (t *URNAdded) Type() string {
+	return TypeURNAdded
+}
+
+func (t *URNAdded) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact) error {
+	urn := t.URN.Normalize()
+
+	// if contact already has this URN, nothing to do
+	if mc.FindURN(urn) != nil {
+		return nil
+	}
+
+	oldOwnerID, err := models.ClaimURN(ctx, rt.DB, oa, mc.ID(), urn)
+	if err != nil {
+		return fmt.Errorf("error claiming urn: %w", err)
+	}
+
+	// update modified_on for affected contacts
+	contactIDs := []models.ContactID{mc.ID()}
+	if oldOwnerID != models.NilContactID {
+		contactIDs = append(contactIDs, oldOwnerID)
+	}
+
+	if err := models.UpdateContactModifiedOn(ctx, rt.DB, contactIDs); err != nil {
+		return fmt.Errorf("error updating modified_on: %w", err)
+	}
+
+	if err := reindexContacts(ctx, rt, oa, contactIDs); err != nil {
+		return fmt.Errorf("error reindexing contacts: %w", err)
+	}
+
+	return nil
+}
+
+func reindexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contactIDs []models.ContactID) error {
+	contacts, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
+	if err != nil {
+		return fmt.Errorf("error loading contacts for reindex: %w", err)
+	}
+
+	flowContacts := make([]*flows.Contact, 0, len(contacts))
+	currentFlows := make(map[models.ContactID]models.FlowID, len(contacts))
+	for _, c := range contacts {
+		fc, err := c.EngineContact(oa)
+		if err != nil {
+			return fmt.Errorf("error creating engine contact: %w", err)
+		}
+		flowContacts = append(flowContacts, fc)
+		currentFlows[c.ID()] = c.CurrentFlowID()
+	}
+
+	return search.IndexContacts(ctx, rt, oa, flowContacts, currentFlows)
+}

--- a/core/tasks/ctasks/urn_added.go
+++ b/core/tasks/ctasks/urn_added.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/gocommon/urns"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
-	"github.com/nyaruka/mailroom/core/search"
 	"github.com/nyaruka/mailroom/runtime"
 )
 
@@ -53,22 +51,3 @@ func (t *URNAdded) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.
 	return nil
 }
 
-func reindexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contactIDs []models.ContactID) error {
-	contacts, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
-	if err != nil {
-		return fmt.Errorf("error loading contacts for reindex: %w", err)
-	}
-
-	flowContacts := make([]*flows.Contact, 0, len(contacts))
-	currentFlows := make(map[models.ContactID]models.FlowID, len(contacts))
-	for _, c := range contacts {
-		fc, err := c.EngineContact(oa)
-		if err != nil {
-			return fmt.Errorf("error creating engine contact: %w", err)
-		}
-		flowContacts = append(flowContacts, fc)
-		currentFlows[c.ID()] = c.CurrentFlowID()
-	}
-
-	return search.IndexContacts(ctx, rt, oa, flowContacts, currentFlows)
-}

--- a/core/tasks/ctasks/urn_added.go
+++ b/core/tasks/ctasks/urn_added.go
@@ -33,22 +33,20 @@ func (t *URNAdded) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.
 		return nil
 	}
 
-	oldOwnerID, err := models.ClaimURN(ctx, rt.DB, oa, mc.ID(), urn)
+	claimed, err := models.ClaimURN(ctx, rt.DB, oa, mc.ID(), urn)
 	if err != nil {
 		return fmt.Errorf("error claiming urn: %w", err)
 	}
 
-	// update modified_on for affected contacts
-	contactIDs := []models.ContactID{mc.ID()}
-	if oldOwnerID != models.NilContactID {
-		contactIDs = append(contactIDs, oldOwnerID)
+	if !claimed {
+		return nil // URN belongs to another contact, nothing to do
 	}
 
-	if err := models.UpdateContactModifiedOn(ctx, rt.DB, contactIDs); err != nil {
+	if err := models.UpdateContactModifiedOn(ctx, rt.DB, []models.ContactID{mc.ID()}); err != nil {
 		return fmt.Errorf("error updating modified_on: %w", err)
 	}
 
-	if err := reindexContacts(ctx, rt, oa, contactIDs); err != nil {
+	if err := reindexContacts(ctx, rt, oa, []models.ContactID{mc.ID()}); err != nil {
 		return fmt.Errorf("error reindexing contacts: %w", err)
 	}
 

--- a/core/tasks/ctasks/urn_added_test.go
+++ b/core/tasks/ctasks/urn_added_test.go
@@ -18,7 +18,7 @@ func TestURNAdded(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
 
 	// add a new URN that doesn't exist in the database
 	err := tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055749999"})

--- a/core/tasks/ctasks/urn_added_test.go
+++ b/core/tasks/ctasks/urn_added_test.go
@@ -26,6 +26,7 @@ func TestURNAdded(t *testing.T) {
 
 	task, err := rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 
@@ -37,24 +38,27 @@ func TestURNAdded(t *testing.T) {
 
 	task, err = rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 
-	// Ann should still have only her original URN and the new one
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, testdb.Ann.ID).Returns(2)
 
-	// steal a URN from Bob
-	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055742222"})
+	// steal a URN from a different contact - use a new URN assigned to a new contact to avoid modifying base data
+	testContact := testdb.InsertContact(t, rt, testdb.Org1, "01999999-0000-0000-0000-000000000001", "Zed", "", "A")
+	testdb.InsertContactURN(t, rt, testdb.Org1, testContact, urns.URN("tel:+16055740001"), 100, nil)
+
+	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055740001"})
 	require.NoError(t, err)
 
 	task, err = rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 
-	// Bob's URN should now belong to Ann
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055742222", testdb.Ann.ID).Returns(1)
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055742222", testdb.Bob.ID).Returns(0)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740001", testdb.Ann.ID).Returns(1)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740001", testContact.ID).Returns(0)
 
 	// claim an orphaned URN
 	testdb.InsertContactURN(t, rt, testdb.Org1, nil, urns.URN("tel:+16055740000"), 0, nil)
@@ -63,6 +67,7 @@ func TestURNAdded(t *testing.T) {
 
 	task, err = rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 

--- a/core/tasks/ctasks/urn_added_test.go
+++ b/core/tasks/ctasks/urn_added_test.go
@@ -1,0 +1,70 @@
+package ctasks_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
+	"github.com/nyaruka/gocommon/urns"
+	_ "github.com/nyaruka/mailroom/core/runner/handlers"
+	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/ctasks"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURNAdded(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	// add a new URN that doesn't exist in the database
+	err := tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055749999"})
+	require.NoError(t, err)
+
+	task, err := rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055749999", testdb.Ann.ID).Returns(1)
+
+	// add a URN that Ann already has - should be a no-op
+	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055741111"})
+	require.NoError(t, err)
+
+	task, err = rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	// Ann should still have only her original URN and the new one
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, testdb.Ann.ID).Returns(2)
+
+	// steal a URN from Bob
+	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055742222"})
+	require.NoError(t, err)
+
+	task, err = rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	// Bob's URN should now belong to Ann
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055742222", testdb.Ann.ID).Returns(1)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055742222", testdb.Bob.ID).Returns(0)
+
+	// claim an orphaned URN
+	testdb.InsertContactURN(t, rt, testdb.Org1, nil, urns.URN("tel:+16055740000"), 0, nil)
+	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055740000"})
+	require.NoError(t, err)
+
+	task, err = rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740000", testdb.Ann.ID).Returns(1)
+}

--- a/core/tasks/ctasks/urn_added_test.go
+++ b/core/tasks/ctasks/urn_added_test.go
@@ -18,7 +18,7 @@ func TestURNAdded(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetOpenSearch)
 
 	// add a new URN that doesn't exist in the database
 	err := tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNAdded{URN: "tel:+16055749999"})

--- a/core/tasks/ctasks/urn_added_test.go
+++ b/core/tasks/ctasks/urn_added_test.go
@@ -44,7 +44,7 @@ func TestURNAdded(t *testing.T) {
 
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, testdb.Ann.ID).Returns(2)
 
-	// steal a URN from a different contact - use a new URN assigned to a new contact to avoid modifying base data
+	// try to add a URN that belongs to another contact - should be a no-op
 	testContact := testdb.InsertContact(t, rt, testdb.Org1, "01999999-0000-0000-0000-000000000001", "Zed", "", "A")
 	testdb.InsertContactURN(t, rt, testdb.Org1, testContact, urns.URN("tel:+16055740001"), 100, nil)
 
@@ -57,8 +57,9 @@ func TestURNAdded(t *testing.T) {
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740001", testdb.Ann.ID).Returns(1)
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740001", testContact.ID).Returns(0)
+	// URN should still belong to the other contact
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740001", testContact.ID).Returns(1)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055740001", testdb.Ann.ID).Returns(0)
 
 	// claim an orphaned URN
 	testdb.InsertContactURN(t, rt, testdb.Org1, nil, urns.URN("tel:+16055740000"), 0, nil)

--- a/core/tasks/ctasks/urn_removed.go
+++ b/core/tasks/ctasks/urn_removed.go
@@ -1,0 +1,54 @@
+package ctasks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
+)
+
+const TypeURNRemoved = "urn_removed"
+
+func init() {
+	RegisterType(TypeURNRemoved, func() Task { return &URNRemoved{} })
+}
+
+type URNRemoved struct {
+	URN urns.URN `json:"urn"`
+}
+
+func (t *URNRemoved) Type() string {
+	return TypeURNRemoved
+}
+
+func (t *URNRemoved) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact) error {
+	urn := t.URN.Normalize()
+
+	// if contact doesn't have this URN, nothing to do
+	if mc.FindURN(urn) == nil {
+		return nil
+	}
+
+	// don't remove the last URN
+	if len(mc.URNs()) <= 1 {
+		slog.Warn("ignoring urn_removed task, would remove last URN", "contact_id", mc.ID(), "urn", urn.Identity())
+		return nil
+	}
+
+	if err := models.DetachContactURN(ctx, rt.DB, oa.OrgID(), mc.ID(), urn.Identity()); err != nil {
+		return fmt.Errorf("error detaching urn: %w", err)
+	}
+
+	if err := models.UpdateContactModifiedOn(ctx, rt.DB, []models.ContactID{mc.ID()}); err != nil {
+		return fmt.Errorf("error updating modified_on: %w", err)
+	}
+
+	if err := reindexContacts(ctx, rt, oa, []models.ContactID{mc.ID()}); err != nil {
+		return fmt.Errorf("error reindexing contact: %w", err)
+	}
+
+	return nil
+}

--- a/core/tasks/ctasks/urn_removed_test.go
+++ b/core/tasks/ctasks/urn_removed_test.go
@@ -1,0 +1,62 @@
+package ctasks_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
+	"github.com/nyaruka/gocommon/urns"
+	_ "github.com/nyaruka/mailroom/core/runner/handlers"
+	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/core/tasks/ctasks"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURNRemoved(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	// give Ann a second URN so she has two
+	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, urns.URN("tel:+16055749999"), 50, nil)
+
+	// remove the second URN
+	err := tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNRemoved{URN: "tel:+16055749999"})
+	require.NoError(t, err)
+
+	task, err := rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	// URN should be detached (orphaned)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id IS NULL`, "tel:+16055749999").Returns(1)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, testdb.Ann.ID).Returns(1)
+
+	// try to remove a URN Ann doesn't have - should be a no-op
+	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNRemoved{URN: "tel:+16055748888"})
+	require.NoError(t, err)
+
+	task, err = rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	// Ann still has her one URN
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, testdb.Ann.ID).Returns(1)
+
+	// try to remove Ann's last URN - should be refused
+	err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, testdb.Ann.ID, &ctasks.URNRemoved{URN: "tel:+16055741111"})
+	require.NoError(t, err)
+
+	task, err = rt.Queues.Realtime.Pop(ctx, vc)
+	require.NoError(t, err)
+	err = tasks.Perform(ctx, rt, task)
+	require.NoError(t, err)
+
+	// Ann should still have her URN
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = $1 AND contact_id = $2`, "tel:+16055741111", testdb.Ann.ID).Returns(1)
+}

--- a/core/tasks/ctasks/urn_removed_test.go
+++ b/core/tasks/ctasks/urn_removed_test.go
@@ -18,7 +18,7 @@ func TestURNRemoved(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
 
 	// give Ann a second URN so she has two
 	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, urns.URN("tel:+16055749999"), 50, nil)

--- a/core/tasks/ctasks/urn_removed_test.go
+++ b/core/tasks/ctasks/urn_removed_test.go
@@ -29,6 +29,7 @@ func TestURNRemoved(t *testing.T) {
 
 	task, err := rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 
@@ -42,6 +43,7 @@ func TestURNRemoved(t *testing.T) {
 
 	task, err = rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 
@@ -54,6 +56,7 @@ func TestURNRemoved(t *testing.T) {
 
 	task, err = rt.Queues.Realtime.Pop(ctx, vc)
 	require.NoError(t, err)
+	require.NotNil(t, task)
 	err = tasks.Perform(ctx, rt, task)
 	require.NoError(t, err)
 

--- a/core/tasks/ctasks/urn_removed_test.go
+++ b/core/tasks/ctasks/urn_removed_test.go
@@ -18,7 +18,7 @@ func TestURNRemoved(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetOpenSearch)
 
 	// give Ann a second URN so she has two
 	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, urns.URN("tel:+16055749999"), 50, nil)


### PR DESCRIPTION
Add two new contact tasks for courier to add/remove URNs on contacts:
- urn_added: creates a new URN for a contact, or claims an orphaned one (does not steal from other contacts)
- urn_removed: detaches a URN from a contact, refuses to remove last URN