### PR TITLE
Use UUID-based ES search for recipient resolution

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -340,13 +340,12 @@ func LoadContacts(ctx context.Context, db Queryer, oa *OrgAssets, ids []ContactI
 
 // LoadContactsByUUID loads a set of contacts for the passed in UUIDs
 func LoadContactsByUUID(ctx context.Context, db Queryer, oa *OrgAssets, uuids []flows.ContactUUID) ([]*Contact, error) {
-	ids, err := getContactIDsFromUUIDs(ctx, db, oa.OrgID(), uuids)
+	ids, err := GetContactIDsFromUUIDs(ctx, db, oa.OrgID(), uuids)
 	if err != nil {
 		return nil, err
 	}
 	return LoadContacts(ctx, db, oa, ids)
 }
-
 
 // GetContactIDsFromReferences gets the contact ids for the given org and set of references. Note that the order of the returned contacts
 // won't necessarily match the order of the references.
@@ -357,11 +356,11 @@ func GetContactIDsFromReferences(ctx context.Context, db Queryer, orgID OrgID, r
 		uuids[i] = refs[i].UUID
 	}
 
-	return getContactIDsFromUUIDs(ctx, db, orgID, uuids)
+	return GetContactIDsFromUUIDs(ctx, db, orgID, uuids)
 }
 
-// gets the contact IDs for the passed in org and set of UUIDs
-func getContactIDsFromUUIDs(ctx context.Context, db Queryer, orgID OrgID, uuids []flows.ContactUUID) ([]ContactID, error) {
+// GetContactIDsFromUUIDs gets the contact IDs for the passed in org and set of UUIDs
+func GetContactIDsFromUUIDs(ctx context.Context, db Queryer, orgID OrgID, uuids []flows.ContactUUID) ([]ContactID, error) {
 	if len(uuids) == 0 {
 		return nil, nil
 	}

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -3,9 +3,9 @@ package search
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
@@ -166,13 +166,12 @@ func getContactUUIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *m
 	return uuids, results.Hits.Total.Value, nil
 }
 
-// GetContactIDsForQuery returns up to limit the contact ids that match the given query, sorted by id. Limit of -1 means return all.
-func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]models.ContactID, error) {
+// GetContactUUIDsForQuery returns up to limit the contact UUIDs that match the given query, sorted by id. Limit of -1 means return all.
+func GetContactUUIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]flows.ContactUUID, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
 	var err error
 
-	// turn into elastic query
 	if query != "" {
 		parsed, err = contactql.ParseQuery(env, query, oa.SessionAssets())
 		if err != nil {
@@ -188,18 +187,17 @@ func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 
 	eq := buildContactQuery(oa, group, status, nil, parsed)
 
-	return getContactIDsForQuery(ctx, rt, oa, rt.Config.ElasticContactsIndex, eq, limit)
+	return getContactUUIDsForQuery(ctx, rt, oa, rt.Config.ElasticContactsIndex, eq, limit)
 }
 
-func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, index string, eq elastic.Query, limit int) ([]models.ContactID, error) {
+func getContactUUIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, index string, eq elastic.Query, limit int) ([]flows.ContactUUID, error) {
 	sort := elastic.SortBy("id", true)
-	ids := make([]models.ContactID, 0, 100)
+	uuids := make([]flows.ContactUUID, 0, 100)
 
 	// if limit provided that can be done with single search, do that
 	if limit >= 0 && limit <= 10_000 {
 		src := map[string]any{
 			"_source":          false,
-			"docvalue_fields":  []string{"id"},
 			"query":            eq,
 			"sort":             []any{sort},
 			"from":             0,
@@ -211,7 +209,7 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		if err != nil {
 			return nil, fmt.Errorf("error searching ES index: %w", err)
 		}
-		return appendIDsFromESHits(ids, results.Hits.Hits), nil
+		return appendUUIDsFromESHits(uuids, results.Hits.Hits), nil
 	}
 
 	// for larger limits we need to take a point in time and iterate through multiple search requests using search_after
@@ -229,7 +227,6 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 
 	src := map[string]any{
 		"_source":          false,
-		"docvalue_fields":  []string{"id"},
 		"query":            eq,
 		"sort":             []any{sort},
 		"pit":              map[string]any{"id": pit.Id, "keep_alive": "1m"},
@@ -247,14 +244,14 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 			break
 		}
 
-		ids = appendIDsFromESHits(ids, results.Hits.Hits)
+		uuids = appendUUIDsFromESHits(uuids, results.Hits.Hits)
 
-		if limit != -1 && len(ids) >= limit {
-			ids = ids[:limit]
+		if limit != -1 && len(uuids) >= limit {
+			uuids = uuids[:limit]
 			break
 		}
 		if limit != -1 {
-			if remaining := limit - len(ids); remaining < 10_000 {
+			if remaining := limit - len(uuids); remaining < 10_000 {
 				src["size"] = remaining
 			}
 		}
@@ -263,20 +260,32 @@ func getContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.
 		src["search_after"] = lastHit.Sort
 	}
 
-	return ids, nil
+	return uuids, nil
 }
 
-// appendIDsFromESHits extracts contact IDs from Elasticsearch hits using the id docvalue field
-func appendIDsFromESHits(ids []models.ContactID, hits []types.Hit) []models.ContactID {
+// appendUUIDsFromESHits extracts contact UUIDs from Elasticsearch hits using the document _id
+func appendUUIDsFromESHits(uuids []flows.ContactUUID, hits []types.Hit) []flows.ContactUUID {
 	for _, hit := range hits {
-		raw, ok := hit.Fields["id"]
-		if !ok {
-			continue
-		}
-		var vals []models.ContactID
-		if err := json.Unmarshal(raw, &vals); err == nil && len(vals) > 0 {
-			ids = append(ids, vals[0])
-		}
+		uuids = append(uuids, flows.ContactUUID(*hit.Id_))
 	}
-	return ids
+	return uuids
+}
+
+// GetContactIDsForQuery is a temporary wrapper around GetContactUUIDsForQuery that converts the results back to
+// contact IDs. Used by contact exports and group population which still need IDs - these should be updated to work
+// with UUIDs directly.
+func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]models.ContactID, error) {
+	uuids, err := GetContactUUIDsForQuery(ctx, rt, oa, group, status, query, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	ids, err := models.GetContactIDsFromUUIDs(ctx, rt.DB, oa.OrgID(), uuids)
+	if err != nil {
+		return nil, err
+	}
+
+	slices.Sort(ids)
+
+	return ids, nil
 }

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -166,7 +166,7 @@ func getContactUUIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *m
 	return uuids, results.Hits.Total.Value, nil
 }
 
-// GetContactUUIDsForQuery returns up to limit the contact UUIDs that match the given query, sorted by id. Limit of -1 means return all.
+// GetContactUUIDsForQuery returns up to limit the contact UUIDs that match the given query, sorted by contact ID. Limit of -1 means return all.
 func GetContactUUIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]flows.ContactUUID, error) {
 	env := oa.Env()
 	var parsed *contactql.ContactQuery
@@ -272,8 +272,7 @@ func appendUUIDsFromESHits(uuids []flows.ContactUUID, hits []types.Hit) []flows.
 }
 
 // GetContactIDsForQuery is a temporary wrapper around GetContactUUIDsForQuery that converts the results back to
-// contact IDs. Used by contact exports and group population which still need IDs - these should be updated to work
-// with UUIDs directly.
+// contact IDs. Used by call sites that still need IDs; these should be updated to work with UUIDs directly.
 func GetContactIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, query string, limit int) ([]models.ContactID, error) {
 	uuids, err := GetContactUUIDsForQuery(ctx, rt, oa, group, status, query, limit)
 	if err != nil {

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -125,6 +125,110 @@ func TestGetContactUUIDsForQueryPage(t *testing.T) {
 	}
 }
 
+func TestGetContactUUIDsForQuery(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
+
+	oa, err := models.GetOrgAssets(ctx, rt, 1)
+	require.NoError(t, err)
+
+	// so that we can test queries that span multiple responses
+	cylonUUIDs := make([]flows.ContactUUID, 10003)
+	for i := range 10003 {
+		cylonUUIDs[i] = testdb.InsertContact(t, rt, testdb.Org1, flows.NewContactUUID(), fmt.Sprintf("Cylon %d", i), i18n.NilLanguage, models.ContactStatusActive).UUID
+	}
+
+	// create some extra contacts in the other org to be sure we're filtering correctly
+	testdb.InsertContact(t, rt, testdb.Org2, flows.NewContactUUID(), "Cat", i18n.NilLanguage, models.ContactStatusActive)
+	testdb.InsertContact(t, rt, testdb.Org2, flows.NewContactUUID(), "Bob", i18n.NilLanguage, models.ContactStatusActive)
+	testdb.InsertContact(t, rt, testdb.Org2, flows.NewContactUUID(), "Cylon 0", i18n.NilLanguage, models.ContactStatusActive)
+
+	testsuite.IndexContacts(t, rt)
+
+	tcs := []struct {
+		group            *testdb.Group
+		status           models.ContactStatus
+		query            string
+		limit            int
+		expectedContacts []flows.ContactUUID
+		expectedError    string
+	}{
+		{
+			group:            testdb.ActiveGroup,
+			status:           models.NilContactStatus,
+			query:            "cat OR bob",
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{testdb.Cat.UUID, testdb.Bob.UUID},
+		},
+		{
+			group:            nil,
+			status:           models.ContactStatusActive,
+			query:            "cat OR bob",
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{testdb.Cat.UUID, testdb.Bob.UUID},
+		},
+		{
+			group:            testdb.DoctorsGroup,
+			status:           models.ContactStatusActive,
+			query:            "name = ann",
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{testdb.Ann.UUID},
+		},
+		{
+			group:            nil,
+			status:           models.ContactStatusActive,
+			query:            "nobody",
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{},
+		},
+		{
+			group:            nil,
+			status:           models.ContactStatusActive,
+			query:            "cat",
+			limit:            1,
+			expectedContacts: []flows.ContactUUID{testdb.Cat.UUID},
+		},
+		{
+			group:            testdb.DoctorsGroup,
+			status:           models.NilContactStatus,
+			query:            "",
+			limit:            1,
+			expectedContacts: []flows.ContactUUID{testdb.Ann.UUID},
+		},
+		{
+			group:            nil,
+			status:           models.ContactStatusActive,
+			query:            "name has cylon",
+			limit:            -1,
+			expectedContacts: cylonUUIDs,
+		},
+		{
+			group:         nil,
+			status:        models.ContactStatusActive,
+			query:         "goats > 2", // no such contact field
+			limit:         -1,
+			expectedError: "error parsing query: goats > 2: can't resolve 'goats' to attribute, scheme or field",
+		},
+	}
+
+	for i, tc := range tcs {
+		var group *models.Group
+		if tc.group != nil {
+			group = oa.GroupByID(tc.group.ID)
+		}
+
+		uuids, err := search.GetContactUUIDsForQuery(ctx, rt, oa, group, tc.status, tc.query, tc.limit)
+
+		if tc.expectedError != "" {
+			assert.EqualError(t, err, tc.expectedError)
+		} else {
+			assert.NoError(t, err, "%d: error encountered performing query", i)
+			assert.ElementsMatch(t, tc.expectedContacts, uuids, "%d: uuids mismatch", i)
+		}
+	}
+}
+
 func TestGetContactIDsForQuery(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 


### PR DESCRIPTION
## Summary
- Adds `GetContactUUIDsForQuery` which extracts contact UUIDs directly from ES document `_id` instead of using `docvalue_fields`, aligning with how `/contact/search` already works
- Updates `ResolveRecipients` (used by flow starts and broadcasts) to use this UUID-based search, then converts back to IDs via `GetContactIDsFromUUIDs` for downstream processing
- Exports `GetContactIDsFromUUIDs` from models package

This is an incremental step — batches and downstream processing remain ID-based to avoid breaking in-flight queued tasks. A follow-up can change batch structs to carry UUIDs.

## Test plan
- [x] Added `TestGetContactUUIDsForQuery` covering basic queries, group/status filtering, limits, and 10k+ PIT pagination
- [x] Existing `TestResolveRecipients`, `TestBroadcastsFromEvents`, `TestSendBroadcastTask`, `TestStartFlowTask` all pass
- [x] Full test suite passes