### PR TITLE
Add messages mode to mrindex command

### DIFF
--- a/cmd/mrindex/main.go
+++ b/cmd/mrindex/main.go
@@ -152,17 +152,17 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 	return nil
 }
 
-var sqlSelectMessagesForSearch = fmt.Sprintf(`
+const sqlSelectMessagesForSearch = `
 SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid
   FROM msgs_msg m
   JOIN contacts_contact c ON c.id = m.contact_id
  WHERE (m.direction = 'I' OR (m.broadcast_id IS NULL AND m.created_by_id IS NOT NULL))
-   AND LENGTH(m.text) >= %d
+   AND LENGTH(m.text) >= $3
    AND m.visibility IN ('V', 'A')
    AND m.msg_type != 'V'
    AND m.uuid < $1
  ORDER BY m.uuid DESC
- LIMIT $2`, search.MessageTextMinLength)
+ LIMIT $2`
 
 func indexAllMessages(ctx context.Context, rt *runtime.Runtime, startUUID string) error {
 	if startUUID == "" {
@@ -173,7 +173,7 @@ func indexAllMessages(ctx context.Context, rt *runtime.Runtime, startUUID string
 	lastUUID := ""
 
 	for {
-		rows, err := rt.DB.QueryContext(ctx, sqlSelectMessagesForSearch, startUUID, batchSize)
+		rows, err := rt.DB.QueryContext(ctx, sqlSelectMessagesForSearch, startUUID, batchSize, search.MessageTextMinLength)
 		if err != nil {
 			return fmt.Errorf("error querying messages: %w", err)
 		}

--- a/cmd/mrindex/main.go
+++ b/cmd/mrindex/main.go
@@ -152,17 +152,17 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 	return nil
 }
 
-const sqlSelectMessagesForSearch = `
+var sqlSelectMessagesForSearch = fmt.Sprintf(`
 SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid
   FROM msgs_msg m
   JOIN contacts_contact c ON c.id = m.contact_id
  WHERE (m.direction = 'I' OR (m.broadcast_id IS NULL AND m.created_by_id IS NOT NULL))
-   AND LENGTH(m.text) >= 2
+   AND LENGTH(m.text) >= %d
    AND m.visibility IN ('V', 'A')
    AND m.msg_type != 'V'
    AND m.uuid < $1
  ORDER BY m.uuid DESC
- LIMIT $2`
+ LIMIT $2`, search.MessageTextMinLength)
 
 func indexAllMessages(ctx context.Context, rt *runtime.Runtime, startUUID string) error {
 	if startUUID == "" {

--- a/cmd/mrindex/main.go
+++ b/cmd/mrindex/main.go
@@ -2,22 +2,27 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/nyaruka/gocommon/aws/osearch"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/search"
 	"github.com/nyaruka/mailroom/runtime"
+	"github.com/nyaruka/null/v3"
 )
 
-const contactBatchSize = 500
+const batchSize = 500
 
-// command line tool to re-index all contacts in the database to Elastic.
+// command line tool to re-index all contacts or messages.
 //
-// go install github.com/nyaruka/mailroom/cmd/mrindex; mrindex
+// go install github.com/nyaruka/mailroom/cmd/mrindex; mrindex <contacts|messages>
 func main() {
 	cfg, err := runtime.LoadConfig()
 	if err != nil {
@@ -39,15 +44,35 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.TODO()
+	// parse mode from args
+	flags := flag.NewFlagSet("mrindex", flag.ExitOnError)
+	startUUID := flags.String("start-uuid", "", "UUID to start from (messages mode only, works backwards from here)")
+	flags.Parse(os.Args[1:])
 
-	if err := indexAllContacts(ctx, rt); err != nil {
-		rt.Stop()
-		fmt.Printf("error re-indexing contacts: %s\n", err)
+	mode := flags.Arg(0)
+	if mode != "contacts" && mode != "messages" {
+		fmt.Println("usage: mrindex [--start-uuid UUID] <contacts|messages>")
 		os.Exit(1)
 	}
 
-	// stop flushes remaining queued items to Elastic and spool
+	ctx := context.TODO()
+
+	switch mode {
+	case "contacts":
+		if err := indexAllContacts(ctx, rt); err != nil {
+			rt.Stop()
+			fmt.Printf("error re-indexing contacts: %s\n", err)
+			os.Exit(1)
+		}
+	case "messages":
+		if err := indexAllMessages(ctx, rt, *startUUID); err != nil {
+			rt.Stop()
+			fmt.Printf("error re-indexing messages: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// stop flushes remaining queued items to Elastic/OpenSearch and spool
 	rt.Stop()
 }
 
@@ -69,7 +94,7 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 		fmt.Printf(" > Indexing org #%d", orgID)
 
 		for {
-			contactIDs, err := models.GetContactIDsPage(ctx, rt.DB, orgID, afterID, contactBatchSize)
+			contactIDs, err := models.GetContactIDsPage(ctx, rt.DB, orgID, afterID, batchSize)
 			if err != nil {
 				return fmt.Errorf("error getting contact IDs for org #%d: %w", orgID, err)
 			}
@@ -114,7 +139,7 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 				fmt.Print(".")
 			}
 
-			if len(contactIDs) < contactBatchSize {
+			if len(contactIDs) < batchSize {
 				break
 			}
 		}
@@ -124,5 +149,96 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 	}
 
 	fmt.Printf("Completed indexing (%d indexed, %d skipped)\n", totalIndexed, totalSkipped)
+	return nil
+}
+
+const sqlSelectMessagesForSearch = `
+SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid
+  FROM msgs_msg m
+  JOIN contacts_contact c ON c.id = m.contact_id
+ WHERE (m.direction = 'I' OR (m.broadcast_id IS NULL AND m.created_by_id IS NOT NULL))
+   AND LENGTH(m.text) >= 2
+   AND m.visibility IN ('V', 'A')
+   AND m.msg_type != 'V'
+   AND m.uuid < $1
+ ORDER BY m.uuid DESC
+ LIMIT $2`
+
+func indexAllMessages(ctx context.Context, rt *runtime.Runtime, startUUID string) error {
+	if startUUID == "" {
+		startUUID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	}
+
+	numIndexed := 0
+	lastUUID := ""
+
+	for {
+		rows, err := rt.DB.QueryContext(ctx, sqlSelectMessagesForSearch, startUUID, batchSize)
+		if err != nil {
+			return fmt.Errorf("error querying messages: %w", err)
+		}
+
+		batchCount := 0
+		var lastCreatedOn time.Time
+
+		for rows.Next() {
+			var msgUUID, contactUUID string
+			var orgID models.OrgID
+			var text string
+			var createdOn time.Time
+			var ticketUUID null.String
+
+			if err := rows.Scan(&msgUUID, &orgID, &text, &createdOn, &ticketUUID, &contactUUID); err != nil {
+				rows.Close()
+				return fmt.Errorf("error scanning message row: %w", err)
+			}
+
+			msg := &search.MessageDoc{
+				CreatedOn:   createdOn,
+				UUID:        flows.EventUUID(msgUUID),
+				OrgID:       orgID,
+				ContactUUID: flows.ContactUUID(contactUUID),
+				Text:        text,
+				InTicket:    ticketUUID != "",
+			}
+
+			doc, err := json.Marshal(msg)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("error marshalling message doc: %w", err)
+			}
+
+			rt.OS.Writer.Queue(&osearch.Document{
+				Index:   msg.IndexName(rt.Config.OSMessagesIndex),
+				ID:      string(msg.UUID),
+				Routing: fmt.Sprintf("%d", msg.OrgID),
+				Body:    doc,
+			})
+
+			batchCount++
+			lastUUID = msgUUID
+			lastCreatedOn = createdOn
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating message rows: %w", err)
+		}
+		rows.Close()
+
+		if batchCount == 0 {
+			break
+		}
+
+		numIndexed += batchCount
+		startUUID = lastUUID
+
+		fmt.Printf(" > Indexed %d messages (last uuid=%s, created_on=%s)\n", numIndexed, lastUUID, lastCreatedOn.Format(time.RFC3339))
+
+		if batchCount < batchSize {
+			break
+		}
+	}
+
+	fmt.Printf("Done. Indexed %d messages total.\n", numIndexed)
 	return nil
 }


### PR DESCRIPTION
## Summary
- Extends `mrindex` to accept `contacts` or `messages` as a mode argument
- `mrindex messages` backfills historical messages from PostgreSQL into the OpenSearch messages index, replacing the Django `backfill_msg_search` management command
- Supports `--start-uuid` flag for resuming large backfills

## Test plan
- [x] `go build` and `go vet` pass
- [ ] Run `mrindex contacts` and verify existing behavior unchanged
- [ ] Run `mrindex messages` against a test database and verify messages appear in OpenSearch
- [ ] Run `mrindex --start-uuid <uuid> messages` to verify resume works

🤖 Generated with [Claude Code](https://claude.com/claude-code)