### PR TITLE
Change /contact/search to use exclude_uuids instead of exclude_ids

### DIFF
--- a/core/search/search.go
+++ b/core/search/search.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/goflow/contactql/es"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
 )
@@ -36,7 +37,7 @@ func newConverter(oa *models.OrgAssets, uuidAsDocID bool) *es.Converter {
 	return es.NewConverter(oa.Env(), assetMapper, uuidAsDocID)
 }
 
-func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, query *contactql.ContactQuery) elastic.Query {
+func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeUUIDs []flows.ContactUUID, query *contactql.ContactQuery) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
 	filter := []elastic.Query{
@@ -58,12 +59,12 @@ func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.
 
 	bq := map[string]any{"filter": filter}
 
-	if len(excludeIDs) > 0 {
-		ids := make([]any, len(excludeIDs))
-		for i := range excludeIDs {
-			ids[i] = excludeIDs[i]
+	if len(excludeUUIDs) > 0 {
+		ids := make([]string, len(excludeUUIDs))
+		for i := range excludeUUIDs {
+			ids[i] = string(excludeUUIDs[i])
 		}
-		bq["must_not"] = []elastic.Query{{"terms": map[string]any{"id": ids}}}
+		bq["must_not"] = []elastic.Query{elastic.Ids(ids...)}
 	}
 
 	return elastic.Query{"bool": bq}
@@ -102,7 +103,7 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 }
 
 // GetContactIDsForQueryPage returns a page of contact ids for the given query and sort
-func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeIDs []models.ContactID, query string, sort string, offset int, pageSize int) (*contactql.ContactQuery, []models.ContactID, int64, error) {
+func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeUUIDs []flows.ContactUUID, query string, sort string, offset int, pageSize int) (*contactql.ContactQuery, []models.ContactID, int64, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -128,7 +129,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	}
 
 	start := time.Now()
-	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeIDs, parsed, fieldSort, offset, pageSize, rt.Config.ElasticContactsIndex)
+	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeUUIDs, parsed, fieldSort, offset, pageSize, rt.Config.ElasticContactsIndex)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -137,9 +138,9 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	return parsed, hits, total, nil
 }
 
-func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeIDs []models.ContactID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string) ([]models.ContactID, int64, error) {
+func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeUUIDs []flows.ContactUUID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string) ([]models.ContactID, int64, error) {
 	start := time.Now()
-	eq := buildContactQuery(oa, group, status, excludeIDs, parsed)
+	eq := buildContactQuery(oa, group, status, excludeUUIDs, parsed)
 
 	src := map[string]any{
 		"_source":          false,

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -69,7 +69,7 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 
 	tcs := []struct {
 		group            *testdb.Group
-		excludeIDs       []models.ContactID
+		excludeUUIDs     []flows.ContactUUID
 		query            string
 		sort             string
 		expectedContacts []models.ContactID
@@ -97,7 +97,7 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 		},
 		{ // 3
 			group:            testdb.ActiveGroup,
-			excludeIDs:       []models.ContactID{testdb.Cat.ID},
+			excludeUUIDs:     []flows.ContactUUID{testdb.Cat.UUID},
 			query:            "age >= 30",
 			sort:             "-age",
 			expectedContacts: []models.ContactID{},
@@ -113,7 +113,7 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 	for i, tc := range tcs {
 		group := oa.GroupByID(tc.group.ID)
 
-		_, ids, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, tc.excludeIDs, tc.query, tc.sort, 0, 50)
+		_, ids, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, tc.excludeUUIDs, tc.query, tc.sort, 0, 50)
 
 		if tc.expectedError != "" {
 			assert.EqualError(t, err, tc.expectedError)

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -28,13 +28,13 @@ func init() {
 //	  "limit": 50
 //	}
 type searchRequest struct {
-	OrgID      models.OrgID       `json:"org_id"      validate:"required"`
-	GroupID    models.GroupID     `json:"group_id"    validate:"required"`
+	OrgID        models.OrgID        `json:"org_id"      validate:"required"`
+	GroupID      models.GroupID      `json:"group_id"    validate:"required"`
 	ExcludeUUIDs []flows.ContactUUID `json:"exclude_uuids"`
-	Query      string             `json:"query"`
-	Sort       string             `json:"sort"`
-	Offset     int                `json:"offset"`
-	Limit      int                `json:"limit"`
+	Query        string              `json:"query"`
+	Sort         string              `json:"sort"`
+	Offset       int                 `json:"offset"`
+	Limit        int                 `json:"limit"`
 }
 
 // Response for a contact search

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/nyaruka/goflow/contactql"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/search"
 	"github.com/nyaruka/mailroom/runtime"
@@ -29,7 +30,7 @@ func init() {
 type searchRequest struct {
 	OrgID      models.OrgID       `json:"org_id"      validate:"required"`
 	GroupID    models.GroupID     `json:"group_id"    validate:"required"`
-	ExcludeIDs []models.ContactID `json:"exclude_ids"`
+	ExcludeUUIDs []flows.ContactUUID `json:"exclude_uuids"`
 	Query      string             `json:"query"`
 	Sort       string             `json:"sort"`
 	Offset     int                `json:"offset"`
@@ -68,7 +69,7 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		r.Limit = 50
 	}
 
-	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeIDs, r.Query, r.Sort, r.Offset, r.Limit)
+	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeUUIDs, r.Query, r.Sort, r.Offset, r.Limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
 	}

--- a/web/contact/testdata/search.json
+++ b/web/contact/testdata/search.json
@@ -80,9 +80,9 @@
             "org_id": 1,
             "query": "Ann OR Cat",
             "group_id": 10000,
-            "exclude_ids": [
-                10001,
-                10002
+            "exclude_uuids": [
+                "b699a406-7e44-49be-9f01-1a82893e8a10",
+                "cd024bcd-f473-4719-a00a-bd0bb1190135"
             ]
         },
         "status": 200,


### PR DESCRIPTION
## Summary
- Change the `/contact/search` endpoint to accept `exclude_uuids` (contact UUIDs) instead of `exclude_ids` (numeric IDs)
- Use ES `ids` query on document `_id` (which is already the contact UUID) for exclusions, avoiding any DB lookup

## Test plan
- [x] Unit tests updated and passing (`core/search`)
- [x] Integration tests updated and passing (`web/contact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)