### PR TITLE
Add config to exclude specific orgs from latency metrics

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	S3AttachmentsBucket string `help:"S3 bucket to write attachments to"`
 	S3PathStyle         bool   `help:"S3 should use path style URLs"`
 
+	LatencyExcludedOrgs []int  `help:"comma separated list of org IDs to exclude from latency metrics"`
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
 	CloudwatchNamespace string `help:"the namespace to use for cloudwatch metrics"`
 	DeploymentID        string `help:"the deployment identifier to use for metrics"`

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -87,7 +87,7 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 	}
 
 	rt.Queues = newQueues(cfg)
-	rt.Stats = NewStatsCollector(rt.VK)
+	rt.Stats = NewStatsCollector(rt.VK, cfg.LatencyExcludedOrgs)
 
 	return rt, nil
 }

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -20,11 +20,12 @@ type LLMTypeAndModel struct {
 }
 
 type Stats struct {
-	ContactTaskCount    map[string]int           // number of contact tasks handled by type
-	ContactTaskErrors   map[string]int           // number of contact tasks that errored by type
-	ContactTaskDuration map[string]time.Duration // total time spent handling contact tasks
-	ContactTaskLatency  map[string]time.Duration // total time spent queuing and handling contact tasks
-	RealtimeLockFails   int                      // number of times an attempt to get a contact lock failed
+	ContactTaskCount        map[string]int           // number of contact tasks handled by type
+	ContactTaskErrors       map[string]int           // number of contact tasks that errored by type
+	ContactTaskDuration     map[string]time.Duration // total time spent handling contact tasks
+	ContactTaskLatency      map[string]time.Duration // total time spent queuing and handling contact tasks (excluding excluded orgs)
+	ContactTaskLatencyCount map[string]int           // number of contact tasks whose latency was included in ContactTaskLatency
+	RealtimeLockFails       int                      // number of times an attempt to get a contact lock failed
 
 	CronTaskCount    map[string]int           // number of cron tasks run by type
 	CronTaskDuration map[string]time.Duration // total time spent running cron tasks
@@ -41,10 +42,11 @@ type Stats struct {
 
 func newStats() *Stats {
 	return &Stats{
-		ContactTaskCount:    make(map[string]int),
-		ContactTaskErrors:   make(map[string]int),
-		ContactTaskDuration: make(map[string]time.Duration),
-		ContactTaskLatency:  make(map[string]time.Duration),
+		ContactTaskCount:        make(map[string]int),
+		ContactTaskErrors:       make(map[string]int),
+		ContactTaskDuration:     make(map[string]time.Duration),
+		ContactTaskLatency:      make(map[string]time.Duration),
+		ContactTaskLatencyCount: make(map[string]int),
 
 		CronTaskCount:    make(map[string]int),
 		CronTaskDuration: make(map[string]time.Duration),
@@ -63,14 +65,21 @@ func (s *Stats) ToMetrics(advanced bool) []types.MetricDatum {
 	for typ, count := range s.ContactTaskCount {
 		// convert task timings to averages
 		avgDuration := s.ContactTaskDuration[typ] / time.Duration(count)
-		avgLatency := s.ContactTaskLatency[typ] / time.Duration(count)
+		typDim := cwatch.Dimension("TaskType", typ)
 
 		metrics = append(metrics,
-			cwatch.Datum("HandlerTaskCount", float64(count), types.StandardUnitCount, cwatch.Dimension("TaskType", typ)),
-			cwatch.Datum("HandlerTaskErrors", float64(s.ContactTaskErrors[typ]), types.StandardUnitCount, cwatch.Dimension("TaskType", typ)),
-			cwatch.Datum("HandlerTaskDuration", float64(avgDuration)/float64(time.Second), types.StandardUnitCount, cwatch.Dimension("TaskType", typ)),
-			cwatch.Datum("HandlerTaskLatency", float64(avgLatency)/float64(time.Second), types.StandardUnitCount, cwatch.Dimension("TaskType", typ)),
+			cwatch.Datum("HandlerTaskCount", float64(count), types.StandardUnitCount, typDim),
+			cwatch.Datum("HandlerTaskErrors", float64(s.ContactTaskErrors[typ]), types.StandardUnitCount, typDim),
+			cwatch.Datum("HandlerTaskDuration", float64(avgDuration)/float64(time.Second), types.StandardUnitCount, typDim),
 		)
+
+		// latency average uses its own count because tasks from excluded orgs aren't added to the sum
+		if latencyCount := s.ContactTaskLatencyCount[typ]; latencyCount > 0 {
+			avgLatency := s.ContactTaskLatency[typ] / time.Duration(latencyCount)
+			metrics = append(metrics,
+				cwatch.Datum("HandlerTaskLatency", float64(avgLatency)/float64(time.Second), types.StandardUnitCount, typDim),
+			)
+		}
 	}
 
 	for typeAndModel, count := range s.LLMCallCount {
@@ -142,6 +151,7 @@ func (c *StatsCollector) RecordContactTask(typ string, orgID int, d, l time.Dura
 	c.stats.ContactTaskDuration[typ] += d
 	if !c.excludedOrgs[orgID] {
 		c.stats.ContactTaskLatency[typ] += l
+		c.stats.ContactTaskLatencyCount[typ]++
 	}
 	if errored {
 		c.stats.ContactTaskErrors[typ]++

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -121,21 +121,28 @@ func (s *Stats) ToMetrics(advanced bool) []types.MetricDatum {
 
 // StatsCollector provides threadsafe stats collection
 type StatsCollector struct {
-	vk    *valkey.Pool
-	mutex sync.Mutex
-	stats *Stats
+	vk           *valkey.Pool
+	excludedOrgs map[int]bool
+	mutex        sync.Mutex
+	stats        *Stats
 }
 
 // NewStatsCollector creates a new stats collector
-func NewStatsCollector(vk *valkey.Pool) *StatsCollector {
-	return &StatsCollector{vk: vk, stats: newStats()}
+func NewStatsCollector(vk *valkey.Pool, excludedOrgs []int) *StatsCollector {
+	excluded := make(map[int]bool, len(excludedOrgs))
+	for _, id := range excludedOrgs {
+		excluded[id] = true
+	}
+	return &StatsCollector{vk: vk, excludedOrgs: excluded, stats: newStats()}
 }
 
 func (c *StatsCollector) RecordContactTask(typ string, orgID int, d, l time.Duration, errored bool) {
 	c.mutex.Lock()
 	c.stats.ContactTaskCount[typ]++
 	c.stats.ContactTaskDuration[typ] += d
-	c.stats.ContactTaskLatency[typ] += l
+	if !c.excludedOrgs[orgID] {
+		c.stats.ContactTaskLatency[typ] += l
+	}
 	if errored {
 		c.stats.ContactTaskErrors[typ]++
 	}

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -19,7 +19,7 @@ func TestStats(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	sc := runtime.NewStatsCollector(rt.VK)
+	sc := runtime.NewStatsCollector(rt.VK, nil)
 	sc.RecordCronTask("make_foos", 10*time.Second)
 	sc.RecordCronTask("make_foos", 5*time.Second)
 	sc.RecordLLMCall("openai", "gpt-4", 7*time.Second)
@@ -79,4 +79,36 @@ func TestStats(t *testing.T) {
 			{Type: "msg_received", Count: 2, TotalMS: 400, AvgMS: 200},
 		}},
 	}, latencies)
+}
+
+func TestStatsLatencyExcludedOrgs(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	// create collector with org 2 excluded from latency metrics
+	sc := runtime.NewStatsCollector(rt.VK, []int{2})
+
+	sc.RecordContactTask("msg_received", 1, 100*time.Millisecond, 200*time.Millisecond, false)
+	sc.RecordContactTask("msg_received", 2, 100*time.Millisecond, 5*time.Second, false)
+	sc.RecordContactTask("msg_received", 3, 100*time.Millisecond, 300*time.Millisecond, false)
+
+	stats := sc.Extract()
+
+	// count and duration include all orgs
+	assert.Equal(t, 3, stats.ContactTaskCount["msg_received"])
+	assert.Equal(t, 300*time.Millisecond, stats.ContactTaskDuration["msg_received"])
+
+	// latency excludes org 2
+	assert.Equal(t, 500*time.Millisecond, stats.ContactTaskLatency["msg_received"])
+
+	// but per-org Valkey latency still includes org 2
+	key := fmt.Sprintf("ctask_latency:%s", time.Now().UTC().Format("2006-01-02T15"))
+	assertvk.HGetAll(t, vc, key, map[string]string{
+		"1/msg_received:n": "1", "1/msg_received:t": "200",
+		"2/msg_received:n": "1", "2/msg_received:t": "5000",
+		"3/msg_received:n": "1", "3/msg_received:t": "300",
+	})
 }

--- a/runtime/stats_test.go
+++ b/runtime/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/vkutil/assertvk"
@@ -101,8 +102,15 @@ func TestStatsLatencyExcludedOrgs(t *testing.T) {
 	assert.Equal(t, 3, stats.ContactTaskCount["msg_received"])
 	assert.Equal(t, 300*time.Millisecond, stats.ContactTaskDuration["msg_received"])
 
-	// latency excludes org 2
+	// latency sum and count both exclude org 2
 	assert.Equal(t, 500*time.Millisecond, stats.ContactTaskLatency["msg_received"])
+	assert.Equal(t, 2, stats.ContactTaskLatencyCount["msg_received"])
+
+	// CloudWatch metric HandlerTaskLatency should average over the 2 non-excluded tasks (250ms)
+	// not over all 3 tasks (which would incorrectly give ~167ms)
+	datums := stats.ToMetrics(false)
+	assert.Equal(t, 0.25, findDatumValue(t, datums, "HandlerTaskLatency"))
+	assert.Equal(t, float64(3), findDatumValue(t, datums, "HandlerTaskCount"))
 
 	// but per-org Valkey latency still includes org 2
 	key := fmt.Sprintf("ctask_latency:%s", time.Now().UTC().Format("2006-01-02T15"))
@@ -111,4 +119,24 @@ func TestStatsLatencyExcludedOrgs(t *testing.T) {
 		"2/msg_received:n": "1", "2/msg_received:t": "5000",
 		"3/msg_received:n": "1", "3/msg_received:t": "300",
 	})
+
+	// if all orgs for a task type are excluded, HandlerTaskLatency should be omitted (no div-by-zero)
+	sc2 := runtime.NewStatsCollector(rt.VK, []int{5})
+	sc2.RecordContactTask("msg_received", 5, 100*time.Millisecond, 200*time.Millisecond, false)
+	datums2 := sc2.Extract().ToMetrics(false)
+
+	for _, d := range datums2 {
+		assert.NotEqual(t, "HandlerTaskLatency", *d.MetricName, "HandlerTaskLatency should be omitted when all orgs are excluded")
+	}
+}
+
+// findDatumValue returns the value of the first MetricDatum with the given name
+func findDatumValue(t *testing.T, datums []types.MetricDatum, name string) float64 {
+	for _, d := range datums {
+		if d.MetricName != nil && *d.MetricName == name {
+			return *d.Value
+		}
+	}
+	t.Fatalf("no datum with name %q found", name)
+	return 0
 }


### PR DESCRIPTION
## Summary
- Adds `LatencyExcludedOrgs` config option (env var `MAILROOM_LATENCY_EXCLUDED_ORGS`) to exclude specified org IDs from the aggregated `HandlerTaskLatency` CloudWatch metric
- Excluded orgs still have their count, duration, and errors recorded normally, and their per-org latency is still tracked in Valkey for the `/system/latency` endpoint
- Addresses the issue of a handful of orgs with slow webhooks skewing the latency metric for everyone

## Test plan
- [ ] Verify `TestStatsLatencyExcludedOrgs` passes
- [ ] Deploy with `MAILROOM_LATENCY_EXCLUDED_ORGS` set to known slow orgs and confirm CloudWatch latency metric improves