### PR TITLE
Use contact UUID as _id in v3 contacts ES index

### DIFF
--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -38,10 +38,10 @@ type ContactDocURN struct {
 	Path   string `json:"path"`
 }
 
-// ContactDoc represents a contact document in the contacts index. DBID is used as the document _id.
+// ContactDoc represents a contact document in the contacts index. UUID is used as the document _id.
 type ContactDoc struct {
-	DBID           models.ContactID     `json:"id"` // also used as _id
-	UUID           flows.ContactUUID    `json:"uuid"`
+	DBID           models.ContactID     `json:"id"`
+	UUID           flows.ContactUUID    `json:"-"` // used as _id, not in body
 	OrgID          models.OrgID         `json:"org_id"`
 	Name           string               `json:"name,omitempty"`
 	Status         models.ContactStatus `json:"status"`
@@ -161,7 +161,7 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 
 		rt.ES.Writer.Queue(&elastic.Document{
 			Index:   rt.Config.ElasticContactsIndex,
-			ID:      doc.DBID.String(),
+			ID:      string(doc.UUID),
 			Routing: doc.OrgID.String(),
 			Version: time.Now().UnixNano(),
 			Body:    body,
@@ -171,11 +171,16 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 	return nil
 }
 
-// DeindexContactsByID de-indexes the contacts with the given IDs from Elastic
-func DeindexContactsByID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactIDs []models.ContactID) (int, error) {
+// DeindexContactsByUUID de-indexes the contacts with the given UUIDs from Elastic
+func DeindexContactsByUUID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactUUIDs []flows.ContactUUID) (int, error) {
+	ids := make([]string, len(contactUUIDs))
+	for i, uuid := range contactUUIDs {
+		ids[i] = string(uuid)
+	}
+
 	cmds := &bytes.Buffer{}
-	for _, id := range contactIDs {
-		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": id.String()}}))
+	for _, id := range ids {
+		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": id}}))
 		cmds.WriteString("\n")
 	}
 

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -132,17 +132,17 @@ func TestDeindexContacts(t *testing.T) {
 	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
 	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
-	// DeindexContactsByID operates on the v2 index
-	deindexedByID, err := search.DeindexContactsByID(ctx, rt, testdb.Org1.ID, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
+	// DeindexContactsByUUID operates on the v3 index
+	deindexedByUUID, err := search.DeindexContactsByUUID(ctx, rt, testdb.Org1.ID, []flows.ContactUUID{testdb.Bob.UUID, testdb.Cat.UUID})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, deindexedByID)
+	assert.Equal(t, 2, deindexedByUUID)
 
 	refreshV2()
 
 	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 122)
 	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
-	// DeindexContactsByOrg also operates on the v2 index
+	// DeindexContactsByOrg also operates on the v3 index
 	deindexed, err := search.DeindexContactsByOrg(ctx, rt, testdb.Org1.ID, 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 100, deindexed)

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -156,7 +156,8 @@ func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, own)
 
 	src := map[string]any{
-		"_source":          []string{"id"},
+		"_source":          false,
+		"docvalue_fields":  []string{"id"},
 		"query":            eq,
 		"sort":             []any{fieldSort},
 		"from":             offset,
@@ -209,7 +210,8 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	// if limit provided that can be done with single search, do that
 	if limit >= 0 && limit <= 10_000 {
 		src := map[string]any{
-			"_source":          []string{"id"},
+			"_source":          false,
+		"docvalue_fields":  []string{"id"},
 			"query":            eq,
 			"sort":             []any{sort},
 			"from":             0,
@@ -238,7 +240,8 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	}()
 
 	src := map[string]any{
-		"_source":          []string{"id"},
+		"_source":          false,
+		"docvalue_fields":  []string{"id"},
 		"query":            eq,
 		"sort":             []any{sort},
 		"pit":              map[string]any{"id": pit.Id, "keep_alive": "1m"},
@@ -275,14 +278,16 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	return ids, nil
 }
 
-// appendIDsFromESHits extracts contact IDs from Elasticsearch hits using the id field in _source
+// appendIDsFromESHits extracts contact IDs from Elasticsearch hits using the id docvalue field
 func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.ContactID {
 	for _, hit := range hits {
-		var src struct {
-			ID models.ContactID `json:"id"`
+		raw, ok := hit.Fields["id"]
+		if !ok {
+			continue
 		}
-		if err := json.Unmarshal(hit.Source_, &src); err == nil {
-			ids = append(ids, src.ID)
+		var vals []models.ContactID
+		if err := json.Unmarshal(raw, &vals); err == nil && len(vals) > 0 {
+			ids = append(ids, vals[0])
 		}
 	}
 	return ids

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -19,7 +19,7 @@ import (
 )
 
 func contactsIndex(rt *runtime.Runtime) (string, bool) {
-	if rt.Config.ElasticContactsUseV2 {
+	if rt.Config.ElasticContactsUseOwn {
 		return rt.Config.ElasticContactsIndex, true
 	}
 	return rt.Config.ElasticContactsLegacyIndex, false
@@ -43,15 +43,15 @@ func newConverter(oa *models.OrgAssets, uuidAsDocID bool) *es.Converter {
 	return es.NewConverter(oa.Env(), assetMapper, uuidAsDocID)
 }
 
-func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, v2 bool) elastic.Query {
+func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, own bool) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
 	filter := []elastic.Query{
 		elastic.Term("org_id", oa.OrgID()),
 	}
 
-	// rp-indexer index has is_active field, v2 index only indexes active contacts
-	if !v2 {
+	// rp-indexer index has is_active field, own index only indexes active contacts
+	if !own {
 		filter = append(filter, elastic.Term("is_active", true))
 	}
 
@@ -64,7 +64,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 	}
 
 	if query != nil {
-		conv := newConverter(oa, v2)
+		conv := newConverter(oa, own)
 		filter = append(filter, conv.Query(query))
 	}
 
@@ -101,8 +101,8 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
-	index, v2 := contactsIndex(rt)
-	eq := buildContactQuery(oa, group, status, nil, parsed, v2)
+	index, own := contactsIndex(rt)
+	eq := buildContactQuery(oa, group, status, nil, parsed, own)
 	src := map[string]any{"query": eq}
 
 	count, err := rt.ES.Client.Count().Index(index).Routing(oa.OrgID().String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
@@ -133,16 +133,16 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		group = nil
 	}
 
-	index, v2 := contactsIndex(rt)
+	index, own := contactsIndex(rt)
 
-	conv := newConverter(oa, v2)
+	conv := newConverter(oa, own)
 	fieldSort, err := conv.Sort(sort, oa.SessionAssets())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
 	}
 
 	start := time.Now()
-	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, index, v2)
+	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, index, own)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -151,9 +151,9 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	return parsed, hits, total, nil
 }
 
-func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string, v2 bool) ([]models.ContactID, int64, error) {
+func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string, own bool) ([]models.ContactID, int64, error) {
 	start := time.Now()
-	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, v2)
+	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, own)
 
 	src := map[string]any{
 		"_source":          []string{"id"},
@@ -197,8 +197,8 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		group = nil
 	}
 
-	index, v2 := contactsIndex(rt)
-	eq := buildContactQuery(oa, group, status, nil, parsed, v2)
+	index, own := contactsIndex(rt)
+	eq := buildContactQuery(oa, group, status, nil, parsed, own)
 	return getContactIDsForQuery(ctx, rt, oa, index, eq, limit)
 }
 

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -3,9 +3,9 @@ package search
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
@@ -39,8 +39,8 @@ func (m *AssetMapper) Group(g assets.Group) int64 {
 
 var assetMapper = &AssetMapper{}
 
-func newConverter(oa *models.OrgAssets) *es.Converter {
-	return es.NewConverter(oa.Env(), assetMapper, false)
+func newConverter(oa *models.OrgAssets, uuidAsDocID bool) *es.Converter {
+	return es.NewConverter(oa.Env(), assetMapper, uuidAsDocID)
 }
 
 func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, v2 bool) elastic.Query {
@@ -64,18 +64,18 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 	}
 
 	if query != nil {
-		conv := newConverter(oa)
+		conv := newConverter(oa, v2)
 		filter = append(filter, conv.Query(query))
 	}
 
 	bq := map[string]any{"filter": filter}
 
 	if len(excludeIDs) > 0 {
-		ids := make([]string, len(excludeIDs))
+		ids := make([]any, len(excludeIDs))
 		for i := range excludeIDs {
-			ids[i] = fmt.Sprintf("%d", excludeIDs[i])
+			ids[i] = excludeIDs[i]
 		}
-		bq["must_not"] = []elastic.Query{elastic.Ids(ids...)}
+		bq["must_not"] = []elastic.Query{{"terms": map[string]any{"id": ids}}}
 	}
 
 	return elastic.Query{"bool": bq}
@@ -135,7 +135,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 
 	index, v2 := contactsIndex(rt)
 
-	conv := newConverter(oa)
+	conv := newConverter(oa, v2)
 	fieldSort, err := conv.Sort(sort, oa.SessionAssets())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
@@ -156,7 +156,7 @@ func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, v2)
 
 	src := map[string]any{
-		"_source":          false,
+		"_source":          []string{"id"},
 		"query":            eq,
 		"sort":             []any{fieldSort},
 		"from":             offset,
@@ -209,7 +209,7 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	// if limit provided that can be done with single search, do that
 	if limit >= 0 && limit <= 10_000 {
 		src := map[string]any{
-			"_source":          false,
+			"_source":          []string{"id"},
 			"query":            eq,
 			"sort":             []any{sort},
 			"from":             0,
@@ -238,7 +238,7 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	}()
 
 	src := map[string]any{
-		"_source":          false,
+		"_source":          []string{"id"},
 		"query":            eq,
 		"sort":             []any{sort},
 		"pit":              map[string]any{"id": pit.Id, "keep_alive": "1m"},
@@ -275,12 +275,14 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	return ids, nil
 }
 
-// appendIDsFromESHits extracts contact IDs from Elasticsearch hits where _id is the database contact ID
+// appendIDsFromESHits extracts contact IDs from Elasticsearch hits using the id field in _source
 func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.ContactID {
 	for _, hit := range hits {
-		id, err := strconv.Atoi(*hit.Id_)
-		if err == nil {
-			ids = append(ids, models.ContactID(id))
+		var src struct {
+			ID models.ContactID `json:"id"`
+		}
+		if err := json.Unmarshal(hit.Source_, &src); err == nil {
+			ids = append(ids, src.ID)
 		}
 	}
 	return ids

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	ElasticPassword            string `help:"the password for ElasticSearch if using basic auth"`
 	ElasticContactsLegacyIndex string `help:"the name of the legacy contacts index written by rp-indexer"`
 	ElasticContactsIndex       string `help:"the name of the contacts index written by mailroom"`
-	ElasticContactsUseV2       bool   `help:"whether to use the v2 contacts index for searches"`
+	ElasticContactsUseV2       bool   `help:"whether to use the v3 contacts index for searches"`
 	ElasticMessagesIndex       string `help:"the base name for monthly message indexes (e.g. messages-v1 -> messages-v1-2026-02)"`
 
 	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
@@ -121,7 +121,7 @@ func NewDefaultConfig() *Config {
 		ElasticUsername:            "",
 		ElasticPassword:            "",
 		ElasticContactsLegacyIndex: "contacts",
-		ElasticContactsIndex:       "contacts-v2",
+		ElasticContactsIndex:       "contacts-v3",
 		ElasticMessagesIndex:       "messages-v1",
 
 		AWSAccessKeyID:     "",

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	ElasticPassword            string `help:"the password for ElasticSearch if using basic auth"`
 	ElasticContactsLegacyIndex string `help:"the name of the legacy contacts index written by rp-indexer"`
 	ElasticContactsIndex       string `help:"the name of the contacts index written by mailroom"`
-	ElasticContactsUseV2       bool   `help:"whether to use the v3 contacts index for searches"`
+	ElasticContactsUseOwn      bool   `help:"whether to use mailroom's own contacts index for searches"`
 	ElasticMessagesIndex       string `help:"the base name for monthly message indexes (e.g. messages-v1 -> messages-v1-2026-02)"`
 
 	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -76,7 +76,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.DynamoEndpoint = "http://localstack:4566"
 	cfg.DynamoTablePrefix = "Test"
 	cfg.ElasticContactsIndex = "contacts-test"
-	cfg.ElasticContactsUseV2 = true
+	cfg.ElasticContactsUseOwn = true
 	cfg.ElasticMessagesIndex = "messages-test"
 	cfg.SpoolDir = absPath("./_test_spool")
 

--- a/testsuite/testdata/es_contacts.json
+++ b/testsuite/testdata/es_contacts.json
@@ -77,9 +77,6 @@
             "id": {
                 "type": "long"
             },
-            "uuid": {
-                "type": "keyword"
-            },
             "org_id": {
                 "type": "keyword"
             },

--- a/web/contact/deindex.go
+++ b/web/contact/deindex.go
@@ -20,16 +20,15 @@ func init() {
 //
 //	{
 //	  "org_id": 1,
-//	  "contact_uuids": ["548f43fb-f32a-491f-abb7-0c29a453a06e", "540eb87f-57b7-4f9f-9fce-0ea6facbec08"]
+//	  "contact_uuids": ["548f43fb-f32a-491f-abb7-0c29a453a06e"]
 //	}
 type deindexRequest struct {
 	OrgID        models.OrgID        `json:"org_id"        validate:"required"`
-	ContactIDs   []models.ContactID  `json:"contact_ids"   validate:"required"`
-	ContactUUIDs []flows.ContactUUID `json:"contact_uuids" validate:"required"` // needed for message de-indexing
+	ContactUUIDs []flows.ContactUUID `json:"contact_uuids" validate:"required"`
 }
 
 func handleDeindex(ctx context.Context, rt *runtime.Runtime, r *deindexRequest) (any, int, error) {
-	deindexed, err := search.DeindexContactsByID(ctx, rt, r.OrgID, r.ContactIDs)
+	deindexed, err := search.DeindexContactsByUUID(ctx, rt, r.OrgID, r.ContactUUIDs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error de-indexing contacts in org #%d: %w", r.OrgID, err)
 	}

--- a/web/contact/testdata/deindex.json
+++ b/web/contact/testdata/deindex.json
@@ -17,10 +17,6 @@
             "contact_uuids": [
                 "b699a406-7e44-49be-9f01-1a82893e8a10",
                 "cd024bcd-f473-4719-a00a-bd0bb1190135"
-            ],
-            "contact_ids": [
-                10001,
-                10002
             ]
         },
         "status": 200,


### PR DESCRIPTION
## Summary
- Write contact UUID as the ES document `_id` instead of the database contact ID, removing `uuid` as a separate indexed field
- Rename index from `contacts-v2` to `contacts-v3` to reflect the new document structure
- Rename `DeindexContactsByID` to `DeindexContactsByUUID` since `_id` is now the UUID
- Pass `uuidAsDocID=true` to goflow's `es.Converter` when searching the v3 index
- Extract contact DB IDs from `_source.id` instead of parsing `_id` in search results

## Test plan
- [x] All existing tests pass (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)