### PR TITLE
Remove support for legacy rp-indexer contacts index

### DIFF
--- a/core/search/search.go
+++ b/core/search/search.go
@@ -18,13 +18,6 @@ import (
 	"github.com/nyaruka/mailroom/runtime"
 )
 
-func contactsIndex(rt *runtime.Runtime) (string, bool) {
-	if rt.Config.ElasticContactsUseOwn {
-		return rt.Config.ElasticContactsIndex, true
-	}
-	return rt.Config.ElasticContactsLegacyIndex, false
-}
-
 // AssetMapper maps resolved assets in queries to how we identify them in ES which in the case
 // of flows and groups is their ids. We can do this by just type cracking them to their models.
 type AssetMapper struct{}
@@ -43,16 +36,11 @@ func newConverter(oa *models.OrgAssets, uuidAsDocID bool) *es.Converter {
 	return es.NewConverter(oa.Env(), assetMapper, uuidAsDocID)
 }
 
-func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery, own bool) elastic.Query {
+func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
 	filter := []elastic.Query{
 		elastic.Term("org_id", oa.OrgID()),
-	}
-
-	// rp-indexer index has is_active field, own index only indexes active contacts
-	if !own {
-		filter = append(filter, elastic.Term("is_active", true))
 	}
 
 	if group != nil {
@@ -64,7 +52,7 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 	}
 
 	if query != nil {
-		conv := newConverter(oa, own)
+		conv := newConverter(oa, true)
 		filter = append(filter, conv.Query(query))
 	}
 
@@ -101,8 +89,8 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
-	index, own := contactsIndex(rt)
-	eq := buildContactQuery(oa, group, status, nil, parsed, own)
+	index := rt.Config.ElasticContactsIndex
+	eq := buildContactQuery(oa, group, status, nil, parsed)
 	src := map[string]any{"query": eq}
 
 	count, err := rt.ES.Client.Count().Index(index).Routing(oa.OrgID().String()).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
@@ -133,16 +121,14 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		group = nil
 	}
 
-	index, own := contactsIndex(rt)
-
-	conv := newConverter(oa, own)
+	conv := newConverter(oa, true)
 	fieldSort, err := conv.Sort(sort, oa.SessionAssets())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
 	}
 
 	start := time.Now()
-	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, index, own)
+	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, rt.Config.ElasticContactsIndex)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -151,9 +137,9 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	return parsed, hits, total, nil
 }
 
-func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string, own bool) ([]models.ContactID, int64, error) {
+func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string) ([]models.ContactID, int64, error) {
 	start := time.Now()
-	eq := buildContactQuery(oa, group, status, excludeIDs, parsed, own)
+	eq := buildContactQuery(oa, group, status, excludeIDs, parsed)
 
 	src := map[string]any{
 		"_source":          false,
@@ -198,9 +184,9 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		group = nil
 	}
 
-	index, own := contactsIndex(rt)
-	eq := buildContactQuery(oa, group, status, nil, parsed, own)
-	return getContactIDsForQuery(ctx, rt, oa, index, eq, limit)
+	eq := buildContactQuery(oa, group, status, nil, parsed)
+
+	return getContactIDsForQuery(ctx, rt, oa, rt.Config.ElasticContactsIndex, eq, limit)
 }
 
 func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, index string, eq elastic.Query, limit int) ([]models.ContactID, error) {
@@ -211,7 +197,7 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 	if limit >= 0 && limit <= 10_000 {
 		src := map[string]any{
 			"_source":          false,
-		"docvalue_fields":  []string{"id"},
+			"docvalue_fields":  []string{"id"},
 			"query":            eq,
 			"sort":             []any{sort},
 			"from":             0,

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -50,13 +50,11 @@ type Config struct {
 	MaxSprintsPerSession int      `help:"the maximum number of sprints allowed per engine session"`
 	MaxValueLength       int      `help:"the maximum size in characters for contact field values and run result values"`
 
-	Elastic                    string `validate:"url" help:"the URL of your ElasticSearch instance"`
-	ElasticUsername            string `help:"the username for ElasticSearch if using basic auth"`
-	ElasticPassword            string `help:"the password for ElasticSearch if using basic auth"`
-	ElasticContactsLegacyIndex string `help:"the name of the legacy contacts index written by rp-indexer"`
-	ElasticContactsIndex       string `help:"the name of the contacts index written by mailroom"`
-	ElasticContactsUseOwn      bool   `help:"whether to use mailroom's own contacts index for searches"`
-	ElasticMessagesIndex       string `help:"the base name for monthly message indexes (e.g. messages-v1 -> messages-v1-2026-02)"`
+	Elastic              string `validate:"url" help:"the URL of your ElasticSearch instance"`
+	ElasticUsername      string `help:"the username for ElasticSearch if using basic auth"`
+	ElasticPassword      string `help:"the password for ElasticSearch if using basic auth"`
+	ElasticContactsIndex string `help:"the name of the contacts index written by mailroom"`
+	ElasticMessagesIndex string `help:"the base name for monthly message indexes (e.g. messages-v1 -> messages-v1-2026-02)"`
 
 	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
 	AWSSecretAccessKey string `help:"secret access key to use for AWS services"`
@@ -117,12 +115,11 @@ func NewDefaultConfig() *Config {
 		MaxSprintsPerSession: 250,
 		MaxValueLength:       640,
 
-		Elastic:                    "http://elastic:9200",
-		ElasticUsername:            "",
-		ElasticPassword:            "",
-		ElasticContactsLegacyIndex: "contacts",
-		ElasticContactsIndex:       "contacts-v1",
-		ElasticMessagesIndex:       "messages-v1",
+		Elastic:              "http://elastic:9200",
+		ElasticUsername:      "",
+		ElasticPassword:      "",
+		ElasticContactsIndex: "contacts-v1",
+		ElasticMessagesIndex: "messages-v1",
 
 		AWSAccessKeyID:     "",
 		AWSSecretAccessKey: "",

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -76,7 +76,6 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.DynamoEndpoint = "http://localstack:4566"
 	cfg.DynamoTablePrefix = "Test"
 	cfg.ElasticContactsIndex = "contacts-test"
-	cfg.ElasticContactsUseOwn = true
 	cfg.ElasticMessagesIndex = "messages-test"
 	cfg.SpoolDir = absPath("./_test_spool")
 


### PR DESCRIPTION
## Summary
- Removes `ElasticContactsLegacyIndex` and `ElasticContactsUseOwn` config options that are no longer needed
- Simplifies contact search queries by removing the legacy index branching and `is_active` filter
- All searching now uses mailroom's own contacts index directly

## Test plan
- [x] `core/search` tests pass
- [x] `runtime` and `web` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)