### PR TITLE
Add other_urns to courier send message payload

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -15,6 +15,7 @@ import (
 	valkey "github.com/gomodule/redigo/redis"
 	"github.com/lib/pq"
 	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/dbutil"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/urns"
@@ -674,15 +675,41 @@ func updateMessageStatus(ctx context.Context, db DBorTx, msgs []*Msg, status Msg
 
 // loads the bare minimum contact info we need for sending messages. Note that contacts may belong to
 // different orgs.
+const sqlSelectContactsForSending = `
+SELECT ROW_TO_JSON(r) FROM (SELECT
+	c.id,
+	c.uuid,
+	c.last_seen_on,
+	u.urns AS urns
+FROM
+	contacts_contact c
+LEFT JOIN (
+	SELECT contact_id,
+		array_agg(
+			json_build_object('id', u.id, 'identity', u.identity, 'scheme', u.scheme, 'path', path, 'display', display, 'channel_id', channel_id, 'auth_tokens', auth_tokens) ORDER BY priority DESC, id ASC
+		) AS urns
+	FROM contacts_contacturn u
+	WHERE u.contact_id = ANY($1)
+	GROUP BY contact_id
+) u ON c.id = u.contact_id
+WHERE c.id = ANY($1)
+) r`
+
 func loadContactsForSending(ctx context.Context, db *sqlx.DB, contactIDs []ContactID) (map[ContactID]*Contact, error) {
-	contacts := make([]*contactEnvelope, 0, len(contactIDs))
-	if err := db.SelectContext(ctx, &contacts, `SELECT id, uuid, last_seen_on FROM contacts_contact WHERE id = ANY($1)`, pq.Array(contactIDs)); err != nil {
+	rows, err := db.QueryContext(ctx, sqlSelectContactsForSending, pq.Array(contactIDs))
+	if err != nil {
 		return nil, fmt.Errorf("error loading contacts for sending: %w", err)
 	}
+	defer rows.Close()
 
-	contactsByID := make(map[ContactID]*Contact, len(contacts))
-	for _, c := range contacts {
-		contactsByID[c.ID] = &Contact{id: c.ID, uuid: c.UUID, lastSeenOn: c.LastSeenOn}
+	contactsByID := make(map[ContactID]*Contact, len(contactIDs))
+	for rows.Next() {
+		e := &contactEnvelope{}
+		if err := dbutil.ScanJSON(rows, e); err != nil {
+			return nil, fmt.Errorf("error scanning contact json: %w", err)
+		}
+
+		contactsByID[e.ID] = &Contact{id: e.ID, uuid: e.UUID, lastSeenOn: e.LastSeenOn, urns: e.URNs}
 	}
 
 	return contactsByID, nil

--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -46,6 +46,7 @@ type Contact struct {
 	ID         models.ContactID  `json:"id"`
 	UUID       flows.ContactUUID `json:"uuid"`
 	LastSeenOn *time.Time        `json:"last_seen_on,omitempty"`
+	OtherURNs  []urns.URN        `json:"other_urns,omitempty"` // currently needed for WA handlers to know if contact already has a BSUID URN, may not be needed long term
 }
 
 type OptInRef struct {
@@ -100,6 +101,17 @@ type Msg struct {
 	Session              *Session           `json:"session,omitempty"`
 }
 
+// otherURNs returns the identities of all URNs on the contact except the one being sent to
+func otherURNs(mo *models.MsgOut) []urns.URN {
+	var others []urns.URN
+	for _, u := range mo.Contact.URNs() {
+		if u.ID != mo.URN.ID {
+			others = append(others, u.Identity)
+		}
+	}
+	return others
+}
+
 // NewCourierMsg creates a courier message in the format it's expecting to be queued
 func NewCourierMsg(oa *models.OrgAssets, mo *models.MsgOut, ch *models.Channel) (*Msg, error) {
 	msg := &Msg{
@@ -109,6 +121,7 @@ func NewCourierMsg(oa *models.OrgAssets, mo *models.MsgOut, ch *models.Channel) 
 			ID:         mo.ContactID(),
 			UUID:       mo.Contact.UUID(),
 			LastSeenOn: mo.Contact.LastSeenOn(),
+			OtherURNs:  otherURNs(mo),
 		},
 		Text:         mo.Text(),
 		Attachments:  mo.Attachments(),

--- a/core/msgio/courier_test.go
+++ b/core/msgio/courier_test.go
@@ -32,6 +32,9 @@ func TestNewCourierMsg(t *testing.T) {
 	testFred := testdb.InsertContact(t, rt, testdb.Org1, "fed2d179-73ac-44fd-b838-7f866fef0a3a", "Fred", "eng", models.ContactStatusActive)
 	testdb.InsertContactURN(t, rt, testdb.Org1, testFred, "tel:+593979123456", 1000, map[string]string{fmt.Sprintf("optin:%d", optInID): "sesame"})
 
+	// add a second URN to Ann so we can test other_urns
+	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, "whatsapp:16055741111", 100, nil)
+
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOptIns)
 	require.NoError(t, err)
 	require.False(t, oa.Org().Suspended())
@@ -82,7 +85,7 @@ func TestNewCourierMsg(t *testing.T) {
 			"image/jpeg:https://dl-foo.com/image.jpg"
 		],
 		"channel_uuid": "0f661e8b-ea9d-4bd3-9953-d368340acf91",
-		"contact": {"id": 10000, "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf"},
+		"contact": {"id": 10000, "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf", "other_urns": ["whatsapp:16055741111"]},
 		"created_on": %s,
 		"flow": {"uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", "name": "Favorites"},
 		"high_priority": false,
@@ -132,7 +135,7 @@ func TestNewCourierMsg(t *testing.T) {
 
 	createAndAssertCourierMsg(t, oa, msg2, fmt.Sprintf(`{
 		"channel_uuid": "74729f45-7f29-4868-9dc4-90e491e3c7d8",
-		"contact": {"id": 10000, "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf", "last_seen_on": "2023-04-20T10:15:00Z"},
+		"contact": {"id": 10000, "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf", "last_seen_on": "2023-04-20T10:15:00Z", "other_urns": ["whatsapp:16055741111"]},
 		"created_on": %s,
 		"flow": {"uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", "name": "Favorites"},
 		"response_to_external_id": "EX123",
@@ -191,7 +194,7 @@ func TestNewCourierMsg(t *testing.T) {
 
 	createAndAssertCourierMsg(t, oa, msg4, fmt.Sprintf(`{
 		"channel_uuid": "74729f45-7f29-4868-9dc4-90e491e3c7d8",
-		"contact": {"id": 10000, "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf", "last_seen_on": "2023-04-20T10:15:00Z"},
+		"contact": {"id": 10000, "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf", "last_seen_on": "2023-04-20T10:15:00Z", "other_urns": ["whatsapp:16055741111"]},
 		"created_on": %s,
 		"flow": {"uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", "name": "Favorites"},
 		"high_priority": true,
@@ -228,7 +231,7 @@ func TestNewCourierMsg(t *testing.T) {
 			"image/jpeg:https://dl-foo.com/image.jpg"
 		],
 		"channel_uuid": "0f661e8b-ea9d-4bd3-9953-d368340acf91",
-		"contact": {"id": 10000, "last_seen_on": "2023-04-20T10:15:00Z", "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf"},
+		"contact": {"id": 10000, "last_seen_on": "2023-04-20T10:15:00Z", "other_urns": ["whatsapp:16055741111"], "uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf"},
 		"created_on": %s,
 		"flow": {"uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", "name": "Favorites"},
 		"high_priority": false,


### PR DESCRIPTION
## Summary
- Adds `other_urns` field to the contact object in courier send message payloads, containing all of the contact's URN identities except the one being sent to
- Allows courier handlers (e.g. WhatsApp) to check if a contact already has URNs of specific schemes like BSUID
- Also loads contact URNs in the retry/resend path so `other_urns` is populated there too

## Test plan
- [x] `TestNewCourierMsg` updated with a second URN on Ann to verify `other_urns` appears in payloads
- [x] Retry path test case also verifies `other_urns` is present
- [x] Fred (single URN) correctly omits `other_urns` from payload
- [x] All msgio and models tests pass