### PR TITLE
Switch handler test search assertions to use UUIDs directly

### DIFF
--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -226,9 +226,9 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 				require.NoError(t, err)
 
 				for _, sa := range tc.AssertSearch {
-					ids, err := search.GetContactIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, sa.Query, -1)
+					uuids, err := search.GetContactUUIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, sa.Query, -1)
 					assert.NoError(t, err, "%s: search query '%s' failed", tc.Label, sa.Query)
-					assert.ElementsMatch(t, sa.Contacts, ids, "%s: search query '%s' returned wrong contacts", tc.Label, sa.Query)
+					assert.ElementsMatch(t, sa.Contacts, uuids, "%s: search query '%s' returned wrong contacts", tc.Label, sa.Query)
 				}
 			}
 		} else {

--- a/core/runner/handlers/testdata/contact_field_changed.json
+++ b/core/runner/handlers/testdata/contact_field_changed.json
@@ -303,19 +303,19 @@
             {
                 "query": "gender = Female",
                 "contacts": [
-                    10000
+                    "a393abc0-283d-4c9b-a1b3-641a035c34bf"
                 ]
             },
             {
                 "query": "gender = Male",
                 "contacts": [
-                    10001
+                    "b699a406-7e44-49be-9f01-1a82893e8a10"
                 ]
             },
             {
                 "query": "age = 40",
                 "contacts": [
-                    10002
+                    "cd024bcd-f473-4719-a00a-bd0bb1190135"
                 ]
             }
         ]

--- a/core/runner/handlers/testdata/contact_groups_changed.json
+++ b/core/runner/handlers/testdata/contact_groups_changed.json
@@ -126,8 +126,8 @@
             {
                 "query": "group = Testers",
                 "contacts": [
-                    10000,
-                    10002
+                    "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                    "cd024bcd-f473-4719-a00a-bd0bb1190135"
                 ]
             }
         ]

--- a/core/runner/handlers/testdata/contact_language_changed.json
+++ b/core/runner/handlers/testdata/contact_language_changed.json
@@ -60,7 +60,7 @@
             {
                 "query": "language = spa",
                 "contacts": [
-                    10000
+                    "a393abc0-283d-4c9b-a1b3-641a035c34bf"
                 ]
             }
         ]

--- a/core/runner/handlers/testdata/contact_name_changed.json
+++ b/core/runner/handlers/testdata/contact_name_changed.json
@@ -135,13 +135,13 @@
             {
                 "query": "name = Tarzan",
                 "contacts": [
-                    10000
+                    "a393abc0-283d-4c9b-a1b3-641a035c34bf"
                 ]
             },
             {
                 "query": "name = \"Geoff Newman\"",
                 "contacts": [
-                    10002
+                    "cd024bcd-f473-4719-a00a-bd0bb1190135"
                 ]
             }
         ]

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -189,10 +189,10 @@ func GetIndexedMessages(t *testing.T, rt *runtime.Runtime, clear bool) []Indexed
 	return msgs
 }
 
-// SearchAssertion is a search query and the expected contact IDs that should match.
+// SearchAssertion is a search query and the expected contact UUIDs that should match.
 type SearchAssertion struct {
-	Query    string             `json:"query"`
-	Contacts []models.ContactID `json:"contacts"`
+	Query    string              `json:"query"`
+	Contacts []flows.ContactUUID `json:"contacts"`
 }
 
 // removes all documents from the contacts index and deletes all message indexes.


### PR DESCRIPTION
## Summary
- Switch `SearchAssertion.Contacts` from `[]models.ContactID` to `[]flows.ContactUUID`
- Use `GetContactUUIDsForQuery` instead of the temporary `GetContactIDsForQuery` wrapper in handler test assertions
- Update 4 JSON test fixtures to use contact UUIDs instead of numeric IDs

## Test plan
- [x] `go test -p=1 ./core/runner/handlers/...` passes