### PR TITLE
Change /contact/search to return contact_uuids instead of contact_ids

### DIFF
--- a/core/search/search.go
+++ b/core/search/search.go
@@ -102,8 +102,8 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 	return parsed, count.Count, nil
 }
 
-// GetContactIDsForQueryPage returns a page of contact ids for the given query and sort
-func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeUUIDs []flows.ContactUUID, query string, sort string, offset int, pageSize int) (*contactql.ContactQuery, []models.ContactID, int64, error) {
+// GetContactUUIDsForQueryPage returns a page of contact UUIDs for the given query and sort
+func GetContactUUIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, excludeUUIDs []flows.ContactUUID, query string, sort string, offset int, pageSize int) (*contactql.ContactQuery, []flows.ContactUUID, int64, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
@@ -129,7 +129,7 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	}
 
 	start := time.Now()
-	hits, total, err := getContactIDsForQueryPage(ctx, rt, oa, group, status, excludeUUIDs, parsed, fieldSort, offset, pageSize, rt.Config.ElasticContactsIndex)
+	hits, total, err := getContactUUIDsForQueryPage(ctx, rt, oa, group, status, excludeUUIDs, parsed, fieldSort, offset, pageSize, rt.Config.ElasticContactsIndex)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -138,13 +138,12 @@ func GetContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 	return parsed, hits, total, nil
 }
 
-func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeUUIDs []flows.ContactUUID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string) ([]models.ContactID, int64, error) {
+func getContactUUIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeUUIDs []flows.ContactUUID, parsed *contactql.ContactQuery, fieldSort map[string]any, offset int, pageSize int, index string) ([]flows.ContactUUID, int64, error) {
 	start := time.Now()
 	eq := buildContactQuery(oa, group, status, excludeUUIDs, parsed)
 
 	src := map[string]any{
 		"_source":          false,
-		"docvalue_fields":  []string{"id"},
 		"query":            eq,
 		"sort":             []any{fieldSort},
 		"from":             offset,
@@ -157,12 +156,14 @@ func getContactIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *mod
 		return nil, 0, fmt.Errorf("error performing query: %w", err)
 	}
 
-	ids := make([]models.ContactID, 0, pageSize)
-	ids = appendIDsFromESHits(ids, results.Hits.Hits)
+	uuids := make([]flows.ContactUUID, 0, pageSize)
+	for _, hit := range results.Hits.Hits {
+		uuids = append(uuids, flows.ContactUUID(*hit.Id_))
+	}
 
-	slog.Debug("paged contact query complete", "org_id", oa.OrgID(), "index", index, "elapsed", time.Since(start), "page_count", len(ids), "total_count", results.Hits.Total.Value)
+	slog.Debug("paged contact query complete", "org_id", oa.OrgID(), "index", index, "elapsed", time.Since(start), "page_count", len(uuids), "total_count", results.Hits.Total.Value)
 
-	return ids, results.Hits.Total.Value, nil
+	return uuids, results.Hits.Total.Value, nil
 }
 
 // GetContactIDsForQuery returns up to limit the contact ids that match the given query, sorted by id. Limit of -1 means return all.

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -58,7 +58,7 @@ func TestGetContactTotal(t *testing.T) {
 	}
 }
 
-func TestGetContactIDsForQueryPage(t *testing.T) {
+func TestGetContactUUIDsForQueryPage(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
@@ -72,27 +72,27 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 		excludeUUIDs     []flows.ContactUUID
 		query            string
 		sort             string
-		expectedContacts []models.ContactID
+		expectedContacts []flows.ContactUUID
 		expectedTotal    int64
 		expectedError    string
 	}{
 		{ // 0
 			group:            testdb.ActiveGroup,
 			query:            "cat OR bob",
-			expectedContacts: []models.ContactID{testdb.Cat.ID, testdb.Bob.ID},
+			expectedContacts: []flows.ContactUUID{testdb.Cat.UUID, testdb.Bob.UUID},
 			expectedTotal:    2,
 		},
 		{ // 1
 			group:            testdb.BlockedGroup,
 			query:            "cat",
-			expectedContacts: []models.ContactID{},
+			expectedContacts: []flows.ContactUUID{},
 			expectedTotal:    0,
 		},
 		{ // 2
 			group:            testdb.ActiveGroup,
 			query:            "age >= 30",
 			sort:             "-age",
-			expectedContacts: []models.ContactID{testdb.Cat.ID},
+			expectedContacts: []flows.ContactUUID{testdb.Cat.UUID},
 			expectedTotal:    1,
 		},
 		{ // 3
@@ -100,7 +100,7 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 			excludeUUIDs:     []flows.ContactUUID{testdb.Cat.UUID},
 			query:            "age >= 30",
 			sort:             "-age",
-			expectedContacts: []models.ContactID{},
+			expectedContacts: []flows.ContactUUID{},
 			expectedTotal:    0,
 		},
 		{ // 4
@@ -113,13 +113,13 @@ func TestGetContactIDsForQueryPage(t *testing.T) {
 	for i, tc := range tcs {
 		group := oa.GroupByID(tc.group.ID)
 
-		_, ids, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, tc.excludeUUIDs, tc.query, tc.sort, 0, 50)
+		_, uuids, total, err := search.GetContactUUIDsForQueryPage(ctx, rt, oa, group, tc.excludeUUIDs, tc.query, tc.sort, 0, 50)
 
 		if tc.expectedError != "" {
 			assert.EqualError(t, err, tc.expectedError)
 		} else {
 			assert.NoError(t, err, "%d: error encountered performing query", i)
-			assert.Equal(t, tc.expectedContacts, ids, "%d: ids mismatch", i)
+			assert.Equal(t, tc.expectedContacts, uuids, "%d: uuids mismatch", i)
 			assert.Equal(t, tc.expectedTotal, total, "%d: total mismatch", i)
 		}
 	}

--- a/web/contact/search.go
+++ b/web/contact/search.go
@@ -41,8 +41,8 @@ type searchRequest struct {
 //
 //	{
 //	  "query": "age > 10",
-//	  "contact_ids": [5,10,15],
-//	  "total": 3,
+//	  "contact_uuids": ["b699a406-7e44-49be-9f01-1a82893e8a10"],
+//	  "total": 1,
 //	  "metadata": {
 //	    "fields": [
 //	      {"key": "age", "name": "Age"}
@@ -51,10 +51,10 @@ type searchRequest struct {
 //	  }
 //	}
 type searchResponse struct {
-	Query      string                `json:"query"`
-	ContactIDs []models.ContactID    `json:"contact_ids"`
-	Total      int64                 `json:"total"`
-	Metadata   *contactql.Inspection `json:"metadata,omitempty"`
+	Query        string                `json:"query"`
+	ContactUUIDs []flows.ContactUUID   `json:"contact_uuids"`
+	Total        int64                 `json:"total"`
+	Metadata     *contactql.Inspection `json:"metadata,omitempty"`
 }
 
 // handles a contact search request
@@ -69,7 +69,7 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 		r.Limit = 50
 	}
 
-	parsed, hits, total, err := search.GetContactIDsForQueryPage(ctx, rt, oa, group, r.ExcludeUUIDs, r.Query, r.Sort, r.Offset, r.Limit)
+	parsed, hits, total, err := search.GetContactUUIDsForQueryPage(ctx, rt, oa, group, r.ExcludeUUIDs, r.Query, r.Sort, r.Offset, r.Limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error searching page: %w", err)
 	}
@@ -85,10 +85,10 @@ func handleSearch(ctx context.Context, rt *runtime.Runtime, r *searchRequest) (a
 
 	// build our response
 	response := &searchResponse{
-		Query:      normalized,
-		ContactIDs: hits,
-		Total:      total,
-		Metadata:   metadata,
+		Query:        normalized,
+		ContactUUIDs: hits,
+		Total:        total,
+		Metadata:     metadata,
 	}
 
 	return response, http.StatusOK, nil

--- a/web/contact/testdata/search.json
+++ b/web/contact/testdata/search.json
@@ -57,8 +57,8 @@
         "status": 200,
         "response": {
             "query": "name ~ \"Ann\"",
-            "contact_ids": [
-                10000
+            "contact_uuids": [
+                "a393abc0-283d-4c9b-a1b3-641a035c34bf"
             ],
             "total": 1,
             "metadata": {
@@ -88,8 +88,8 @@
         "status": 200,
         "response": {
             "query": "name ~ \"Ann\" OR name ~ \"Cat\"",
-            "contact_ids": [
-                10000
+            "contact_uuids": [
+                "a393abc0-283d-4c9b-a1b3-641a035c34bf"
             ],
             "total": 1,
             "metadata": {
@@ -115,7 +115,7 @@
         "status": 200,
         "response": {
             "query": "fields.age = 10 AND fields.gender = \"M\"",
-            "contact_ids": [],
+            "contact_uuids": [],
             "total": 0,
             "metadata": {
                 "attributes": [],
@@ -147,17 +147,17 @@
         "status": 200,
         "response": {
             "query": "",
-            "contact_ids": [
-                10013,
-                10012,
-                10011,
-                10010,
-                10009,
-                10008,
-                10007,
-                10006,
-                10005,
-                10004
+            "contact_uuids": [
+                "01206316-7eaa-4cd2-b6f8-ab7558683b01",
+                "03e607e7-4d43-4159-b6f5-1edf76c279cb",
+                "eab52173-c81b-43af-9bf2-683a8d4d90cb",
+                "df17cd52-2d73-4918-8ca8-a9d82dbd33e8",
+                "5f42c9ea-dcf7-4784-b730-8cc3b659f96f",
+                "af690bc3-d2b7-4fcf-9a3f-1fd34649d055",
+                "7c4bb02c-3291-4222-8cee-537d6b20ef04",
+                "c42af660-7cd0-40f9-901d-6fca031dcb7e",
+                "86056241-4ac5-4c8c-ad71-bf9159b41059",
+                "860d4519-6698-41f2-847a-66334bce96cc"
             ],
             "total": 10
         }
@@ -175,12 +175,12 @@
         "status": 200,
         "response": {
             "query": "",
-            "contact_ids": [
-                10013,
-                10012,
-                10011,
-                10010,
-                10009
+            "contact_uuids": [
+                "01206316-7eaa-4cd2-b6f8-ab7558683b01",
+                "03e607e7-4d43-4159-b6f5-1edf76c279cb",
+                "eab52173-c81b-43af-9bf2-683a8d4d90cb",
+                "df17cd52-2d73-4918-8ca8-a9d82dbd33e8",
+                "5f42c9ea-dcf7-4784-b730-8cc3b659f96f"
             ],
             "total": 10
         }
@@ -199,12 +199,12 @@
         "status": 200,
         "response": {
             "query": "",
-            "contact_ids": [
-                10004,
-                10005,
-                10006,
-                10007,
-                10008
+            "contact_uuids": [
+                "860d4519-6698-41f2-847a-66334bce96cc",
+                "86056241-4ac5-4c8c-ad71-bf9159b41059",
+                "c42af660-7cd0-40f9-901d-6fca031dcb7e",
+                "7c4bb02c-3291-4222-8cee-537d6b20ef04",
+                "af690bc3-d2b7-4fcf-9a3f-1fd34649d055"
             ],
             "total": 10
         }


### PR DESCRIPTION
## Summary
- Change `/contact/search` response field from `contact_ids` (numeric DB IDs) to `contact_uuids` (UUID strings)
- Extract UUIDs directly from ES document `_id` (`hit.Id_`) instead of using `docvalue_fields` to fetch numeric IDs
- Rename `GetContactIDsForQueryPage` to `GetContactUUIDsForQueryPage`

## Test plan
- [x] Unit tests updated and passing for `core/search` and `web/contact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)