### PR TITLE
Index newly created contacts in Elasticsearch

### DIFF
--- a/web/contact/create.go
+++ b/web/contact/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/web"
 )
@@ -58,6 +59,10 @@ func handleCreate(ctx context.Context, rt *runtime.Runtime, r *createRequest) (a
 	_, err = runner.ModifyWithoutLock(ctx, rt, oa, r.UserID, []*models.Contact{mc}, []*flows.Contact{contact}, modifiers, r.Via)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error modifying new contact: %w", err)
+	}
+
+	if err := search.IndexContacts(ctx, rt, oa, []*flows.Contact{contact}, nil); err != nil {
+		return nil, 0, fmt.Errorf("error indexing new contact: %w", err)
 	}
 
 	return map[string]any{"contact": contact}, http.StatusOK, nil


### PR DESCRIPTION
Contact creation relied on post-commit hooks attached by modifier event handlers to trigger Elasticsearch indexing. When a contact was created with no fields or groups (e.g. just a name and URNs), no modifiers were applied, no events fired, and the `IndexContacts` hook was never attached — so the contact was never indexed. This adds an explicit `search.IndexContacts` call after creation to ensure every new contact is indexed.