### PR TITLE
Internalize v1/v2 ES index comparison into search functions

### DIFF
--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -226,7 +226,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 				require.NoError(t, err)
 
 				for _, sa := range tc.AssertSearch {
-					ids, err := search.GetContactIDsForQuery(ctx, rt, oa2, nil, models.ContactStatusActive, sa.Query, -1, true /*v2*/)
+					ids, err := search.GetContactIDsForQueryV2(ctx, rt, oa2, nil, models.ContactStatusActive, sa.Query, -1)
 					assert.NoError(t, err, "%s: search query '%s' failed", tc.Label, sa.Query)
 					assert.ElementsMatch(t, sa.Contacts, ids, "%s: search query '%s' returned wrong contacts", tc.Label, sa.Query)
 				}

--- a/core/search/resolve.go
+++ b/core/search/resolve.go
@@ -93,7 +93,7 @@ func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 			return nil, fmt.Errorf("error building query: %w", err)
 		}
 
-		matches, err = GetContactIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, query, limit, false)
+		matches, err = GetContactIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, query, limit)
 		if err != nil {
 			return nil, fmt.Errorf("error performing contact search: %w", err)
 		}

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -70,7 +70,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 }
 
 // GetContactTotal returns the total count of matching contacts for the given query
-func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, query string, v2 bool) (*contactql.ContactQuery, int64, error) {
+func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, query string) (*contactql.ContactQuery, int64, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -89,6 +89,24 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
+	v1Count, err := getContactTotal(ctx, rt, oa, group, status, parsed, false)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if rt.Config.ElasticContactsV2Verify {
+		v2Count, v2Err := getContactTotal(ctx, rt, oa, group, status, parsed, true)
+		if v2Err != nil {
+			slog.Warn("error counting v2 contacts index for comparison", "org_id", oa.OrgID(), "error", v2Err)
+		} else if v1Count != v2Count {
+			slog.Error("v1/v2 contacts index count mismatch", "org_id", oa.OrgID(), "query", query, "v1_total", v1Count, "v2_total", v2Count)
+		}
+	}
+
+	return parsed, v1Count, nil
+}
+
+func getContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, parsed *contactql.ContactQuery, v2 bool) (int64, error) {
 	eq := buildContactQuery(oa, group, status, nil, parsed, v2)
 	src := map[string]any{"query": eq}
 
@@ -99,16 +117,15 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 
 	count, err := rt.ES.Client.Count().Index(index).Routing(oa.OrgID().String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
 	if err != nil {
-		return nil, 0, fmt.Errorf("error performing count: %w", err)
+		return 0, fmt.Errorf("error performing count: %w", err)
 	}
 
-	return parsed, count.Count, nil
+	return count.Count, nil
 }
 
 // GetContactIDsForQueryPage returns a page of contact ids for the given query and sort
-func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int, v2 bool) (*contactql.ContactQuery, []models.ContactID, int64, error) {
+func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int) (*contactql.ContactQuery, []models.ContactID, int64, error) {
 	env := oa.Env()
-	start := time.Now()
 	var parsed *contactql.ContactQuery
 	var err error
 
@@ -126,12 +143,45 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, v2)
-
 	fieldSort, err := es.ToElasticSort(sort, oa.SessionAssets())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
 	}
+
+	v1Start := time.Now()
+	v1Hits, v1Total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, false)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	rt.Stats.RecordContactSearch("v1", time.Since(v1Start))
+
+	if rt.Config.ElasticContactsV2Verify {
+		v2Start := time.Now()
+		v2Hits, v2Total, v2Err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, true)
+		rt.Stats.RecordContactSearch("v2", time.Since(v2Start))
+
+		if v2Err != nil {
+			slog.Warn("error searching v2 contacts index for comparison", "org_id", oa.OrgID(), "error", v2Err)
+		} else if v1Total != v2Total || !contactIDsEqual(v1Hits, v2Hits) {
+			example := findMismatchExample(v1Hits, v2Hits)
+			slog.Error("v1/v2 contacts index search mismatch",
+				"org_id", oa.OrgID(),
+				"query", query,
+				"v1_total", v1Total,
+				"v2_total", v2Total,
+				"v1_page_count", len(v1Hits),
+				"v2_page_count", len(v2Hits),
+				"example_contact", example,
+			)
+		}
+	}
+
+	return parsed, v1Hits, v1Total, nil
+}
+
+func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, v2 bool) ([]models.ContactID, int64, error) {
+	start := time.Now()
+	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, v2)
 
 	index := rt.Config.ElasticContactsIndex
 	if v2 {
@@ -149,19 +199,19 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 
 	results, err := rt.ES.Client.Search().Index(index).Routing(oa.OrgID().String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("error performing query: %w", err)
+		return nil, 0, fmt.Errorf("error performing query: %w", err)
 	}
 
 	ids := make([]models.ContactID, 0, pageSize)
 	ids = appendIDsFromESHits(ids, results.Hits.Hits)
 
-	slog.Debug("paged contact query complete", "org_id", oa.OrgID(), "query", query, "elapsed", time.Since(start), "page_count", len(ids), "total_count", results.Hits.Total.Value)
+	slog.Debug("paged contact query complete", "org_id", oa.OrgID(), "index", index, "elapsed", time.Since(start), "page_count", len(ids), "total_count", results.Hits.Total.Value)
 
-	return parsed, ids, results.Hits.Total.Value, nil
+	return ids, results.Hits.Total.Value, nil
 }
 
 // GetContactIDsForQuery returns up to limit the contact ids that match the given query, sorted by id. Limit of -1 means return all.
-func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int, v2 bool) ([]models.ContactID, error) {
+func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]models.ContactID, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -180,14 +230,52 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		group = nil
 	}
 
-	eq := buildContactQuery(oa, group, status, nil, parsed, v2)
-
-	index := rt.Config.ElasticContactsIndex
-	if v2 {
-		index = rt.Config.ElasticContactsIndexV2
+	v1Eq := buildContactQuery(oa, group, status, nil, parsed, false)
+	v1IDs, err := getContactIDsForQuery(ctx, rt, oa, rt.Config.ElasticContactsIndex, v1Eq, limit)
+	if err != nil {
+		return nil, err
 	}
 
-	return getContactIDsForQuery(ctx, rt, oa, index, eq, limit)
+	if rt.Config.ElasticContactsV2Verify {
+		v2Eq := buildContactQuery(oa, group, status, nil, parsed, true)
+		v2IDs, v2Err := getContactIDsForQuery(ctx, rt, oa, rt.Config.ElasticContactsIndexV2, v2Eq, limit)
+		if v2Err != nil {
+			slog.Warn("error searching v2 contacts index for comparison", "org_id", oa.OrgID(), "error", v2Err)
+		} else if !contactIDsEqual(v1IDs, v2IDs) {
+			example := findMismatchExample(v1IDs, v2IDs)
+			slog.Error("v1/v2 contacts index search mismatch",
+				"org_id", oa.OrgID(),
+				"query", query,
+				"v1_count", len(v1IDs),
+				"v2_count", len(v2IDs),
+				"example_contact", example,
+			)
+		}
+	}
+
+	return v1IDs, nil
+}
+
+// GetContactIDsForQueryV2 searches only the v2 contacts index. This is intended for tests that verify v2 indexing.
+func GetContactIDsForQueryV2(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]models.ContactID, error) {
+	env := oa.Env()
+	var parsed *contactql.ContactQuery
+	var err error
+
+	if query != "" {
+		parsed, err = contactql.ParseQuery(env, query, oa.SessionAssets())
+		if err != nil {
+			return nil, fmt.Errorf("error parsing query: %s: %w", query, err)
+		}
+	}
+
+	if group != nil && !group.Visible() {
+		status = models.ContactStatus(group.Type())
+		group = nil
+	}
+
+	eq := buildContactQuery(oa, group, status, nil, parsed, true)
+	return getContactIDsForQuery(ctx, rt, oa, rt.Config.ElasticContactsIndexV2, eq, limit)
 }
 
 func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, index string, eq elastic.Query, limit int) ([]models.ContactID, error) {
@@ -272,4 +360,42 @@ func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.Cont
 		}
 	}
 	return ids
+}
+
+// contactIDsEqual returns true if two slices contain the same contact IDs in the same order
+func contactIDsEqual(a, b []models.ContactID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// findMismatchExample returns a description of the first contact ID that differs between v1 and v2 results
+func findMismatchExample(v1IDs, v2IDs []models.ContactID) string {
+	v2Set := make(map[models.ContactID]bool, len(v2IDs))
+	for _, id := range v2IDs {
+		v2Set[id] = true
+	}
+	for _, id := range v1IDs {
+		if !v2Set[id] {
+			return fmt.Sprintf("contact %d in v1 but not v2", id)
+		}
+	}
+
+	v1Set := make(map[models.ContactID]bool, len(v1IDs))
+	for _, id := range v1IDs {
+		v1Set[id] = true
+	}
+	for _, id := range v2IDs {
+		if !v1Set[id] {
+			return fmt.Sprintf("contact %d in v2 but not v1", id)
+		}
+	}
+
+	return "same IDs but different order"
 }

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -44,7 +44,7 @@ func TestGetContactTotal(t *testing.T) {
 			group = oa.GroupByID(tc.group.ID)
 		}
 
-		_, total, err := search.GetContactTotal(ctx, rt, oa, group, tc.query, false)
+		_, total, err := search.GetContactTotal(ctx, rt, oa, group, tc.query)
 
 		if tc.expectedError != "" {
 			assert.EqualError(t, err, tc.expectedError)
@@ -107,7 +107,7 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 	for i, tc := range tcs {
 		group := oa.GroupByID(tc.group.ID)
 
-		_, ids, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, tc.excludeIDs, tc.query, tc.sort, 0, 50, false)
+		_, ids, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, tc.excludeIDs, tc.query, tc.sort, 0, 50)
 
 		if tc.expectedError != "" {
 			assert.EqualError(t, err, tc.expectedError)
@@ -212,7 +212,7 @@ func TestGetContactIDsForQuery(t *testing.T) {
 			group = oa.GroupByID(tc.group.ID)
 		}
 
-		ids, err := search.GetContactIDsForQuery(ctx, rt, oa, group, tc.status, tc.query, tc.limit, false)
+		ids, err := search.GetContactIDsForQuery(ctx, rt, oa, group, tc.status, tc.query, tc.limit)
 
 		if tc.expectedError != "" {
 			assert.EqualError(t, err, tc.expectedError)

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -86,7 +86,7 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	}
 
 	// get contacts that match the query from search
-	matchedIDs, err := search.GetContactIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, t.Query, -1, false)
+	matchedIDs, err := search.GetContactIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, t.Query, -1)
 
 	if err != nil {
 		var qerr *contactql.QueryError

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	ElasticPassword      string `help:"the password for ElasticSearch if using basic auth"`
 	ElasticContactsIndex       string  `help:"the name of index alias for contacts"`
 	ElasticContactsIndexV2     string  `help:"the name of the v2 contacts index written by mailroom"`
-	ElasticContactsV2Verify    float64 `help:"proportion of contact searches to also run against the v2 index for comparison (0 to disable)"`
+	ElasticContactsV2Verify    bool    `help:"whether to also run contact searches against the v2 index for comparison"`
 
 	OSEndpoint      string `name:"os_endpoint"        validate:"url" help:"the URL of your OpenSearch endpoint"`
 	OSMessagesIndex string `name:"os_messages_index"                 help:"the base name for monthly message indexes (e.g. messages -> messages-2026-02)"`

--- a/web/contact/export.go
+++ b/web/contact/export.go
@@ -48,7 +48,7 @@ func handleExport(ctx context.Context, rt *runtime.Runtime, r *exportRequest) (a
 		return errors.New("no such group"), http.StatusBadRequest, nil
 	}
 
-	ids, err := search.GetContactIDsForQuery(ctx, rt, oa, group, models.NilContactStatus, r.Query, -1, false)
+	ids, err := search.GetContactIDsForQuery(ctx, rt, oa, group, models.NilContactStatus, r.Query, -1)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error querying export: %w", err)
 	}

--- a/web/contact/export_preview.go
+++ b/web/contact/export_preview.go
@@ -57,7 +57,7 @@ func handleExportPreview(ctx context.Context, rt *runtime.Runtime, r *previewReq
 		return &previewResponse{Total: count}, http.StatusOK, nil
 	}
 
-	_, total, err := search.GetContactTotal(ctx, rt, oa, group, r.Query, false)
+	_, total, err := search.GetContactTotal(ctx, rt, oa, group, r.Query)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error querying preview: %w", err)
 	}

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -3,10 +3,7 @@ package contact
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/core/models"
@@ -71,35 +68,9 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		r.Limit = 50
 	}
 
-	// perform our search against the v1 ES index (source of truth)
-	v1Start := time.Now()
-	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, false)
+	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
-	}
-	rt.Stats.RecordContactSearch("v1", time.Since(v1Start))
-
-	// also search the v2 index for a proportion of requests to verify consistency
-	if rt.Config.ElasticContactsV2Verify > 0 && rand.Float64() < rt.Config.ElasticContactsV2Verify {
-		v2Start := time.Now()
-		_, v2Hits, v2Total, v2Err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit, true)
-		rt.Stats.RecordContactSearch("v2", time.Since(v2Start))
-
-		if v2Err != nil {
-			slog.Warn("error searching v2 contacts index for comparison", "org_id", r.OrgID, "error", v2Err)
-		} else if total != v2Total || !contactIDsEqual(hits, v2Hits) {
-			example := findMismatchExample(hits, v2Hits)
-			slog.Error("v1/v2 contacts index search mismatch",
-				"org_id", r.OrgID,
-				"group_id", r.GroupID,
-				"query", r.Query,
-				"v1_total", total,
-				"v2_total", v2Total,
-				"v1_page_count", len(hits),
-				"v2_page_count", len(v2Hits),
-				"example_contact", example,
-			)
-		}
 	}
 
 	// normalize and inspect the query
@@ -120,42 +91,4 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 	}
 
 	return response, http.StatusOK, nil
-}
-
-// contactIDsEqual returns true if two slices contain the same contact IDs in the same order
-func contactIDsEqual(a, b []models.ContactID) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// findMismatchExample returns a description of the first contact ID that differs between v1 and v2 results
-func findMismatchExample(v1IDs, v2IDs []models.ContactID) string {
-	v2Set := make(map[models.ContactID]bool, len(v2IDs))
-	for _, id := range v2IDs {
-		v2Set[id] = true
-	}
-	for _, id := range v1IDs {
-		if !v2Set[id] {
-			return fmt.Sprintf("contact %d in v1 but not v2", id)
-		}
-	}
-
-	v1Set := make(map[models.ContactID]bool, len(v1IDs))
-	for _, id := range v1IDs {
-		v1Set[id] = true
-	}
-	for _, id := range v2IDs {
-		if !v1Set[id] {
-			return fmt.Sprintf("contact %d in v2 but not v1", id)
-		}
-	}
-
-	return "same IDs but different order"
 }

--- a/web/flow/start_preview.go
+++ b/web/flow/start_preview.go
@@ -82,7 +82,7 @@ func handleStartPreview(ctx context.Context, rt *runtime.Runtime, r *previewRequ
 		return &previewResponse{Query: "", Total: 0}, http.StatusOK, nil
 	}
 
-	parsedQuery, total, err := search.GetContactTotal(ctx, rt, oa, nil, query, false)
+	parsedQuery, total, err := search.GetContactTotal(ctx, rt, oa, nil, query)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error querying preview: %w", err)
 	}

--- a/web/msg/broadcast_preview.go
+++ b/web/msg/broadcast_preview.go
@@ -74,7 +74,7 @@ func handleBroadcastPreview(ctx context.Context, rt *runtime.Runtime, r *preview
 		return &previewResponse{Query: "", Total: 0}, http.StatusOK, nil
 	}
 
-	parsedQuery, total, err := search.GetContactTotal(ctx, rt, oa, nil, query, false)
+	parsedQuery, total, err := search.GetContactTotal(ctx, rt, oa, nil, query)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error querying preview: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Remove `v2 bool` parameter from public search API (`GetContactTotal`, `GetContactIDsForQueryPage`, `GetContactIDsForQuery`)
- These functions now always search v1 and, when `ElasticContactsV2Verify` is enabled, also search v2 internally to compare results and log mismatches
- All search paths (contact search, flow starts, broadcasts, exports, group population) now get v2 verification automatically
- Simplify `ElasticContactsV2Verify` from `float64` to `bool` since we want all-or-nothing verification per deployment

## Test plan
- [x] All affected package tests pass (`core/search`, `web/contact`, `web/flow`, `web/msg`, `core/tasks`, `core/runner/handlers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)