### PR TITLE
De-index deleted messages from Elasticsearch

### DIFF
--- a/core/runner/handlers/msg_deleted.go
+++ b/core/runner/handlers/msg_deleted.go
@@ -26,6 +26,7 @@ func handleMsgDeleted(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAs
 		ByContact: event.ByContact,
 		UserID:    userID,
 	})
+	scene.AttachPostCommitHook(hooks.DeindexMessages, event.MsgUUID)
 
 	return nil
 }

--- a/core/runner/hooks/deindex_messages.go
+++ b/core/runner/hooks/deindex_messages.go
@@ -2,7 +2,6 @@ package hooks
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/nyaruka/goflow/flows"
@@ -29,7 +28,8 @@ func (h *deindexMessages) Execute(ctx context.Context, rt *runtime.Runtime, oa *
 
 	deleted, err := search.DeindexMessages(ctx, rt, oa.OrgID(), msgUUIDs)
 	if err != nil {
-		return fmt.Errorf("error deindexing messages: %w", err)
+		slog.Error("error deindexing messages from elasticsearch", "error", err, "org_id", oa.OrgID(), "count", len(msgUUIDs))
+		return nil
 	}
 
 	slog.Debug("deindexed messages from elasticsearch", "count", deleted)

--- a/core/runner/hooks/deindex_messages.go
+++ b/core/runner/hooks/deindex_messages.go
@@ -1,0 +1,38 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/runner"
+	"github.com/nyaruka/mailroom/core/search"
+	"github.com/nyaruka/mailroom/runtime"
+)
+
+// DeindexMessages is our hook for de-indexing deleted messages from Elasticsearch
+var DeindexMessages runner.PostCommitHook = &deindexMessages{}
+
+type deindexMessages struct{}
+
+func (h *deindexMessages) Order() int { return 20 }
+
+func (h *deindexMessages) Execute(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, scenes map[*runner.Scene][]any) error {
+	msgUUIDs := make([]flows.EventUUID, 0, len(scenes))
+	for _, args := range scenes {
+		for _, a := range args {
+			msgUUIDs = append(msgUUIDs, a.(flows.EventUUID))
+		}
+	}
+
+	deleted, err := search.DeindexMessages(ctx, rt, oa.OrgID(), msgUUIDs)
+	if err != nil {
+		return fmt.Errorf("error deindexing messages: %w", err)
+	}
+
+	slog.Debug("deindexed messages from elasticsearch", "count", deleted)
+
+	return nil
+}

--- a/core/search/messages.go
+++ b/core/search/messages.go
@@ -143,6 +143,30 @@ func SearchMessages(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID
 	return msgResults, nil
 }
 
+// DeindexMessages deletes specific messages from the Elasticsearch messages index by their UUIDs.
+func DeindexMessages(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, msgUUIDs []flows.EventUUID) (int, error) {
+	routing := fmt.Sprintf("%d", orgID)
+	uuids := make([]string, len(msgUUIDs))
+	for i, u := range msgUUIDs {
+		uuids[i] = string(u)
+	}
+
+	src := map[string]any{
+		"query": map[string]any{
+			"ids": map[string]any{"values": uuids},
+		},
+	}
+
+	index := rt.Config.ElasticMessagesIndex + "-*"
+
+	resp, err := rt.ES.Client.DeleteByQuery(index).Routing(routing).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("error deindexing messages in org #%d: %w", orgID, err)
+	}
+
+	return int(*resp.Deleted), nil
+}
+
 // DeindexMessagesByContact deletes all messages in the Elasticsearch messages index for the given contact UUIDs.
 func DeindexMessagesByContact(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactUUIDs []flows.ContactUUID) (int, error) {
 	routing := fmt.Sprintf("%d", orgID)

--- a/core/tasks/ctasks/msg_deleted_test.go
+++ b/core/tasks/ctasks/msg_deleted_test.go
@@ -16,14 +16,21 @@ import (
 func TestMsgDeleted(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	oa := testdb.Org1.Load(t, rt)
 
 	ann, _, _ := testdb.Ann.Load(t, rt, oa)
 
-	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199c4cb-f111-7ce8-9ce9-614d61a2c198", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
-	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199c4cf-486a-79af-9892-79254b6ac5b7", testdb.TwilioChannel, testdb.Ann, "goodbye", models.MsgStatusHandled, "")
+	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199c4cb-f111-7ce8-9ce9-614d61a2c198", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
+	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199c4cf-486a-79af-9892-79254b6ac5b7", testdb.TwilioChannel, testdb.Ann, "goodbye world", models.MsgStatusHandled, "")
+
+	rt.DB.MustExec(`UPDATE contacts_contact SET last_seen_on = NOW() WHERE id = $1`, testdb.Ann.ID)
+
+	testsuite.IndexMessages(t, rt)
+
+	msgs := testsuite.GetIndexedMessages(t, rt, false)
+	assert.Len(t, msgs, 2)
 
 	task := &ctasks.MsgDeleted{
 		MsgUUID: "0199c4cb-f111-7ce8-9ce9-614d61a2c198",
@@ -36,6 +43,11 @@ func TestMsgDeleted(t *testing.T) {
 		"0199c4cb-f111-7ce8-9ce9-614d61a2c198": "X",
 		"0199c4cf-486a-79af-9892-79254b6ac5b7": "V",
 	})
+
+	// deleted message should be de-indexed, other should remain
+	msgs = testsuite.GetIndexedMessages(t, rt, false)
+	assert.Len(t, msgs, 1)
+	assert.Equal(t, "0199c4cf-486a-79af-9892-79254b6ac5b7", msgs[0].ID)
 
 	items := testsuite.GetHistoryItems(t, rt, false, time.Time{})
 	if assert.Equal(t, 2, len(items)) {

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,11 +32,23 @@ func TestDelete(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
-	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "1", models.MsgStatusHandled, "")
-	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "2", models.MsgStatusPending, "")
-	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-f0bc-7738-8af8-99712a6f8bff", testdb.TwilioChannel, testdb.Ann, "3", models.MsgStatusPending, "")
+	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
+	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "goodbye world", models.MsgStatusPending, "")
+	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-f0bc-7738-8af8-99712a6f8bff", testdb.TwilioChannel, testdb.Ann, "stay visible", models.MsgStatusPending, "")
+
+	rt.DB.MustExec(`UPDATE contacts_contact SET last_seen_on = NOW() WHERE id = $1`, testdb.Ann.ID)
+
+	testsuite.IndexMessages(t, rt)
+
+	msgs := testsuite.GetIndexedMessages(t, rt, false)
+	require.Len(t, msgs, 3)
 
 	testsuite.RunWebTests(t, rt, "testdata/delete.json")
+
+	// first two messages should have been de-indexed, third should remain
+	msgs = testsuite.GetIndexedMessages(t, rt, false)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "0199bad9-f0bc-7738-8af8-99712a6f8bff", msgs[0].ID)
 }
 
 func TestHandle(t *testing.T) {

--- a/web/msg/testdata/delete.json
+++ b/web/msg/testdata/delete.json
@@ -40,7 +40,7 @@
             {
                 "query": "SELECT visibility, text FROM msgs_msg WHERE uuid = '0199bad9-f0bc-7738-8af8-99712a6f8bff'",
                 "columns": {
-                    "text": "3",
+                    "text": "stay visible",
                     "visibility": "V"
                 }
             }


### PR DESCRIPTION
## Summary
- When messages are deleted (by user or channel event), they now get removed from the Elasticsearch messages index
- Adds `DeindexMessages` function using `DeleteByQuery` with an `ids` query across monthly message indexes
- Adds a post-commit hook that runs after the DB deletion commits, ensuring consistency

## Test plan
- [x] `TestDelete` (web endpoint) indexes messages, deletes two, verifies only the non-deleted one remains in ES
- [x] `TestMsgDeleted` (channel event task) indexes messages, deletes one by contact, verifies it's removed from ES
- [x] All related test suites pass