### PR TITLE
Bump valkey from 8.0 to 8.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     services:
       valkey:
-        image: valkey/valkey:8.0-alpine
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6379:6379
       postgres:


### PR DESCRIPTION
## Summary
- Bump valkey Docker image from 8.0-alpine to 8.1-alpine in CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)