### PR TITLE
Validate contact tasks after deserializing from Valkey

### DIFF
--- a/core/tasks/ctasks/base.go
+++ b/core/tasks/ctasks/base.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows/modifiers"
+	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/runner"
 	"github.com/nyaruka/mailroom/runtime"
@@ -36,7 +37,7 @@ func ReadTask(type_ string, data []byte) (Task, error) {
 	}
 
 	t := fn()
-	return t, json.Unmarshal(data, t)
+	return t, utils.UnmarshalAndValidate(data, t)
 }
 
 // Payload wrapper for encoding a contact task

--- a/core/tasks/ctasks/base_test.go
+++ b/core/tasks/ctasks/base_test.go
@@ -16,6 +16,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestReadTask(t *testing.T) {
+	// valid contact_changed task
+	task, err := ctasks.ReadTask("contact_changed", []byte(`{"new_urn": {"value": "telegram:98765", "action": "append"}}`))
+	assert.NoError(t, err)
+	assert.Equal(t, "contact_changed", task.Type())
+
+	// invalid: missing required action field
+	_, err = ctasks.ReadTask("contact_changed", []byte(`{"new_urn": {"value": "telegram:98765"}}`))
+	assert.ErrorContains(t, err, "action")
+
+	// invalid: unsupported action value
+	_, err = ctasks.ReadTask("contact_changed", []byte(`{"new_urn": {"value": "telegram:98765", "action": "prepend"}}`))
+	assert.ErrorContains(t, err, "action")
+
+	// unknown task type
+	_, err = ctasks.ReadTask("unknown", []byte(`{}`))
+	assert.ErrorContains(t, err, "unknown task type")
+}
+
 func TestTimedEvents(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()


### PR DESCRIPTION
## Summary
- Uses `utils.UnmarshalAndValidate` in `ctasks.ReadTask` instead of plain `json.Unmarshal`, matching the pattern already used by `tasks.ReadTask` for non-contact tasks
- This ensures `validate` struct tags (e.g. on `NewURNSpec`) are enforced when contact tasks are deserialized from Valkey, not just at the web layer

## Test plan
- [x] All existing ctasks tests pass