### PR TITLE
Switch contact indexing from OpenSearch to Elastic v2 index

### DIFF
--- a/cmd/mrindex/main.go
+++ b/cmd/mrindex/main.go
@@ -15,7 +15,7 @@ import (
 
 const contactBatchSize = 500
 
-// command line tool to re-index all contacts in the database to OpenSearch.
+// command line tool to re-index all contacts in the database to Elastic.
 //
 // go install github.com/nyaruka/mailroom/cmd/mrindex; mrindex
 func main() {
@@ -47,7 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// stop flushes remaining queued items to OpenSearch and spool
+	// stop flushes remaining queued items to Elastic and spool
 	rt.Stop()
 }
 

--- a/core/crons/deindex_deleted_orgs_test.go
+++ b/core/crons/deindex_deleted_orgs_test.go
@@ -25,11 +25,11 @@ func TestDeindexDeletedOrgsCron(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
 
-		_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
+		_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(ctx)
 		require.NoError(t, err)
 	}
 
-	testsuite.ReindexElastic(t, rt)
+	testsuite.IndexOrgContacts(t, rt, testdb.Org1)
 
 	// no orgs to deindex
 	assertRun(map[string]any{"contacts": map[models.OrgID]int{}})

--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -226,7 +226,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 				require.NoError(t, err)
 
 				for _, sa := range tc.AssertSearch {
-					ids, err := search.GetContactIDsForQuery(ctx, rt, oa2, nil, models.ContactStatusActive, sa.Query, -1, true)
+					ids, err := search.GetContactIDsForQuery(ctx, rt, oa2, nil, models.ContactStatusActive, sa.Query, -1, true /*useV2*/)
 					assert.NoError(t, err, "%s: search query '%s' failed", tc.Label, sa.Query)
 					assert.ElementsMatch(t, sa.Contacts, ids, "%s: search query '%s' returned wrong contacts", tc.Label, sa.Query)
 				}

--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -226,7 +226,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 				require.NoError(t, err)
 
 				for _, sa := range tc.AssertSearch {
-					ids, err := search.GetContactIDsForQuery(ctx, rt, oa2, nil, models.ContactStatusActive, sa.Query, -1, true /*useV2*/)
+					ids, err := search.GetContactIDsForQuery(ctx, rt, oa2, nil, models.ContactStatusActive, sa.Query, -1, true /*v2*/)
 					assert.NoError(t, err, "%s: search query '%s' failed", tc.Label, sa.Query)
 					assert.ElementsMatch(t, sa.Contacts, ids, "%s: search query '%s' returned wrong contacts", tc.Label, sa.Query)
 				}

--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
-	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,9 +103,9 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 
 	test.MockUniverse()
 
-	// clear any stale opensearch data from previous test runs
+	// clear any stale data from previous test runs
 	testsuite.GetIndexedMessages(t, rt, true)
-	testsuite.ClearOSContactsIndex(t, rt)
+	testsuite.ClearESContactsIndexV2(t, rt)
 
 	for i, tc := range tcs {
 		scenes := make([]*runner.Scene, 4)
@@ -207,7 +206,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 			}
 			test.AssertEqualJSON(t, jsonx.MustMarshal(tc.IndexedMessages), jsonx.MustMarshal(actual.IndexedMessages), "%s: indexed messages mismatch", tc.Label)
 
-			// check search assertions against OpenSearch contacts index
+			// check search assertions against v2 Elastic contacts index
 			if len(tc.AssertSearch) > 0 {
 				// reload contacts from DB and re-index since handler tests add events directly
 				// (bypassing the flow engine) so the flow contacts used by IndexContacts hook
@@ -222,8 +221,8 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 					require.NoError(t, err)
 				}
 
-				rt.OS.Writer.Flush()
-				_, err = rt.OS.Client.Indices.Refresh(ctx, &opensearchapi.IndicesRefreshReq{Indices: []string{rt.Config.OSContactsIndex}})
+				rt.ES.Writer.Flush()
+				_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(ctx)
 				require.NoError(t, err)
 
 				for _, sa := range tc.AssertSearch {
@@ -232,7 +231,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 					assert.ElementsMatch(t, sa.Contacts, ids, "%s: search query '%s' returned wrong contacts", tc.Label, sa.Query)
 				}
 
-				testsuite.ClearOSContactsIndex(t, rt)
+				testsuite.ClearESContactsIndexV2(t, rt)
 			}
 		} else {
 			tcs[i] = actual

--- a/core/runner/hooks/index_contacts.go
+++ b/core/runner/hooks/index_contacts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nyaruka/mailroom/runtime"
 )
 
-// IndexContacts is our hook for indexing contacts to OpenSearch after the database transaction has committed
+// IndexContacts is our hook for indexing contacts to Elastic after the database transaction has committed
 var IndexContacts runner.PostCommitHook = &indexContacts{}
 
 type indexContacts struct{}

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -202,7 +202,7 @@ func DeindexContactsByOrg(ctx context.Context, rt *runtime.Runtime, orgID models
 		"max_docs": limit,
 	}
 
-	resp, err := rt.ES.Client.DeleteByQuery(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+	resp, err := rt.ES.Client.DeleteByQuery(rt.Config.ElasticContactsIndexV2).Routing(orgID.String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("error deindexing contacts in org #%d from elastic: %w", orgID, err)
 	}

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -180,7 +180,7 @@ func DeindexContactsByID(ctx context.Context, rt *runtime.Runtime, orgID models.
 		cmds.WriteString("\n")
 	}
 
-	resp, err := rt.ES.Client.Bulk().Index(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(cmds.Bytes())).Do(ctx)
+	resp, err := rt.ES.Client.Bulk().Index(rt.Config.ElasticContactsIndexV2).Routing(orgID.String()).Raw(bytes.NewReader(cmds.Bytes())).Do(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("error deindexing deleted contacts from elastic: %w", err)
 	}

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/operationtype"
-	"github.com/nyaruka/gocommon/aws/osearch"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/elastic"
 	"github.com/nyaruka/gocommon/i18n"
@@ -17,11 +16,10 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
-	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/shopspring/decimal"
 )
 
-// ContactDocField represents a single field value in a contact document for OpenSearch.
+// ContactDocField represents a single field value in a contact document.
 type ContactDocField struct {
 	Field           assets.FieldUUID `json:"field"`
 	Text            string           `json:"text,omitempty"`
@@ -35,13 +33,13 @@ type ContactDocField struct {
 	WardKeyword     string           `json:"ward_keyword,omitempty"`
 }
 
-// ContactDocURN represents a single URN in a contact document for OpenSearch.
+// ContactDocURN represents a single URN in a contact document.
 type ContactDocURN struct {
 	Scheme string `json:"scheme"`
 	Path   string `json:"path"`
 }
 
-// ContactDoc represents a contact document in the OpenSearch contacts index. DBID is used as the document _id.
+// ContactDoc represents a contact document in the contacts index. DBID is used as the document _id.
 type ContactDoc struct {
 	DBID           models.ContactID     `json:"id"` // also used as _id
 	UUID           flows.ContactUUID    `json:"uuid"`
@@ -137,7 +135,7 @@ func NewContactDoc(oa *models.OrgAssets, c *flows.Contact, currentFlowID models.
 	return doc
 }
 
-// IndexContacts builds contact documents and queues them for indexing in OpenSearch.
+// IndexContacts builds contact documents and queues them for indexing in Elastic.
 func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, flowContacts []*flows.Contact, currentFlows map[models.ContactID]models.FlowID) error {
 	if len(flowContacts) == 0 {
 		return nil
@@ -162,8 +160,8 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 			return fmt.Errorf("error marshalling contact doc: %w", err)
 		}
 
-		rt.OS.Writer.Queue(&osearch.Document{
-			Index:   rt.Config.OSContactsIndex,
+		rt.ES.Writer.Queue(&elastic.Document{
+			Index:   rt.Config.ElasticContactsIndexV2,
 			ID:      doc.DBID.String(),
 			Routing: doc.OrgID.String(),
 			Version: dates.Now().UnixNano(),
@@ -174,46 +172,27 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 	return nil
 }
 
-// DeindexContactsByID de-indexes the contacts with the given IDs from Elastic and OpenSearch
-func DeindexContactsByID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactIDs []models.ContactID) (int, int, error) {
+// DeindexContactsByID de-indexes the contacts with the given IDs from Elastic
+func DeindexContactsByID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactIDs []models.ContactID) (int, error) {
 	cmds := &bytes.Buffer{}
 	for _, id := range contactIDs {
 		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": id.String()}}))
 		cmds.WriteString("\n")
 	}
-	body := cmds.Bytes()
 
-	resp, err := rt.ES.Client.Bulk().Index(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(body)).Do(ctx)
+	resp, err := rt.ES.Client.Bulk().Index(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(cmds.Bytes())).Do(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error deindexing deleted contacts from elastic: %w", err)
+		return 0, fmt.Errorf("error deindexing deleted contacts from elastic: %w", err)
 	}
 
-	esDeleted := 0
+	deleted := 0
 	for _, r := range resp.Items {
 		if r[operationtype.Delete].Status == 200 {
-			esDeleted++
+			deleted++
 		}
 	}
 
-	osResp, err := rt.OS.Client.Bulk(ctx, opensearchapi.BulkReq{
-		Index: rt.Config.OSContactsIndex,
-		Body:  bytes.NewReader(body),
-		Params: opensearchapi.BulkParams{
-			Routing: orgID.String(),
-		},
-	})
-	if err != nil {
-		return 0, 0, fmt.Errorf("error deindexing deleted contacts from opensearch: %w", err)
-	}
-
-	osDeleted := 0
-	for _, item := range osResp.Items {
-		if d, ok := item["delete"]; ok && d.Status == 200 {
-			osDeleted++
-		}
-	}
-
-	return esDeleted, osDeleted, nil
+	return deleted, nil
 }
 
 // DeindexContactsByOrg de-indexes all contacts in the given org from Elastic

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -119,35 +119,21 @@ func TestDeindexContacts(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
-	testsuite.ReindexElastic(t, rt)
+	// index all org1 and org2 contacts into the v2 index
+	testsuite.IndexOrgContacts(t, rt, testdb.Org1)
+	testsuite.IndexOrgContacts(t, rt, testdb.Org2)
 
-	// index Bob and Cat into the v2 index via IndexContacts
-	oa := testdb.Org1.Load(t, rt)
-	mcs, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
-	require.NoError(t, err)
-	fcs := make([]*flows.Contact, len(mcs))
-	for i, mc := range mcs {
-		fcs[i], err = mc.EngineContact(oa)
-		require.NoError(t, err)
-	}
-	err = search.IndexContacts(ctx, rt, oa, fcs, map[models.ContactID]models.FlowID{})
-	require.NoError(t, err)
-	rt.ES.Writer.Flush()
-
-	// ensures changes are visible in the v2 index
 	refreshV2 := func() {
 		_, err := rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(ctx)
-		require.NoError(t, err)
-	}
-	// ensures changes are visible in the legacy index
-	refreshLegacy := func() {
-		_, err := rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
 		require.NoError(t, err)
 	}
 
 	refreshV2()
 
-	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 2)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE org_id = $1`, testdb.Org1.ID).Returns(124)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE org_id = $1`, testdb.Org2.ID).Returns(121)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
 	// DeindexContactsByID operates on the v2 index
 	deindexedByID, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
@@ -156,42 +142,31 @@ func TestDeindexContacts(t *testing.T) {
 
 	refreshV2()
 
-	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 0)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 122)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
-	// DeindexContactsByOrg operates on the legacy index (managed by rp-indexer)
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE org_id = $1`, testdb.Org1.ID).Returns(124)
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
-
+	// DeindexContactsByOrg also operates on the v2 index
 	deindexed, err := search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 100, deindexed)
 
-	refreshLegacy()
+	refreshV2()
 
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 24)
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 22)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
 	deindexed, err = search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
-	assert.Equal(t, 24, deindexed)
+	assert.Equal(t, 22, deindexed)
 
-	refreshLegacy()
+	refreshV2()
 
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 0)
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 0)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
 	deindexed, err = search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, deindexed)
-}
-
-func assertSearchCount(t *testing.T, rt *runtime.Runtime, query elastic.Query, expected int) {
-	src := map[string]any{"query": query}
-
-	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, expected, int(resp.Count))
 }
 
 func assertSearchCountV2(t *testing.T, rt *runtime.Runtime, query elastic.Query, expected int) {

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -2,7 +2,6 @@ package search_test
 
 import (
 	"bytes"
-	"context"
 	"sort"
 	"testing"
 
@@ -172,7 +171,7 @@ func TestDeindexContacts(t *testing.T) {
 func assertSearchCountV2(t *testing.T, rt *runtime.Runtime, query elastic.Query, expected int) {
 	src := map[string]any{"query": query}
 
-	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndexV2).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(context.Background())
+	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndexV2).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, expected, int(resp.Count))
 }

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -132,10 +132,9 @@ func TestDeindexContacts(t *testing.T) {
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
-	esDeindexed, osDeindexed, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
+	deindexedByID, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, esDeindexed)
-	assert.Equal(t, 0, osDeindexed)
+	assert.Equal(t, 2, deindexedByID)
 
 	refreshElastic()
 

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -121,40 +121,62 @@ func TestDeindexContacts(t *testing.T) {
 
 	testsuite.ReindexElastic(t, rt)
 
-	// ensures changes are visible in elastic
-	refreshElastic := func() {
+	// index Bob and Cat into the v2 index via IndexContacts
+	oa := testdb.Org1.Load(t, rt)
+	mcs, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
+	require.NoError(t, err)
+	fcs := make([]*flows.Contact, len(mcs))
+	for i, mc := range mcs {
+		fcs[i], err = mc.EngineContact(oa)
+		require.NoError(t, err)
+	}
+	err = search.IndexContacts(ctx, rt, oa, fcs, map[models.ContactID]models.FlowID{})
+	require.NoError(t, err)
+	rt.ES.Writer.Flush()
+
+	// ensures changes are visible in the v2 index
+	refreshV2 := func() {
+		_, err := rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(ctx)
+		require.NoError(t, err)
+	}
+	// ensures changes are visible in the legacy index
+	refreshLegacy := func() {
 		_, err := rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
 		require.NoError(t, err)
 	}
 
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE org_id = $1`, testdb.Org1.ID).Returns(124)
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE org_id = $1`, testdb.Org2.ID).Returns(121)
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
+	refreshV2()
 
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 2)
+
+	// DeindexContactsByID operates on the v2 index
 	deindexedByID, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, deindexedByID)
 
-	refreshElastic()
+	refreshV2()
 
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 122)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 0)
+
+	// DeindexContactsByOrg operates on the legacy index (managed by rp-indexer)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE org_id = $1`, testdb.Org1.ID).Returns(124)
+	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
 	deindexed, err := search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 100, deindexed)
 
-	refreshElastic()
+	refreshLegacy()
 
-	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 22)
+	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 24)
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
 	deindexed, err = search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
-	assert.Equal(t, 22, deindexed)
+	assert.Equal(t, 24, deindexed)
 
-	refreshElastic()
+	refreshLegacy()
 
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org1.ID), 0)
 	assertSearchCount(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
@@ -168,6 +190,14 @@ func assertSearchCount(t *testing.T, rt *runtime.Runtime, query elastic.Query, e
 	src := map[string]any{"query": query}
 
 	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, expected, int(resp.Count))
+}
+
+func assertSearchCountV2(t *testing.T, rt *runtime.Runtime, query elastic.Query, expected int) {
+	src := map[string]any{"query": query}
+
+	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndexV2).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, expected, int(resp.Count))
 }

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -32,18 +32,6 @@ func (m *AssetMapper) Group(g assets.Group) int64 {
 
 var assetMapper = &AssetMapper{}
 
-// BuildElasticQuery turns the passed in contact ql query into an elastic query
-func BuildElasticQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery) elastic.Query {
-	return buildContactQuery(oa, group, status, excludeIDs, query, false)
-}
-
-// BuildContactQuery turns the passed in contact ql query into a query for the given index. If v2
-// is true, it targets the v2 index (which only contains active contacts, so no is_active filter is
-// needed). If false, it targets the legacy rp-indexer index (which requires an is_active filter).
-func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, v2 bool) elastic.Query {
-	return buildContactQuery(oa, group, status, excludeIDs, query, v2)
-}
-
 func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, v2 bool) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -37,12 +37,14 @@ func BuildElasticQuery(oa *models.OrgAssets, group *models.Group, status models.
 	return buildContactQuery(oa, group, status, excludeIDs, query, false)
 }
 
-// BuildContactQuery turns the passed in contact ql query into a query for the given backend
-func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, os bool) elastic.Query {
-	return buildContactQuery(oa, group, status, excludeIDs, query, os)
+// BuildContactQuery turns the passed in contact ql query into a query for the given index. If useV2
+// is true, it targets the v2 index (which only contains active contacts, so no is_active filter is
+// needed). If false, it targets the legacy rp-indexer index (which requires an is_active filter).
+func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, useV2 bool) elastic.Query {
+	return buildContactQuery(oa, group, status, excludeIDs, query, useV2)
 }
 
-func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, os bool) elastic.Query {
+func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, useV2 bool) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
 	filter := []elastic.Query{
@@ -50,7 +52,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 	}
 
 	// rp-indexer index has is_active field, v2 index only indexes active contacts
-	if !os {
+	if !useV2 {
 		filter = append(filter, elastic.Term("is_active", true))
 	}
 
@@ -80,7 +82,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 }
 
 // GetContactTotal returns the total count of matching contacts for the given query
-func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, query string, os bool) (*contactql.ContactQuery, int64, error) {
+func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, query string, useV2 bool) (*contactql.ContactQuery, int64, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -99,11 +101,11 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, nil, parsed, os)
+	eq := buildContactQuery(oa, group, status, nil, parsed, useV2)
 	src := map[string]any{"query": eq}
 
 	index := rt.Config.ElasticContactsIndex
-	if os {
+	if useV2 {
 		index = rt.Config.ElasticContactsIndexV2
 	}
 
@@ -116,7 +118,7 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 }
 
 // GetContactIDsForQueryPage returns a page of contact ids for the given query and sort
-func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int, os bool) (*contactql.ContactQuery, []models.ContactID, int64, error) {
+func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int, useV2 bool) (*contactql.ContactQuery, []models.ContactID, int64, error) {
 	env := oa.Env()
 	start := time.Now()
 	var parsed *contactql.ContactQuery
@@ -136,7 +138,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, os)
+	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, useV2)
 
 	fieldSort, err := es.ToElasticSort(sort, oa.SessionAssets())
 	if err != nil {
@@ -144,7 +146,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	}
 
 	index := rt.Config.ElasticContactsIndex
-	if os {
+	if useV2 {
 		index = rt.Config.ElasticContactsIndexV2
 	}
 
@@ -171,7 +173,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 }
 
 // GetContactIDsForQuery returns up to limit the contact ids that match the given query, sorted by id. Limit of -1 means return all.
-func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int, os bool) ([]models.ContactID, error) {
+func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int, useV2 bool) ([]models.ContactID, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -190,10 +192,10 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, nil, parsed, os)
+	eq := buildContactQuery(oa, group, status, nil, parsed, useV2)
 
 	index := rt.Config.ElasticContactsIndex
-	if os {
+	if useV2 {
 		index = rt.Config.ElasticContactsIndexV2
 	}
 

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -16,7 +16,6 @@ import (
 	"github.com/nyaruka/goflow/contactql/es"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
-	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
 // AssetMapper maps resolved assets in queries to how we identify them in ES which in the case
@@ -50,7 +49,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 		elastic.Term("org_id", oa.OrgID()),
 	}
 
-	// Elastic has is_active field, OpenSearch only indexes active contacts
+	// rp-indexer index has is_active field, v2 index only indexes active contacts
 	if !os {
 		filter = append(filter, elastic.Term("is_active", true))
 	}
@@ -103,19 +102,12 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 	eq := buildContactQuery(oa, group, status, nil, parsed, os)
 	src := map[string]any{"query": eq}
 
+	index := rt.Config.ElasticContactsIndex
 	if os {
-		resp, err := rt.OS.Client.Indices.Count(ctx, &opensearchapi.IndicesCountReq{
-			Indices: []string{rt.Config.OSContactsIndex},
-			Body:    bytes.NewReader(jsonx.MustMarshal(src)),
-			Params:  opensearchapi.IndicesCountParams{Routing: []string{oa.OrgID().String()}},
-		})
-		if err != nil {
-			return nil, 0, fmt.Errorf("error performing count: %w", err)
-		}
-		return parsed, int64(resp.Count), nil
+		index = rt.Config.ElasticContactsIndexV2
 	}
 
-	count, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndex).Routing(oa.OrgID().String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+	count, err := rt.ES.Client.Count().Index(index).Routing(oa.OrgID().String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error performing count: %w", err)
 	}
@@ -151,35 +143,11 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
 	}
 
+	index := rt.Config.ElasticContactsIndex
 	if os {
-		src := map[string]any{
-			"_source":          false,
-			"query":            eq,
-			"sort":             []any{fieldSort},
-			"from":             offset,
-			"size":             pageSize,
-			"track_total_hits": true,
-		}
-
-		routing := oa.OrgID().String()
-		resp, err := rt.OS.Client.Search(ctx, &opensearchapi.SearchReq{
-			Indices: []string{rt.Config.OSContactsIndex},
-			Body:    bytes.NewReader(jsonx.MustMarshal(src)),
-			Params:  opensearchapi.SearchParams{Routing: []string{routing}},
-		})
-		if err != nil {
-			return nil, nil, 0, fmt.Errorf("error performing query: %w", err)
-		}
-
-		ids := make([]models.ContactID, 0, pageSize)
-		ids = appendIDsFromOSHits(ids, resp.Hits.Hits)
-
-		slog.Debug("paged contact query complete", "org_id", oa.OrgID(), "query", query, "elapsed", time.Since(start), "page_count", len(ids), "total_count", resp.Hits.Total.Value)
-
-		return parsed, ids, int64(resp.Hits.Total.Value), nil
+		index = rt.Config.ElasticContactsIndexV2
 	}
 
-	index := rt.Config.ElasticContactsIndex
 	src := map[string]any{
 		"_source":          false,
 		"query":            eq,
@@ -224,14 +192,15 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 
 	eq := buildContactQuery(oa, group, status, nil, parsed, os)
 
+	index := rt.Config.ElasticContactsIndex
 	if os {
-		return getContactIDsForQueryOS(ctx, rt, oa, eq, limit)
+		index = rt.Config.ElasticContactsIndexV2
 	}
-	return getContactIDsForQueryES(ctx, rt, oa, eq, limit)
+
+	return getContactIDsForQuery(ctx, rt, oa, index, eq, limit)
 }
 
-func getContactIDsForQueryES(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, eq elastic.Query, limit int) ([]models.ContactID, error) {
-	index := rt.Config.ElasticContactsIndex
+func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, index string, eq elastic.Query, limit int) ([]models.ContactID, error) {
 	sort := elastic.SortBy("id", true)
 	ids := make([]models.ContactID, 0, 100)
 
@@ -304,107 +273,10 @@ func getContactIDsForQueryES(ctx context.Context, rt *runtime.Runtime, oa *model
 	return ids, nil
 }
 
-func getContactIDsForQueryOS(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, eq elastic.Query, limit int) ([]models.ContactID, error) {
-	index := rt.Config.OSContactsIndex
-	routing := oa.OrgID().String()
-	sort := elastic.SortBy("id", true)
-	ids := make([]models.ContactID, 0, 100)
-
-	// if limit provided that can be done with single search, do that
-	if limit >= 0 && limit <= 10_000 {
-		src := map[string]any{
-			"_source":          false,
-			"query":            eq,
-			"sort":             []any{sort},
-			"from":             0,
-			"size":             limit,
-			"track_total_hits": false,
-		}
-
-		resp, err := rt.OS.Client.Search(ctx, &opensearchapi.SearchReq{
-			Indices: []string{index},
-			Body:    bytes.NewReader(jsonx.MustMarshal(src)),
-			Params:  opensearchapi.SearchParams{Routing: []string{routing}},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error searching OS index: %w", err)
-		}
-		return appendIDsFromOSHits(ids, resp.Hits.Hits), nil
-	}
-
-	// for larger limits we need to take a point in time and iterate through multiple search requests using search_after
-	pit, err := rt.OS.Client.PointInTime.Create(ctx, opensearchapi.PointInTimeCreateReq{
-		Indices: []string{index},
-		Params:  opensearchapi.PointInTimeCreateParams{KeepAlive: time.Minute, Routing: routing},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error creating OS point-in-time: %w", err)
-	}
-	defer func() {
-		cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if _, err := rt.OS.Client.PointInTime.Delete(cctx, opensearchapi.PointInTimeDeleteReq{
-			PitID: []string{pit.PitID},
-		}); err != nil {
-			slog.Error("error closing OS point-in-time", "error", err)
-		}
-	}()
-
-	src := map[string]any{
-		"_source":          false,
-		"query":            eq,
-		"sort":             []any{sort},
-		"pit":              map[string]any{"id": pit.PitID, "keep_alive": "1m"},
-		"size":             10_000,
-		"track_total_hits": false,
-	}
-
-	for {
-		resp, err := rt.OS.Client.Search(ctx, &opensearchapi.SearchReq{
-			Body: bytes.NewReader(jsonx.MustMarshal(src)),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error searching OS index: %w", err)
-		}
-
-		if len(resp.Hits.Hits) == 0 {
-			break
-		}
-
-		ids = appendIDsFromOSHits(ids, resp.Hits.Hits)
-
-		if limit != -1 && len(ids) >= limit {
-			ids = ids[:limit]
-			break
-		}
-		if limit != -1 {
-			if remaining := limit - len(ids); remaining < 10_000 {
-				src["size"] = remaining
-			}
-		}
-
-		lastHit := resp.Hits.Hits[len(resp.Hits.Hits)-1]
-		src["search_after"] = lastHit.Sort
-	}
-
-	return ids, nil
-}
-
 // appendIDsFromESHits extracts contact IDs from Elasticsearch hits where _id is the database contact ID
 func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.ContactID {
 	for _, hit := range hits {
 		id, err := strconv.Atoi(*hit.Id_)
-		if err == nil {
-			ids = append(ids, models.ContactID(id))
-		}
-	}
-	return ids
-}
-
-// appendIDsFromOSHits extracts contact IDs from OpenSearch hits where _id is the database contact ID
-func appendIDsFromOSHits(ids []models.ContactID, hits []opensearchapi.SearchHit) []models.ContactID {
-	for _, hit := range hits {
-		id, err := strconv.Atoi(hit.ID)
 		if err == nil {
 			ids = append(ids, models.ContactID(id))
 		}

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -37,14 +37,14 @@ func BuildElasticQuery(oa *models.OrgAssets, group *models.Group, status models.
 	return buildContactQuery(oa, group, status, excludeIDs, query, false)
 }
 
-// BuildContactQuery turns the passed in contact ql query into a query for the given index. If useV2
+// BuildContactQuery turns the passed in contact ql query into a query for the given index. If v2
 // is true, it targets the v2 index (which only contains active contacts, so no is_active filter is
 // needed). If false, it targets the legacy rp-indexer index (which requires an is_active filter).
-func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, useV2 bool) elastic.Query {
-	return buildContactQuery(oa, group, status, excludeIDs, query, useV2)
+func BuildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, v2 bool) elastic.Query {
+	return buildContactQuery(oa, group, status, excludeIDs, query, v2)
 }
 
-func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, useV2 bool) elastic.Query {
+func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, v2 bool) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
 	filter := []elastic.Query{
@@ -52,7 +52,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 	}
 
 	// rp-indexer index has is_active field, v2 index only indexes active contacts
-	if !useV2 {
+	if !v2 {
 		filter = append(filter, elastic.Term("is_active", true))
 	}
 
@@ -82,7 +82,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 }
 
 // GetContactTotal returns the total count of matching contacts for the given query
-func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, query string, useV2 bool) (*contactql.ContactQuery, int64, error) {
+func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, query string, v2 bool) (*contactql.ContactQuery, int64, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -101,11 +101,11 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, nil, parsed, useV2)
+	eq := buildContactQuery(oa, group, status, nil, parsed, v2)
 	src := map[string]any{"query": eq}
 
 	index := rt.Config.ElasticContactsIndex
-	if useV2 {
+	if v2 {
 		index = rt.Config.ElasticContactsIndexV2
 	}
 
@@ -118,7 +118,7 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 }
 
 // GetContactIDsForQueryPage returns a page of contact ids for the given query and sort
-func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int, useV2 bool) (*contactql.ContactQuery, []models.ContactID, int64, error) {
+func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int, v2 bool) (*contactql.ContactQuery, []models.ContactID, int64, error) {
 	env := oa.Env()
 	start := time.Now()
 	var parsed *contactql.ContactQuery
@@ -138,7 +138,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, useV2)
+	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, v2)
 
 	fieldSort, err := es.ToElasticSort(sort, oa.SessionAssets())
 	if err != nil {
@@ -146,7 +146,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	}
 
 	index := rt.Config.ElasticContactsIndex
-	if useV2 {
+	if v2 {
 		index = rt.Config.ElasticContactsIndexV2
 	}
 
@@ -173,7 +173,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 }
 
 // GetContactIDsForQuery returns up to limit the contact ids that match the given query, sorted by id. Limit of -1 means return all.
-func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int, useV2 bool) ([]models.ContactID, error) {
+func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int, v2 bool) ([]models.ContactID, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -192,10 +192,10 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, nil, parsed, useV2)
+	eq := buildContactQuery(oa, group, status, nil, parsed, v2)
 
 	index := rt.Config.ElasticContactsIndex
-	if useV2 {
+	if v2 {
 		index = rt.Config.ElasticContactsIndexV2
 	}
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -53,12 +53,11 @@ type Config struct {
 	Elastic              string `validate:"url" help:"the URL of your ElasticSearch instance"`
 	ElasticUsername      string `help:"the username for ElasticSearch if using basic auth"`
 	ElasticPassword      string `help:"the password for ElasticSearch if using basic auth"`
-	ElasticContactsIndex string `help:"the name of index alias for contacts"`
+	ElasticContactsIndex   string `help:"the name of index alias for contacts"`
+	ElasticContactsIndexV2 string `help:"the name of the v2 contacts index written by mailroom"`
 
-	OSEndpoint             string  `name:"os_endpoint"              validate:"url" help:"the URL of your OpenSearch endpoint"`
-	OSMessagesIndex        string  `name:"os_messages_index"                      help:"the base name for monthly message indexes (e.g. messages -> messages-2026-02)"`
-	OSContactsIndex        string  `name:"os_contacts_index"                      help:"the name of the index for contacts (e.g. contacts)"`
-	OSContactsSearchVerify float64 `name:"os_contacts_search_verify"              help:"proportion of contact searches to also run against OpenSearch for comparison (0.0 to 1.0)"`
+	OSEndpoint      string `name:"os_endpoint"        validate:"url" help:"the URL of your OpenSearch endpoint"`
+	OSMessagesIndex string `name:"os_messages_index"                 help:"the base name for monthly message indexes (e.g. messages -> messages-2026-02)"`
 
 	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
 	AWSSecretAccessKey string `help:"secret access key to use for AWS services"`
@@ -122,12 +121,11 @@ func NewDefaultConfig() *Config {
 		Elastic:              "http://elastic:9200",
 		ElasticUsername:      "",
 		ElasticPassword:      "",
-		ElasticContactsIndex: "contacts",
+		ElasticContactsIndex:   "contacts",
+		ElasticContactsIndexV2: "contacts-v2",
 
-		OSEndpoint:             "http://opensearch:9200",
-		OSMessagesIndex:        "messages-v1",
-		OSContactsIndex:        "contacts",
-		OSContactsSearchVerify: 0,
+		OSEndpoint:      "http://opensearch:9200",
+		OSMessagesIndex: "messages-v1",
 
 		AWSAccessKeyID:     "",
 		AWSSecretAccessKey: "",

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -53,8 +53,9 @@ type Config struct {
 	Elastic              string `validate:"url" help:"the URL of your ElasticSearch instance"`
 	ElasticUsername      string `help:"the username for ElasticSearch if using basic auth"`
 	ElasticPassword      string `help:"the password for ElasticSearch if using basic auth"`
-	ElasticContactsIndex   string `help:"the name of index alias for contacts"`
-	ElasticContactsIndexV2 string `help:"the name of the v2 contacts index written by mailroom"`
+	ElasticContactsIndex       string  `help:"the name of index alias for contacts"`
+	ElasticContactsIndexV2     string  `help:"the name of the v2 contacts index written by mailroom"`
+	ElasticContactsV2Verify    float64 `help:"proportion of contact searches to also run against the v2 index for comparison (0 to disable)"`
 
 	OSEndpoint      string `name:"os_endpoint"        validate:"url" help:"the URL of your OpenSearch endpoint"`
 	OSMessagesIndex string `name:"os_messages_index"                 help:"the base name for monthly message indexes (e.g. messages -> messages-2026-02)"`

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -35,8 +35,8 @@ type Stats struct {
 	WebhookCallCount    int           // number of webhook calls
 	WebhookCallDuration time.Duration // total time spent handling webhook calls
 
-	ContactSearchCount    int           // number of contact searches
-	ContactSearchDuration time.Duration // total time spent searching contacts
+	ContactSearchCount    map[string]int           // number of contact searches by version (v1/v2)
+	ContactSearchDuration map[string]time.Duration // total time spent searching contacts by version
 }
 
 func newStats() *Stats {
@@ -51,6 +51,9 @@ func newStats() *Stats {
 
 		LLMCallCount:    make(map[LLMTypeAndModel]int),
 		LLMCallDuration: make(map[LLMTypeAndModel]time.Duration),
+
+		ContactSearchCount:    make(map[string]int),
+		ContactSearchDuration: make(map[string]time.Duration),
 	}
 }
 
@@ -89,15 +92,14 @@ func (s *Stats) ToMetrics(advanced bool) []types.MetricDatum {
 		cwatch.Datum("WebhookCallDuration", float64(avgWebhookDuration)/float64(time.Second), types.StandardUnitSeconds),
 	)
 
-	var avgSearchDuration time.Duration
-	if s.ContactSearchCount > 0 {
-		avgSearchDuration = s.ContactSearchDuration / time.Duration(s.ContactSearchCount)
-	}
+	for version, count := range s.ContactSearchCount {
+		avgDuration := s.ContactSearchDuration[version] / time.Duration(count)
 
-	metrics = append(metrics,
-		cwatch.Datum("ContactSearchCount", float64(s.ContactSearchCount), types.StandardUnitCount),
-		cwatch.Datum("ContactSearchDuration", float64(avgSearchDuration)/float64(time.Second), types.StandardUnitSeconds),
-	)
+		metrics = append(metrics,
+			cwatch.Datum("ContactSearchCount", float64(count), types.StandardUnitCount, cwatch.Dimension("Version", version)),
+			cwatch.Datum("ContactSearchDuration", float64(avgDuration)/float64(time.Second), types.StandardUnitSeconds, cwatch.Dimension("Version", version)),
+		)
+	}
 
 	if advanced {
 		metrics = append(metrics,
@@ -162,10 +164,10 @@ func (c *StatsCollector) RecordWebhookCall(d time.Duration) {
 	c.mutex.Unlock()
 }
 
-func (c *StatsCollector) RecordContactSearch(d time.Duration) {
+func (c *StatsCollector) RecordContactSearch(version string, d time.Duration) {
 	c.mutex.Lock()
-	c.stats.ContactSearchCount++
-	c.stats.ContactSearchDuration += d
+	c.stats.ContactSearchCount[version]++
+	c.stats.ContactSearchDuration[version] += d
 	c.mutex.Unlock()
 }
 

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -35,10 +35,8 @@ type Stats struct {
 	WebhookCallCount    int           // number of webhook calls
 	WebhookCallDuration time.Duration // total time spent handling webhook calls
 
-	ESContactSearchCount    int           // number of contact searches against Elasticsearch
-	ESContactSearchDuration time.Duration // total time spent searching Elasticsearch
-	OSContactSearchCount    int           // number of contact searches against OpenSearch
-	OSContactSearchDuration time.Duration // total time spent searching OpenSearch
+	ContactSearchCount    int           // number of contact searches
+	ContactSearchDuration time.Duration // total time spent searching contacts
 }
 
 func newStats() *Stats {
@@ -91,20 +89,14 @@ func (s *Stats) ToMetrics(advanced bool) []types.MetricDatum {
 		cwatch.Datum("WebhookCallDuration", float64(avgWebhookDuration)/float64(time.Second), types.StandardUnitSeconds),
 	)
 
-	var avgESSearchDuration time.Duration
-	if s.ESContactSearchCount > 0 {
-		avgESSearchDuration = s.ESContactSearchDuration / time.Duration(s.ESContactSearchCount)
-	}
-	var avgOSSearchDuration time.Duration
-	if s.OSContactSearchCount > 0 {
-		avgOSSearchDuration = s.OSContactSearchDuration / time.Duration(s.OSContactSearchCount)
+	var avgSearchDuration time.Duration
+	if s.ContactSearchCount > 0 {
+		avgSearchDuration = s.ContactSearchDuration / time.Duration(s.ContactSearchCount)
 	}
 
 	metrics = append(metrics,
-		cwatch.Datum("ContactSearchCount", float64(s.ESContactSearchCount), types.StandardUnitCount, cwatch.Dimension("Backend", "es")),
-		cwatch.Datum("ContactSearchDuration", float64(avgESSearchDuration)/float64(time.Second), types.StandardUnitSeconds, cwatch.Dimension("Backend", "es")),
-		cwatch.Datum("ContactSearchCount", float64(s.OSContactSearchCount), types.StandardUnitCount, cwatch.Dimension("Backend", "os")),
-		cwatch.Datum("ContactSearchDuration", float64(avgOSSearchDuration)/float64(time.Second), types.StandardUnitSeconds, cwatch.Dimension("Backend", "os")),
+		cwatch.Datum("ContactSearchCount", float64(s.ContactSearchCount), types.StandardUnitCount),
+		cwatch.Datum("ContactSearchDuration", float64(avgSearchDuration)/float64(time.Second), types.StandardUnitSeconds),
 	)
 
 	if advanced {
@@ -170,15 +162,10 @@ func (c *StatsCollector) RecordWebhookCall(d time.Duration) {
 	c.mutex.Unlock()
 }
 
-func (c *StatsCollector) RecordContactSearch(backend string, d time.Duration) {
+func (c *StatsCollector) RecordContactSearch(d time.Duration) {
 	c.mutex.Lock()
-	if backend == "os" {
-		c.stats.OSContactSearchCount++
-		c.stats.OSContactSearchDuration += d
-	} else {
-		c.stats.ESContactSearchCount++
-		c.stats.ESContactSearchDuration += d
-	}
+	c.stats.ContactSearchCount++
+	c.stats.ContactSearchDuration += d
 	c.mutex.Unlock()
 }
 

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -25,9 +25,9 @@ func TestStats(t *testing.T) {
 	sc.RecordLLMCall("openai", "gpt-4", 7*time.Second)
 	sc.RecordLLMCall("openai", "gpt-4", 3*time.Second)
 	sc.RecordLLMCall("anthropic", "claude-3.7", 4*time.Second)
-	sc.RecordContactSearch("es", 100*time.Millisecond)
-	sc.RecordContactSearch("es", 200*time.Millisecond)
-	sc.RecordContactSearch("os", 150*time.Millisecond)
+	sc.RecordContactSearch(100 * time.Millisecond)
+	sc.RecordContactSearch(200 * time.Millisecond)
+	sc.RecordContactSearch(150 * time.Millisecond)
 
 	stats := sc.Extract()
 	assert.Equal(t, 2, stats.CronTaskCount["make_foos"])
@@ -36,16 +36,14 @@ func TestStats(t *testing.T) {
 	assert.Equal(t, 10*time.Second, stats.LLMCallDuration[runtime.LLMTypeAndModel{Type: "openai", Model: "gpt-4"}])
 	assert.Equal(t, 1, stats.LLMCallCount[runtime.LLMTypeAndModel{Type: "anthropic", Model: "claude-3.7"}])
 	assert.Equal(t, 4*time.Second, stats.LLMCallDuration[runtime.LLMTypeAndModel{Type: "anthropic", Model: "claude-3.7"}])
-	assert.Equal(t, 2, stats.ESContactSearchCount)
-	assert.Equal(t, 300*time.Millisecond, stats.ESContactSearchDuration)
-	assert.Equal(t, 1, stats.OSContactSearchCount)
-	assert.Equal(t, 150*time.Millisecond, stats.OSContactSearchDuration)
+	assert.Equal(t, 3, stats.ContactSearchCount)
+	assert.Equal(t, 450*time.Millisecond, stats.ContactSearchDuration)
 
 	datums := stats.ToMetrics(true)
-	assert.Len(t, datums, 13)
+	assert.Len(t, datums, 11)
 
 	datums = stats.ToMetrics(false)
-	assert.Len(t, datums, 10)
+	assert.Len(t, datums, 8)
 
 	// no latencies recorded yet
 	latencies, err := runtime.GetCTaskLatencies(rt.VK)

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -25,9 +25,9 @@ func TestStats(t *testing.T) {
 	sc.RecordLLMCall("openai", "gpt-4", 7*time.Second)
 	sc.RecordLLMCall("openai", "gpt-4", 3*time.Second)
 	sc.RecordLLMCall("anthropic", "claude-3.7", 4*time.Second)
-	sc.RecordContactSearch(100 * time.Millisecond)
-	sc.RecordContactSearch(200 * time.Millisecond)
-	sc.RecordContactSearch(150 * time.Millisecond)
+	sc.RecordContactSearch("v1", 100*time.Millisecond)
+	sc.RecordContactSearch("v1", 200*time.Millisecond)
+	sc.RecordContactSearch("v2", 150*time.Millisecond)
 
 	stats := sc.Extract()
 	assert.Equal(t, 2, stats.CronTaskCount["make_foos"])
@@ -36,14 +36,16 @@ func TestStats(t *testing.T) {
 	assert.Equal(t, 10*time.Second, stats.LLMCallDuration[runtime.LLMTypeAndModel{Type: "openai", Model: "gpt-4"}])
 	assert.Equal(t, 1, stats.LLMCallCount[runtime.LLMTypeAndModel{Type: "anthropic", Model: "claude-3.7"}])
 	assert.Equal(t, 4*time.Second, stats.LLMCallDuration[runtime.LLMTypeAndModel{Type: "anthropic", Model: "claude-3.7"}])
-	assert.Equal(t, 3, stats.ContactSearchCount)
-	assert.Equal(t, 450*time.Millisecond, stats.ContactSearchDuration)
+	assert.Equal(t, 2, stats.ContactSearchCount["v1"])
+	assert.Equal(t, 300*time.Millisecond, stats.ContactSearchDuration["v1"])
+	assert.Equal(t, 1, stats.ContactSearchCount["v2"])
+	assert.Equal(t, 150*time.Millisecond, stats.ContactSearchDuration["v2"])
 
 	datums := stats.ToMetrics(true)
-	assert.Len(t, datums, 11)
+	assert.Len(t, datums, 13)
 
 	datums = stats.ToMetrics(false)
-	assert.Len(t, datums, 8)
+	assert.Len(t, datums, 10)
 
 	// no latencies recorded yet
 	latencies, err := runtime.GetCTaskLatencies(rt.VK)

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	elasticURL           = "http://elastic:9200"
-	elasticContactsIndex = "test_contacts"
-	postgresDumpPath     = "./testsuite/testdata/postgres.dump"
-	dynamoTablesPath     = "./testsuite/testdata/dynamo.json"
+	elasticURL             = "http://elastic:9200"
+	elasticContactsIndex   = "test_contacts"
+	elasticContactsIndexV2 = "test_contacts-v2"
+	postgresDumpPath       = "./testsuite/testdata/postgres.dump"
+	dynamoTablesPath       = "./testsuite/testdata/dynamo.json"
 )
 
 // Refresh is our type for the pieces of org assets we want fresh (not cached)
@@ -79,6 +80,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.Port = 8091
 	cfg.DB = "postgres://mailroom_test:temba@postgres/mailroom_test?sslmode=disable&Timezone=UTC"
 	cfg.ElasticContactsIndex = elasticContactsIndex
+	cfg.ElasticContactsIndexV2 = elasticContactsIndexV2
 	cfg.Elastic = elasticURL
 	cfg.AWSAccessKeyID = "root"
 	cfg.AWSSecretAccessKey = "tembatemba"
@@ -98,6 +100,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 
 	createBucket(t, rt, rt.Config.S3AttachmentsBucket)
 	setupOpenSearch(t, rt)
+	setupElasticContactsV2(t, rt)
 
 	// create Postgres tables if necessary
 	_, err = rt.DB.Exec("SELECT * from orgs_org")
@@ -241,30 +244,35 @@ func resetElastic(t *testing.T, rt *runtime.Runtime) {
 		}
 	}
 
+	// delete and recreate the v2 contacts index
+	rt.ES.Client.Indices.Delete(elasticContactsIndexV2).Do(t.Context())
+	setupElasticContactsV2(t, rt)
+
 	ReindexElastic(t, rt)
 }
 
 func setupOpenSearch(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
 
-	client := rt.OS.Client
-
 	// create messages index template (idempotent)
 	messagesBody := ReadFile(t, absPath("./testsuite/testdata/os_messages.json"))
-	_, err := client.IndexTemplate.Create(t.Context(), opensearchapi.IndexTemplateCreateReq{
+	_, err := rt.OS.Client.IndexTemplate.Create(t.Context(), opensearchapi.IndexTemplateCreateReq{
 		IndexTemplate: rt.Config.OSMessagesIndex,
 		Body:          bytes.NewReader(messagesBody),
 	})
 	require.NoError(t, err)
+}
 
-	// create contacts index if it doesn't already exist (client returns error for 404)
-	resp, _ := client.Indices.Exists(t.Context(), opensearchapi.IndicesExistsReq{Indices: []string{rt.Config.OSContactsIndex}})
-	if resp == nil || resp.StatusCode != 200 {
-		contactsBody := ReadFile(t, absPath("./testsuite/testdata/os_contacts.json"))
-		_, err = client.Indices.Create(t.Context(), opensearchapi.IndicesCreateReq{
-			Index: rt.Config.OSContactsIndex,
-			Body:  bytes.NewReader(contactsBody),
-		})
+// setupElasticContactsV2 creates the v2 contacts index in Elastic if it doesn't already exist
+func setupElasticContactsV2(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	exists, err := rt.ES.Client.Indices.Exists(elasticContactsIndexV2).IsSuccess(t.Context())
+	require.NoError(t, err)
+
+	if !exists {
+		contactsBody := ReadFile(t, absPath("./testsuite/testdata/es_contacts.json"))
+		_, err = rt.ES.Client.Indices.Create(elasticContactsIndexV2).Raw(bytes.NewReader(contactsBody)).Do(t.Context())
 		require.NoError(t, err)
 	}
 }
@@ -274,9 +282,6 @@ func resetOpenSearch(t *testing.T, rt *runtime.Runtime) {
 
 	// delete all indexes matching the messages pattern (ignore 404 if none exist)
 	rt.OS.Client.Indices.Delete(t.Context(), opensearchapi.IndicesDeleteReq{Indices: []string{rt.Config.OSMessagesIndex + "-*"}})
-
-	// delete contacts index (ignore 404 if it doesn't exist)
-	rt.OS.Client.Indices.Delete(t.Context(), opensearchapi.IndicesDeleteReq{Indices: []string{rt.Config.OSContactsIndex}})
 }
 
 func resetDynamo(t *testing.T, rt *runtime.Runtime) {

--- a/testsuite/testdata/es_contacts.json
+++ b/testsuite/testdata/es_contacts.json
@@ -1,0 +1,187 @@
+{
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "trigrams": {
+                    "type": "custom",
+                    "tokenizer": "trigram",
+                    "filter": [
+                        "lowercase"
+                    ]
+                },
+                "locations": {
+                    "tokenizer": "location_tokenizer",
+                    "filter": [
+                        "lowercase",
+                        "word_delimiter"
+                    ]
+                },
+                "prefix": {
+                    "type": "custom",
+                    "tokenizer": "standard",
+                    "filter": [
+                        "lowercase",
+                        "prefix_filter"
+                    ]
+                },
+                "name_search": {
+                    "type": "custom",
+                    "tokenizer": "standard",
+                    "filter": [
+                        "lowercase",
+                        "max_length"
+                    ]
+                }
+            },
+            "tokenizer": {
+                "location_tokenizer": {
+                    "type": "pattern",
+                    "pattern": "(.* > )?([^>]+)",
+                    "group": 2
+                },
+                "trigram": {
+                    "type": "ngram",
+                    "min_gram": 3,
+                    "max_gram": 3
+                }
+            },
+            "normalizer": {
+                "lowercase": {
+                    "type": "custom",
+                    "char_filter": [],
+                    "filter": [
+                        "lowercase",
+                        "trim"
+                    ]
+                }
+            },
+            "filter": {
+                "prefix_filter": {
+                    "type": "edge_ngram",
+                    "min_gram": 2,
+                    "max_gram": 8
+                },
+                "max_length": {
+                    "type": "truncate",
+                    "length": 8
+                }
+            }
+        }
+    },
+    "mappings": {
+        "dynamic": false,
+        "_routing": {
+            "required": true
+        },
+        "properties": {
+            "id": {
+                "type": "long"
+            },
+            "uuid": {
+                "type": "keyword"
+            },
+            "org_id": {
+                "type": "keyword"
+            },
+            "name": {
+                "type": "text",
+                "analyzer": "prefix",
+                "search_analyzer": "name_search",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase"
+                    }
+                }
+            },
+            "status": {
+                "type": "keyword"
+            },
+            "language": {
+                "type": "keyword",
+                "normalizer": "lowercase"
+            },
+            "fields": {
+                "type": "nested",
+                "properties": {
+                    "field": {
+                        "type": "keyword"
+                    },
+                    "text": {
+                        "type": "keyword",
+                        "normalizer": "lowercase"
+                    },
+                    "number": {
+                        "type": "scaled_float",
+                        "scaling_factor": 10000,
+                        "ignore_malformed": true
+                    },
+                    "datetime": {
+                        "type": "date"
+                    },
+                    "state": {
+                        "type": "text",
+                        "analyzer": "locations"
+                    },
+                    "state_keyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase"
+                    },
+                    "district": {
+                        "type": "text",
+                        "analyzer": "locations"
+                    },
+                    "district_keyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase"
+                    },
+                    "ward": {
+                        "type": "text",
+                        "analyzer": "locations"
+                    },
+                    "ward_keyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase"
+                    }
+                }
+            },
+            "urns": {
+                "type": "nested",
+                "properties": {
+                    "path": {
+                        "type": "text",
+                        "analyzer": "trigrams",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "lowercase"
+                            }
+                        }
+                    },
+                    "scheme": {
+                        "type": "keyword",
+                        "normalizer": "lowercase"
+                    }
+                }
+            },
+            "group_ids": {
+                "type": "keyword"
+            },
+            "flow_id": {
+                "type": "keyword"
+            },
+            "flow_history_ids": {
+                "type": "keyword"
+            },
+            "tickets": {
+                "type": "integer"
+            },
+            "created_on": {
+                "type": "date"
+            },
+            "last_seen_on": {
+                "type": "date"
+            }
+        }
+    }
+}

--- a/testsuite/utils.go
+++ b/testsuite/utils.go
@@ -258,6 +258,37 @@ type SearchAssertion struct {
 	Contacts []models.ContactID `json:"contacts"`
 }
 
+// IndexOrgContacts indexes all active contacts for the given org into the v2 Elastic contacts index
+// and refreshes the index so they're immediately searchable.
+func IndexOrgContacts(t *testing.T, rt *runtime.Runtime, org *testdb.Org) {
+	t.Helper()
+
+	ctx := t.Context()
+	oa, err := models.GetOrgAssets(ctx, rt, org.ID)
+	require.NoError(t, err)
+
+	contactIDs, err := models.GetContactIDsPage(ctx, rt.DB, org.ID, models.NilContactID, 10_000)
+	require.NoError(t, err)
+
+	contacts, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
+	require.NoError(t, err)
+
+	fcs := make([]*flows.Contact, 0, len(contacts))
+	for _, mc := range contacts {
+		fc, err := mc.EngineContact(oa)
+		require.NoError(t, err)
+		fcs = append(fcs, fc)
+	}
+
+	err = search.IndexContacts(ctx, rt, oa, fcs, map[models.ContactID]models.FlowID{})
+	require.NoError(t, err)
+
+	rt.ES.Writer.Flush()
+
+	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(ctx)
+	require.NoError(t, err)
+}
+
 // ClearESContactsIndexV2 removes all documents from the v2 Elastic contacts index.
 func ClearESContactsIndexV2(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()

--- a/testsuite/utils.go
+++ b/testsuite/utils.go
@@ -258,19 +258,14 @@ type SearchAssertion struct {
 	Contacts []models.ContactID `json:"contacts"`
 }
 
-// ClearOSContactsIndex removes all documents from the OpenSearch contacts index.
-func ClearOSContactsIndex(t *testing.T, rt *runtime.Runtime) {
+// ClearESContactsIndexV2 removes all documents from the v2 Elastic contacts index.
+func ClearESContactsIndexV2(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
 
-	client := rt.OS.Client
-
-	_, err := client.Document.DeleteByQuery(t.Context(), opensearchapi.DocumentDeleteByQueryReq{
-		Indices: []string{rt.Config.OSContactsIndex},
-		Body:    strings.NewReader(`{"query": {"match_all": {}}}`),
-	})
+	_, err := rt.ES.Client.DeleteByQuery(rt.Config.ElasticContactsIndexV2).Raw(strings.NewReader(`{"query": {"match_all": {}}}`)).Do(t.Context())
 	require.NoError(t, err)
 
-	_, err = client.Indices.Refresh(t.Context(), &opensearchapi.IndicesRefreshReq{Indices: []string{rt.Config.OSContactsIndex}})
+	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(t.Context())
 	require.NoError(t, err)
 }
 

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/runner/clocks"
 	_ "github.com/nyaruka/mailroom/core/runner/handlers"
@@ -31,9 +32,24 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDeindex(t *testing.T) {
-	_, rt := testsuite.Runtime(t)
+	ctx, rt := testsuite.Runtime(t)
 
 	defer testsuite.Reset(t, rt, testsuite.ResetElastic|testsuite.ResetOpenSearch)
+
+	// index Bob and Cat into the v2 contacts index
+	oa := testdb.Org1.Load(t, rt)
+	mcs, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
+	require.NoError(t, err)
+	fcs := make([]*flows.Contact, len(mcs))
+	for i, mc := range mcs {
+		fcs[i], err = mc.EngineContact(oa)
+		require.NoError(t, err)
+	}
+	err = search.IndexContacts(ctx, rt, oa, fcs, map[models.ContactID]models.FlowID{})
+	require.NoError(t, err)
+	rt.ES.Writer.Flush()
+	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndexV2).Do(ctx)
+	require.NoError(t, err)
 
 	// index some test messages into OpenSearch for Bob (10001) and Cat (10002)
 	testsuite.IndexMessages(t, rt, []search.MessageDoc{

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -1,13 +1,10 @@
 package contact_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/nyaruka/gocommon/aws/osearch"
 	"github.com/nyaruka/gocommon/i18n"
-	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
@@ -39,18 +36,11 @@ func TestDeindex(t *testing.T) {
 	defer testsuite.Reset(t, rt, testsuite.ResetElastic|testsuite.ResetOpenSearch)
 
 	// index some test messages into OpenSearch for Bob (10001) and Cat (10002)
-	for _, msg := range []search.MessageDoc{
+	testsuite.IndexMessages(t, rt, []search.MessageDoc{
 		{CreatedOn: time.Date(2025, 5, 1, 12, 0, 0, 0, time.UTC), OrgID: testdb.Org1.ID, UUID: "01968bb7-ca00-7000-8000-000000000001", ContactUUID: testdb.Bob.UUID, Text: "hello from bob"},
 		{CreatedOn: time.Date(2025, 5, 1, 13, 0, 0, 0, time.UTC), OrgID: testdb.Org1.ID, UUID: "01968bee-b880-7000-8000-000000000002", ContactUUID: testdb.Cat.UUID, Text: "hello from cat"},
 		{CreatedOn: time.Date(2025, 5, 1, 14, 0, 0, 0, time.UTC), OrgID: testdb.Org1.ID, UUID: "01968c25-a700-7000-8000-000000000003", ContactUUID: testdb.Ann.UUID, Text: "hello from ann"},
-	} {
-		rt.OS.Writer.Queue(&osearch.Document{
-			Index:   msg.IndexName(rt.Config.OSMessagesIndex),
-			ID:      string(msg.UUID),
-			Routing: fmt.Sprintf("%d", msg.OrgID),
-			Body:    jsonx.MustMarshal(msg),
-		})
-	}
+	})
 
 	msgs := testsuite.GetIndexedMessages(t, rt, false)
 	assert.Len(t, msgs, 3)
@@ -66,7 +56,7 @@ func TestDeindex(t *testing.T) {
 func TestReindex(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetOpenSearch)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.RunWebTests(t, rt, "testdata/reindex.json")
 }

--- a/web/contact/deindex.go
+++ b/web/contact/deindex.go
@@ -16,7 +16,7 @@ func init() {
 	web.InternalRoute(http.MethodPost, "/contact/deindex", web.JSONPayload(handleDeindex))
 }
 
-// Requests de-indexing of the given contacts from Elastic and OpenSearch indexes.
+// Requests de-indexing of the given contacts from Elastic indexes.
 //
 //	{
 //	  "org_id": 1,
@@ -29,7 +29,7 @@ type deindexRequest struct {
 }
 
 func handleDeindex(ctx context.Context, rt *runtime.Runtime, r *deindexRequest) (any, int, error) {
-	esDeleted, osDeleted, err := search.DeindexContactsByID(ctx, rt, r.OrgID, r.ContactIDs)
+	deindexed, err := search.DeindexContactsByID(ctx, rt, r.OrgID, r.ContactIDs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error de-indexing contacts in org #%d: %w", r.OrgID, err)
 	}
@@ -38,5 +38,5 @@ func handleDeindex(ctx context.Context, rt *runtime.Runtime, r *deindexRequest) 
 		return nil, 0, fmt.Errorf("error de-indexing messages in org #%d: %w", r.OrgID, err)
 	}
 
-	return map[string]any{"es_deindexed": esDeleted, "os_deindexed": osDeleted}, http.StatusOK, nil
+	return map[string]any{"deindexed": deindexed}, http.StatusOK, nil
 }

--- a/web/contact/reindex.go
+++ b/web/contact/reindex.go
@@ -16,7 +16,7 @@ func init() {
 	web.InternalRoute(http.MethodPost, "/contact/reindex", web.JSONPayload(handleReindex))
 }
 
-// Loads the given contacts from the database and reindexes them in OpenSearch.
+// Loads the given contacts from the database and reindexes them in Elastic.
 //
 //	{
 //	  "org_id": 1,

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -3,8 +3,6 @@ package contact
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"math/rand"
 	"net/http"
 	"time"
 
@@ -71,36 +69,13 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		r.Limit = 50
 	}
 
-	// perform our search against ES (source of truth)
-	esStart := time.Now()
+	// perform our search against ES
+	start := time.Now()
 	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, false)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
 	}
-	rt.Stats.RecordContactSearch("es", time.Since(esStart))
-
-	// also search OpenSearch for a proportion of requests and compare results
-	if rt.Config.OSContactsSearchVerify > 0 && rand.Float64() < rt.Config.OSContactsSearchVerify {
-		osStart := time.Now()
-		_, osHits, osTotal, osErr := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
-		rt.Stats.RecordContactSearch("os", time.Since(osStart))
-
-		if osErr != nil {
-			slog.Warn("error searching OpenSearch for comparison", "org_id", r.OrgID, "error", osErr)
-		} else if total != osTotal || !contactIDsEqual(hits, osHits) {
-			example := findMismatchExample(hits, osHits)
-			slog.Error("ES/OpenSearch search mismatch",
-				"org_id", r.OrgID,
-				"group_id", r.GroupID,
-				"query", r.Query,
-				"es_total", total,
-				"os_total", osTotal,
-				"es_page_count", len(hits),
-				"os_page_count", len(osHits),
-				"example_contact", example,
-			)
-		}
-	}
+	rt.Stats.RecordContactSearch(time.Since(start))
 
 	// normalize and inspect the query
 	normalized := ""
@@ -120,42 +95,4 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 	}
 
 	return response, http.StatusOK, nil
-}
-
-// contactIDsEqual returns true if two slices contain the same contact IDs in the same order
-func contactIDsEqual(a, b []models.ContactID) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// findMismatchExample returns a description of the first contact ID that differs between ES and OS results
-func findMismatchExample(esIDs, osIDs []models.ContactID) string {
-	osSet := make(map[models.ContactID]bool, len(osIDs))
-	for _, id := range osIDs {
-		osSet[id] = true
-	}
-	for _, id := range esIDs {
-		if !osSet[id] {
-			return fmt.Sprintf("contact %d in ES but not OS", id)
-		}
-	}
-
-	esSet := make(map[models.ContactID]bool, len(esIDs))
-	for _, id := range esIDs {
-		esSet[id] = true
-	}
-	for _, id := range osIDs {
-		if !esSet[id] {
-			return fmt.Sprintf("contact %d in OS but not ES", id)
-		}
-	}
-
-	return "same IDs but different order"
 }

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -3,6 +3,8 @@ package contact
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -69,13 +71,36 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		r.Limit = 50
 	}
 
-	// perform our search against ES
-	start := time.Now()
+	// perform our search against the v1 ES index (source of truth)
+	v1Start := time.Now()
 	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, false)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
 	}
-	rt.Stats.RecordContactSearch(time.Since(start))
+	rt.Stats.RecordContactSearch("v1", time.Since(v1Start))
+
+	// also search the v2 index for a proportion of requests to verify consistency
+	if rt.Config.ElasticContactsV2Verify > 0 && rand.Float64() < rt.Config.ElasticContactsV2Verify {
+		v2Start := time.Now()
+		_, v2Hits, v2Total, v2Err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
+		rt.Stats.RecordContactSearch("v2", time.Since(v2Start))
+
+		if v2Err != nil {
+			slog.Warn("error searching v2 contacts index for comparison", "org_id", r.OrgID, "error", v2Err)
+		} else if total != v2Total || !contactIDsEqual(hits, v2Hits) {
+			example := findMismatchExample(hits, v2Hits)
+			slog.Error("v1/v2 contacts index search mismatch",
+				"org_id", r.OrgID,
+				"group_id", r.GroupID,
+				"query", r.Query,
+				"v1_total", total,
+				"v2_total", v2Total,
+				"v1_page_count", len(hits),
+				"v2_page_count", len(v2Hits),
+				"example_contact", example,
+			)
+		}
+	}
 
 	// normalize and inspect the query
 	normalized := ""
@@ -95,4 +120,42 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 	}
 
 	return response, http.StatusOK, nil
+}
+
+// contactIDsEqual returns true if two slices contain the same contact IDs in the same order
+func contactIDsEqual(a, b []models.ContactID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// findMismatchExample returns a description of the first contact ID that differs between v1 and v2 results
+func findMismatchExample(v1IDs, v2IDs []models.ContactID) string {
+	v2Set := make(map[models.ContactID]bool, len(v2IDs))
+	for _, id := range v2IDs {
+		v2Set[id] = true
+	}
+	for _, id := range v1IDs {
+		if !v2Set[id] {
+			return fmt.Sprintf("contact %d in v1 but not v2", id)
+		}
+	}
+
+	v1Set := make(map[models.ContactID]bool, len(v1IDs))
+	for _, id := range v1IDs {
+		v1Set[id] = true
+	}
+	for _, id := range v2IDs {
+		if !v1Set[id] {
+			return fmt.Sprintf("contact %d in v2 but not v1", id)
+		}
+	}
+
+	return "same IDs but different order"
 }

--- a/web/contact/testdata/deindex.json
+++ b/web/contact/testdata/deindex.json
@@ -25,8 +25,7 @@
         },
         "status": 200,
         "response": {
-            "es_deindexed": 2,
-            "os_deindexed": 0
+            "deindexed": 2
         }
     }
 ]


### PR DESCRIPTION
## Summary

- Contacts are now indexed to a new `contacts-v2` Elastic index (configurable via `ElasticContactsIndexV2`, default `contacts-v2`) written by mailroom's existing ES writer/spool architecture, replacing the previous OpenSearch indexing
- The existing rp-indexer `contacts` alias index is unchanged — both indexes coexist
- The `os bool` param in contact search functions is repurposed: `true` now queries the v2 ES index (`ElasticContactsIndexV2`) instead of OpenSearch, with no `is_active` filter (since this index only contains active contacts)
- Removes the OS comparison/verification logic from the contact search web handler
- Simplifies `DeindexContactsByID` to return `(int, error)` (was `(int, int, error)`)
- Simplifies contact search stats to a single `ContactSearchCount`/`ContactSearchDuration` (removes ES/OS split)
- Messages remain on OpenSearch

## Test plan

- [x] `./core/search/...` passes
- [x] `./web/contact/...` passes
- [x] `./core/runner/handlers/...` passes
- [x] `./runtime/...` passes
- [x] Full `./...` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)