### PR TITLE
Add new_urn append support to msg_received task

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -842,9 +842,9 @@ SELECT id, org_id, contact_id, identity, priority, scheme, path, display, auth_t
  WHERE identity = $1 AND org_id = $2`
 
 const sqlInsertContactURN = `
-INSERT INTO contacts_contacturn( contact_id,  identity,  path,  display,  auth_tokens,  scheme,  priority,  org_id)
-				         VALUES(:contact_id, :identity, :path, :display, :auth_tokens, :scheme, :priority, :org_id)
-ON CONFLICT(identity, org_id) DO UPDATE SET contact_id = :contact_id, priority = :priority WHERE contacts_contacturn.contact_id IS NULL`
+INSERT INTO contacts_contacturn( contact_id,  identity,  path,  display,  auth_tokens,  scheme,  priority,  channel_id,  org_id)
+				         VALUES(:contact_id, :identity, :path, :display, :auth_tokens, :scheme, :priority, :channel_id, :org_id)
+ON CONFLICT(identity, org_id) DO UPDATE SET contact_id = :contact_id, priority = :priority, channel_id = COALESCE(NULLIF(:channel_id, 0), contacts_contacturn.channel_id) WHERE contacts_contacturn.contact_id IS NULL`
 
 // CreateOrClaimURN will either create a new URN or claim an existing orphaned one
 func CreateOrClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (*ContactURN, error) {
@@ -1078,6 +1078,7 @@ func UpdateContactURNs(ctx context.Context, rt *runtime.Runtime, db DBorTx, oa *
 					Path:      urn.Path(),
 					Display:   null.String(urn.Display()),
 					Priority:  priority,
+					ChannelID: channelID,
 				})
 			}
 

--- a/core/runner/handlers/testdata/msg_created_with_new_urn.json
+++ b/core/runner/handlers/testdata/msg_created_with_new_urn.json
@@ -33,7 +33,7 @@
                     "msg_channel": 10002,
                     "status": "Q",
                     "text": "Ann Message",
-                    "urn_channel": null
+                    "urn_channel": 10002
                 }
             }
         ],

--- a/core/tasks/ctasks/msg_received.go
+++ b/core/tasks/ctasks/msg_received.go
@@ -26,6 +26,11 @@ func init() {
 	RegisterType(TypeMsgReceived, func() Task { return &MsgReceived{} })
 }
 
+type NewURNSpec struct {
+	Value  urns.URN `json:"value" validate:"required"`
+	Action string   `json:"action" validate:"required,eq=append"`
+}
+
 type MsgReceived struct {
 	MsgUUID       flows.EventUUID  `json:"msg_uuid"`
 	MsgExternalID string           `json:"msg_external_id"`
@@ -35,6 +40,7 @@ type MsgReceived struct {
 	Text          string           `json:"text"`
 	Attachments   []string         `json:"attachments,omitempty"`
 	NewContact    bool             `json:"new_contact"`
+	NewURN        *NewURNSpec      `json:"new_urn,omitempty"`
 }
 
 func (t *MsgReceived) Type() string {
@@ -110,6 +116,19 @@ func (t *MsgReceived) perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 		// if we get a message from a stopped contact, unstop them
 		if err := scene.ApplyModifier(ctx, rt, oa, modifiers.NewStatus(flows.ContactStatusActive), models.NilUserID, ""); err != nil {
 			return fmt.Errorf("error applying modifier to unstop contact: %w", err)
+		}
+	}
+
+	// if a new URN was specified, validate and append it before affinity
+	if t.NewURN != nil {
+		if t.NewURN.Value == urns.NilURN {
+			return fmt.Errorf("new_urn value is required")
+		}
+		if t.NewURN.Action != "append" {
+			return fmt.Errorf("unsupported new_urn action: %s", t.NewURN.Action)
+		}
+		if err := t.applyNewURN(ctx, rt, oa, contact, scene); err != nil {
+			return fmt.Errorf("error applying new URN: %w", err)
 		}
 	}
 
@@ -217,6 +236,15 @@ func (t *MsgReceived) handleMsgEvent(ctx context.Context, rt *runtime.Runtime, o
 		if err := scene.ResumeSession(ctx, rt, oa, session, resumes.NewMsg(msgEvent)); err != nil {
 			return fmt.Errorf("error resuming flow for contact: %w", err)
 		}
+	}
+
+	return nil
+}
+
+func (t *MsgReceived) applyNewURN(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contact *flows.Contact, scene *runner.Scene) error {
+
+	if err := scene.ApplyModifier(ctx, rt, oa, modifiers.NewURNs([]urns.URN{t.NewURN.Value}, modifiers.URNsAppend), models.NilUserID, ""); err != nil {
+		return fmt.Errorf("error applying URNs modifier: %w", err)
 	}
 
 	return nil

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -434,6 +434,120 @@ func TestMsgReceivedTask(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE contact_id = $1 AND direction = 'O' AND created_on > $2`, testdb.Org2Contact.ID, previous).Returns(0)
 }
 
+func TestMsgReceivedNewURN(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetElastic)
+
+	dbMsg := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Bob, "", models.MsgStatusPending, "")
+
+	tcs := []struct {
+		label       string
+		preHook     func()
+		contact     *testdb.Contact
+		channel     *testdb.Channel
+		newURN      *ctasks.NewURNSpec
+		expectedURN []string
+		expectedErr string
+	}{
+		{
+			label:   "append new URN",
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "telegram:98765",
+				Action: "append",
+			},
+			expectedURN: []string{"tel:+16055742222", "telegram:98765"},
+		},
+		{
+			label: "append dedup existing URN",
+			preHook: func() {
+				// reset Bob's URNs to original state
+				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme = 'telegram'`, testdb.Bob.ID)
+				testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Bob, "telegram:98765", 999, nil)
+			},
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "telegram:98765",
+				Action: "append",
+			},
+			// telegram URN moves from high priority to lowest
+			expectedURN: []string{"tel:+16055742222", "telegram:98765"},
+		},
+		{
+			label:   "unsupported action errors",
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "telegram:98765",
+				Action: "prepend",
+			},
+			expectedErr: "unsupported new_urn action: prepend",
+		},
+		{
+			label:   "empty URN value errors",
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "",
+				Action: "append",
+			},
+			expectedErr: "new_urn value is required",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.label, func(t *testing.T) {
+			models.FlushCache()
+
+			if tc.preHook != nil {
+				tc.preHook()
+			}
+
+			rt.DB.MustExec(`UPDATE msgs_msg SET status = 'P', flow_id = NULL WHERE id = $1`, dbMsg.ID)
+
+			task := &ctasks.MsgReceived{
+				ChannelID: tc.channel.ID,
+				MsgUUID:   dbMsg.UUID,
+				URN:       tc.contact.URN,
+				URNID:     tc.contact.URNID,
+				Text:      "hello",
+				NewURN:    tc.newURN,
+			}
+
+			if tc.expectedErr != "" {
+				// call ctasks.Perform directly to check errors (queue processing swallows them)
+				oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+				require.NoError(t, err)
+
+				err = ctasks.Perform(ctx, rt, oa, tc.contact.ID, task)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+
+			err := tasks.QueueContact(ctx, rt, testdb.Org1.ID, tc.contact.ID, task)
+			require.NoError(t, err)
+
+			queued, err := rt.Queues.Realtime.Pop(ctx, vc)
+			require.NoError(t, err)
+			require.NotNil(t, queued)
+
+			err = tasks.Perform(ctx, rt, queued)
+			require.NoError(t, err)
+
+			// verify URN order
+			var urnIdentities []string
+			err = rt.DB.Select(&urnIdentities, `SELECT identity FROM contacts_contacturn WHERE contact_id = $1 ORDER BY priority DESC`, tc.contact.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedURN, urnIdentities)
+		})
+	}
+}
+
 func getLastSeenOn(t *testing.T, rt *runtime.Runtime, c *testdb.Contact) *time.Time {
 	var lastSeenOn *time.Time
 	err := rt.DB.Get(&lastSeenOn, `SELECT last_seen_on FROM contacts_contact WHERE id = $1`, c.ID)


### PR DESCRIPTION
Allow callers to specify a new URN to append to a contact when processing an incoming message. The new URN is added at lowest priority with deduplication by identity. Also update URN insert SQL to include channel_id.