### PR TITLE
Fix TestEventReceived and TestMsgReceivedTask after goflow scheme check

### DIFF
--- a/core/tasks/ctasks/event_received_test.go
+++ b/core/tasks/ctasks/event_received_test.go
@@ -55,6 +55,10 @@ func TestEventReceived(t *testing.T) {
 	// add a URN for Ann so we can test twitter URNs
 	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Bob, urns.URN("twitterid:123456"), 10, nil)
 
+	// add facebook URNs for Ann and Bob so that Facebook new_conversation events have a matching URN
+	annFacebookURNID := testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, urns.URN("facebook:1000000000001"), 100, nil)
+	bobFacebookURNID := testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Bob, urns.URN("facebook:1000000000002"), 100, nil)
+
 	// insert a dummy event into the database that will get the updates from handling each event which pretends to be it
 	eventID := testdb.InsertChannelEvent(t, rt, testdb.Org1, "019ae4fc-56c6-7a94-b757-dcf0640e5ebc", models.EventTypeMissedCall, testdb.TwilioChannel, testdb.Ann, models.EventStatusPending)
 
@@ -73,6 +77,13 @@ func TestEventReceived(t *testing.T) {
 
 	jsonx.MustUnmarshal(tcJSON, &tcs)
 
+	// map of hardcoded placeholder URN IDs used in the JSON to actual dynamic IDs for facebook URNs,
+	// so that Facebook channel events are received on a URN whose scheme actually matches the channel
+	urnIDSubs := map[models.URNID]models.URNID{
+		testdb.Ann.URNID: annFacebookURNID,
+		testdb.Bob.URNID: bobFacebookURNID,
+	}
+
 	reset := test.MockUniverse()
 	defer reset()
 
@@ -86,7 +97,18 @@ func TestEventReceived(t *testing.T) {
 		// reset our dummy db event into an unhandled state
 		rt.DB.MustExec(`UPDATE channels_channelevent SET status = 'P' WHERE id = $1`, eventID)
 
-		err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, contact.ID(), tc.Task)
+		// for Facebook channel events, rewrite the URN ID to the contact's facebook URN so goflow
+		// can resolve the channel by scheme when building outbound messages
+		taskToQueue := tc.Task
+		if taskToQueue.ChannelID == testdb.FacebookChannel.ID {
+			if subID, ok := urnIDSubs[taskToQueue.URNID]; ok {
+				taskCopy := *taskToQueue
+				taskCopy.URNID = subID
+				taskToQueue = &taskCopy
+			}
+		}
+
+		err = tasks.QueueContact(ctx, rt, testdb.Org1.ID, contact.ID(), taskToQueue)
 		assert.NoError(t, err, "%d: error adding task", i)
 
 		task, err := rt.Queues.Realtime.Pop(ctx, vc)

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -84,21 +84,21 @@ func TestMsgReceivedTask(t *testing.T) {
 	}{
 		{ // 0: no trigger match, inbox message
 			org:                testdb.Org1,
-			channel:            testdb.FacebookChannel,
+			channel:            testdb.TwilioChannel,
 			contact:            testdb.Ann,
 			text:               "noop",
 			expectedVisibility: models.VisibilityVisible,
 		},
 		{ // 1: no trigger match, inbox message (trigger is keyword only)
 			org:                testdb.Org1,
-			channel:            testdb.FacebookChannel,
+			channel:            testdb.TwilioChannel,
 			contact:            testdb.Ann,
 			text:               "start other",
 			expectedVisibility: models.VisibilityVisible,
 		},
 		{ // 2: keyword trigger match, flow message
 			org:                 testdb.Org1,
-			channel:             testdb.FacebookChannel,
+			channel:             testdb.TwilioChannel,
 			contact:             testdb.Ann,
 			text:                "start",
 			expectedVisibility:  models.VisibilityVisible,
@@ -108,7 +108,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 3:
 			org:                 testdb.Org1,
-			channel:             testdb.FacebookChannel,
+			channel:             testdb.TwilioChannel,
 			contact:             testdb.Ann,
 			text:                "purple",
 			expectedVisibility:  models.VisibilityVisible,
@@ -118,7 +118,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 4:
 			org:                 testdb.Org1,
-			channel:             testdb.FacebookChannel,
+			channel:             testdb.TwilioChannel,
 			contact:             testdb.Ann,
 			text:                "blue",
 			expectedVisibility:  models.VisibilityVisible,
@@ -128,7 +128,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 5:
 			org:                 testdb.Org1,
-			channel:             testdb.FacebookChannel,
+			channel:             testdb.TwilioChannel,
 			contact:             testdb.Ann,
 			text:                "MUTZIG",
 			expectedVisibility:  models.VisibilityVisible,
@@ -138,7 +138,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 6:
 			org:                 testdb.Org1,
-			channel:             testdb.FacebookChannel,
+			channel:             testdb.TwilioChannel,
 			contact:             testdb.Ann,
 			text:                "Ann",
 			expectedVisibility:  models.VisibilityVisible,
@@ -148,7 +148,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 7:
 			org:                testdb.Org1,
-			channel:            testdb.FacebookChannel,
+			channel:            testdb.TwilioChannel,
 			contact:            testdb.Ann,
 			text:               "noop",
 			expectedVisibility: models.VisibilityVisible,
@@ -215,7 +215,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 14:
 			org:                testdb.Org1,
-			channel:            testdb.FacebookChannel,
+			channel:            testdb.TwilioChannel,
 			contact:            testdb.Bob,
 			text:               "ivr",
 			expectedVisibility: models.VisibilityVisible,
@@ -225,7 +225,7 @@ func TestMsgReceivedTask(t *testing.T) {
 				rt.DB.MustExec(`UPDATE contacts_contact SET status = 'S' WHERE id = $1`, testdb.Cat.ID)
 			},
 			org:                 testdb.Org1,
-			channel:             testdb.FacebookChannel,
+			channel:             testdb.TwilioChannel,
 			contact:             testdb.Cat,
 			text:                "start",
 			expectedVisibility:  models.VisibilityVisible,
@@ -287,7 +287,7 @@ func TestMsgReceivedTask(t *testing.T) {
 		},
 		{ // 21: blocked contact
 			org:                testdb.Org1,
-			channel:            testdb.FacebookChannel,
+			channel:            testdb.TwilioChannel,
 			contact:            blocked,
 			text:               "start",
 			expectedVisibility: models.VisibilityArchived,
@@ -383,8 +383,8 @@ func TestMsgReceivedTask(t *testing.T) {
 
 	// check messages queued to courier
 	testsuite.AssertCourierQueues(t, rt, map[string][]int{
-		fmt.Sprintf("msgs:%s|10/1", testdb.FacebookChannel.UUID): {1, 1, 1, 1, 1, 1},
-		fmt.Sprintf("msgs:%s|10/1", testdb.Org2Channel.UUID):     {1, 1, 1, 1, 1, 1, 1, 1, 1},
+		fmt.Sprintf("msgs:%s|10/1", testdb.TwilioChannel.UUID): {1, 1, 1, 1, 1, 1},
+		fmt.Sprintf("msgs:%s|10/1", testdb.Org2Channel.UUID):   {1, 1, 1, 1, 1, 1, 1, 1, 1},
 	})
 
 	// Fred's sessions should not have a timeout because courier will set them

--- a/core/tasks/ctasks/testdata/event_received.json
+++ b/core/tasks/ctasks/testdata/event_received.json
@@ -30,7 +30,8 @@
                     "created_on": "2025-05-04T12:30:49.123456789Z",
                     "type": "contact_urns_changed",
                     "urns": [
-                        "tel:+16055741111?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91"
+                        "facebook:1000000000001?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91",
+                        "tel:+16055741111"
                     ]
                 }
             },
@@ -75,7 +76,7 @@
                         },
                         "locale": "und-US",
                         "text": "What is your favorite color?",
-                        "urn": "tel:+16055741111"
+                        "urn": "facebook:1000000000001"
                     },
                     "type": "msg_created"
                 }
@@ -104,7 +105,8 @@
                     "created_on": "2025-05-04T12:31:20.123456789Z",
                     "type": "contact_urns_changed",
                     "urns": [
-                        "tel:+16055741111?channel=19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
+                        "tel:+16055741111?channel=19012bfd-3ce3-4cae-9bb9-76cf92c73d49",
+                        "facebook:1000000000001?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91"
                     ]
                 }
             },
@@ -160,7 +162,8 @@
                     "created_on": "2025-05-04T12:31:36.123456789Z",
                     "type": "contact_urns_changed",
                     "urns": [
-                        "tel:+16055741111?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91"
+                        "facebook:1000000000001?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91",
+                        "tel:+16055741111?channel=19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
                     ]
                 }
             },
@@ -206,7 +209,8 @@
                     "created_on": "2025-05-04T12:31:46.123456789Z",
                     "type": "contact_urns_changed",
                     "urns": [
-                        "tel:+16055741111?channel=19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
+                        "tel:+16055741111?channel=19012bfd-3ce3-4cae-9bb9-76cf92c73d49",
+                        "facebook:1000000000001?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91"
                     ]
                 }
             },
@@ -574,7 +578,8 @@
                     "created_on": "2025-05-04T12:33:48.123456789Z",
                     "type": "contact_urns_changed",
                     "urns": [
-                        "tel:+16055742222?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91",
+                        "facebook:1000000000002?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91",
+                        "tel:+16055742222",
                         "twitterid:123456"
                     ]
                 }
@@ -620,7 +625,7 @@
                         },
                         "locale": "und-US",
                         "text": "What is your favorite color?",
-                        "urn": "tel:+16055742222"
+                        "urn": "facebook:1000000000002"
                     },
                     "type": "msg_created"
                 }


### PR DESCRIPTION
## Summary
- goflow [v0.273.4](https://github.com/nyaruka/goflow/pull/1505) made `Channels().GetForURN()` require the preferred channel to actually support the URN's scheme. This broke two mailroom tests that were pairing `FacebookChannel` (only supports `facebook`) with contacts that only have `tel:` URNs.
- `TestMsgReceivedTask`: the affected cases weren't specifically testing Facebook behavior, so switched them from `FacebookChannel` to `TwilioChannel` which matches the contacts' `tel:` URNs.
- `TestEventReceived`: the two "new conversation on Facebook" cases *are* specifically testing Facebook `new_conversation` triggers, so Ann and Bob now get `facebook:` URNs inserted at test setup, and the Facebook-channel task `URNID` is substituted at runtime (the JSON snapshot keeps stable placeholder IDs).

## Test plan
- [x] `docker exec dev-mailroom go test -p=1 -run 'TestEventReceived|TestMsgReceivedTask|TestMsgReceivedNewURN' ./core/tasks/ctasks/`
- [x] `docker exec dev-mailroom go test -p=1 ./core/tasks/ctasks/`