### PR TITLE
Index newly created contacts in Elastic

### DIFF
--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/goflow/flows/modifiers"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/vinovest/sqlx"
 )
@@ -80,6 +81,20 @@ func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 				}
 			}
 		}
+	}
+
+	// ensure newly created contacts are indexed in elastic (modifiers may not have generated events
+	// that trigger the indexing hook, e.g. when only URNs are set)
+	createdContacts := make([]*flows.Contact, 0, len(imports))
+	createdFlows := make(map[models.ContactID]models.FlowID, len(imports))
+	for _, imp := range imports {
+		if imp.contact != nil && imp.created {
+			createdContacts = append(createdContacts, imp.flowContact)
+			createdFlows[imp.contact.ID()] = imp.contact.CurrentFlowID()
+		}
+	}
+	if err := search.IndexContacts(ctx, rt, oa, createdContacts, createdFlows); err != nil {
+		return fmt.Errorf("error indexing new contacts: %w", err)
 	}
 
 	if err := markBatchComplete(ctx, rt.DB, b, imports); err != nil {

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -1063,7 +1063,13 @@ func UpdateContactURNs(ctx context.Context, rt *runtime.Runtime, db DBorTx, oa *
 			cu := change.Contact.FindURN(urn)
 
 			if cu != nil {
-				cu.ChannelID = channelID
+				// only overwrite channel affinity if the event URN actually specified one - otherwise preserve
+				// the existing channel_id. The goflow round-trip silently drops channel UUIDs that aren't in
+				// SessionAssets (e.g. disabled channels), and we don't want to wipe perfectly valid channel
+				// affinity just because the engine couldn't resolve the channel.
+				if channelID != NilChannelID {
+					cu.ChannelID = channelID
+				}
 				cu.Priority = priority
 				updates = append(updates, cu)
 				updatedURNIDs = append(updatedURNIDs, cu.ID)

--- a/core/tasks/ctasks/base.go
+++ b/core/tasks/ctasks/base.go
@@ -84,7 +84,10 @@ type NewURNSpec struct {
 }
 
 // Apply appends the new URN to the contact, recording channel affinity for the given channel if set.
-func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, scene *runner.Scene, channel *models.Channel) error {
+// Returns whether the URN was newly added (i.e. didn't already exist on the contact).
+func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, scene *runner.Scene, channel *models.Channel) (bool, error) {
+	wasNew := scene.DBContact.FindURN(s.Value) == nil
+
 	var flowCh *flows.Channel
 	if channel != nil {
 		flowCh = oa.SessionAssets().Channels().Get(channel.UUID())
@@ -92,7 +95,25 @@ func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.
 
 	mod := modifiers.NewRoutes([]flows.Route{{URN: s.Value, Channel: flowCh}}, modifiers.RoutesAppend)
 	if err := scene.ApplyModifier(ctx, rt, oa, mod, models.NilUserID, ""); err != nil {
-		return fmt.Errorf("error applying routes modifier: %w", err)
+		return false, fmt.Errorf("error applying routes modifier: %w", err)
+	}
+	return wasNew, nil
+}
+
+// EnsureChannel makes sure a newly created URN has the given channel affinity - required when the
+// channel isn't loaded in oa (e.g. is_enabled=false) and so the goflow routes modifier couldn't attach
+// the channel via SessionAssets. Called after scene.Commit() so that the URN row is already persisted,
+// and only if Apply reported the URN as newly added.
+func (s *NewURNSpec) EnsureChannel(ctx context.Context, db models.DBorTx, contactID models.ContactID, channelID models.ChannelID) error {
+	if channelID == models.NilChannelID {
+		return nil
+	}
+	_, err := db.ExecContext(ctx,
+		`UPDATE contacts_contacturn SET channel_id = $1 WHERE contact_id = $2 AND identity = $3 AND channel_id IS NULL`,
+		channelID, contactID, s.Value.Identity(),
+	)
+	if err != nil {
+		return fmt.Errorf("error ensuring channel_id on new URN: %w", err)
 	}
 	return nil
 }

--- a/core/tasks/ctasks/contact_changed.go
+++ b/core/tasks/ctasks/contact_changed.go
@@ -32,14 +32,23 @@ func (t *ContactChanged) Perform(ctx context.Context, rt *runtime.Runtime, oa *m
 
 	scene := runner.NewScene(mc, contact)
 
+	var newURNAdded bool
 	if t.NewURN != nil {
-		if err := t.NewURN.Apply(ctx, rt, oa, scene, oa.ChannelByID(t.ChannelID)); err != nil {
+		added, err := t.NewURN.Apply(ctx, rt, oa, scene, oa.ChannelByID(t.ChannelID))
+		if err != nil {
 			return fmt.Errorf("error applying new URN: %w", err)
 		}
+		newURNAdded = added
 	}
 
 	if err := scene.Commit(ctx, rt, oa); err != nil {
 		return fmt.Errorf("error committing scene: %w", err)
+	}
+
+	if newURNAdded {
+		if err := t.NewURN.EnsureChannel(ctx, rt.DB, mc.ID(), t.ChannelID); err != nil {
+			return fmt.Errorf("error ensuring channel affinity on new URN: %w", err)
+		}
 	}
 
 	return nil

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -46,7 +46,7 @@ func TestContactChanged(t *testing.T) {
 			},
 		},
 		{
-			label: "append duplicate URN",
+			label: "append duplicate URN leaves existing channel_id alone",
 			preHook: func() {
 				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme = 'telegram'`, testdb.Bob.ID)
 				testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Bob, "telegram:98765", 999, nil)
@@ -57,7 +57,8 @@ func TestContactChanged(t *testing.T) {
 				Value:  "telegram:98765",
 				Action: "append",
 			},
-			// telegram URN already existed without a channel, no modification event emitted
+			// telegram URN already existed without a channel - modifier is a no-op and the post-commit
+			// channel fixup only applies to truly new URNs, so the existing NULL channel_id is preserved.
 			expectedURN: []urnRow{
 				{Identity: "tel:+16055742222", ChannelID: nil},
 				{Identity: "telegram:98765", ChannelID: nil},

--- a/core/tasks/ctasks/msg_received.go
+++ b/core/tasks/ctasks/msg_received.go
@@ -115,10 +115,13 @@ func (t *MsgReceived) perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 	}
 
 	// if a new URN was specified, append it (with channel affinity) before affinity
+	var newURNAdded bool
 	if t.NewURN != nil {
-		if err := t.NewURN.Apply(ctx, rt, oa, scene, channel); err != nil {
+		added, err := t.NewURN.Apply(ctx, rt, oa, scene, channel)
+		if err != nil {
 			return fmt.Errorf("error applying new URN: %w", err)
 		}
+		newURNAdded = added
 	}
 
 	// if we have URNs make sure the message URN is our highest priority (this is usually a noop)
@@ -145,6 +148,12 @@ func (t *MsgReceived) perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 
 	if err := scene.Commit(ctx, rt, oa); err != nil {
 		return fmt.Errorf("error committing scene: %w", err)
+	}
+
+	if newURNAdded {
+		if err := t.NewURN.EnsureChannel(ctx, rt.DB, mc.ID(), t.ChannelID); err != nil {
+			return fmt.Errorf("error ensuring channel affinity on new URN: %w", err)
+		}
 	}
 
 	return nil

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -453,6 +453,7 @@ func TestMsgReceivedNewURN(t *testing.T) {
 		preHook     func()
 		contact     *testdb.Contact
 		channel     *testdb.Channel
+		newContact  bool
 		newURN      *ctasks.NewURNSpec
 		expectedURN []urnRow
 	}{
@@ -486,6 +487,23 @@ func TestMsgReceivedNewURN(t *testing.T) {
 			},
 		},
 		{
+			label: "new contact with bsuid URN saves channel affinity",
+			preHook: func() {
+				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme IN ('telegram', 'bsuid')`, testdb.Bob.ID)
+			},
+			contact:    testdb.Bob,
+			channel:    testdb.TwilioChannel,
+			newContact: true,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "bsuid:US.NEWCONTACT",
+				Action: "append",
+			},
+			expectedURN: []urnRow{
+				{Identity: "tel:+16055742222", ChannelID: &testdb.TwilioChannel.ID},
+				{Identity: "bsuid:US.NEWCONTACT", ChannelID: &testdb.TwilioChannel.ID},
+			},
+		},
+		{
 			label: "append dedup existing URN",
 			preHook: func() {
 				// reset Bob's URNs to original state
@@ -504,6 +522,31 @@ func TestMsgReceivedNewURN(t *testing.T) {
 				{Identity: "telegram:98765", ChannelID: nil},
 			},
 		},
+		{
+			label: "append new bsuid URN saves channel affinity even when channel is disabled in mailroom",
+			preHook: func() {
+				// clear any prior bsuid/telegram URNs, wipe tel's channel affinity so we can see if the disabled
+				// channel case clobbers it, and disable the twilio channel in mailroom (courier still uses it).
+				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme IN ('telegram', 'bsuid')`, testdb.Bob.ID)
+				rt.DB.MustExec(`UPDATE contacts_contacturn SET channel_id = NULL WHERE contact_id = $1`, testdb.Bob.ID)
+				rt.DB.MustExec(`UPDATE channels_channel SET is_enabled = FALSE WHERE id = $1`, testdb.TwilioChannel.ID)
+				t.Cleanup(func() {
+					rt.DB.MustExec(`UPDATE channels_channel SET is_enabled = TRUE WHERE id = $1`, testdb.TwilioChannel.ID)
+				})
+			},
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "bsuid:US.DISABLED",
+				Action: "append",
+			},
+			// tel URN's NULL channel_id should be preserved (Fix 1), and the new bsuid URN should pick
+			// up the task's ChannelID via post-commit fixup (Fix 2) even though oa.ChannelByID is nil.
+			expectedURN: []urnRow{
+				{Identity: "tel:+16055742222", ChannelID: nil},
+				{Identity: "bsuid:US.DISABLED", ChannelID: &testdb.TwilioChannel.ID},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -517,12 +560,13 @@ func TestMsgReceivedNewURN(t *testing.T) {
 			rt.DB.MustExec(`UPDATE msgs_msg SET status = 'P', flow_id = NULL WHERE id = $1`, dbMsg.ID)
 
 			task := &ctasks.MsgReceived{
-				ChannelID: tc.channel.ID,
-				MsgUUID:   dbMsg.UUID,
-				URN:       tc.contact.URN,
-				URNID:     tc.contact.URNID,
-				Text:      "hello",
-				NewURN:    tc.newURN,
+				ChannelID:  tc.channel.ID,
+				MsgUUID:    dbMsg.UUID,
+				URN:        tc.contact.URN,
+				URNID:      tc.contact.URNID,
+				Text:       "hello",
+				NewContact: tc.newContact,
+				NewURN:     tc.newURN,
 			}
 
 			err := tasks.QueueContact(ctx, rt, testdb.Org1.ID, tc.contact.ID, task)

--- a/web/contact/create.go
+++ b/web/contact/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/web"
 )
@@ -58,6 +59,13 @@ func handleCreate(ctx context.Context, rt *runtime.Runtime, r *createRequest) (a
 	_, err = runner.ModifyWithoutLock(ctx, rt, oa, r.UserID, []*models.Contact{mc}, []*flows.Contact{contact}, modifiers, r.Via)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error modifying new contact: %w", err)
+	}
+
+	// ensure newly created contact is indexed in elastic (modifiers may not have generated events
+	// that trigger the indexing hook, e.g. when no fields or groups are set)
+	currentFlows := map[models.ContactID]models.FlowID{mc.ID(): mc.CurrentFlowID()}
+	if err := search.IndexContacts(ctx, rt, oa, []*flows.Contact{contact}, currentFlows); err != nil {
+		return nil, 0, fmt.Errorf("error indexing new contact: %w", err)
 	}
 
 	return map[string]any{"contact": contact}, http.StatusOK, nil


### PR DESCRIPTION
## Summary
- Fix newly created contacts not being indexed in Elasticsearch when created via `/contact/create` or imports
- The Elastic indexing post-commit hook only fires when modifier events are generated (field/group changes), but contact creation sets name/language/URNs directly in the DB — so contacts created with no fields or groups were never indexed
- Add explicit `search.IndexContacts()` calls after creation in both `web/contact/create.go` and `core/imports/contacts.go`
- Fix channel affinity handling for new URNs: preserve existing `channel_id` when the event URN doesn't specify one, and ensure affinity is set on truly new URNs even when the channel isn't loaded in SessionAssets (e.g. disabled channels)

## Test plan
- [ ] Create a contact via `/contact/create` with only name and URN (no fields/groups) and verify it appears in Elastic
- [ ] Create a contact via `/contact/create` with fields and groups and verify it appears in Elastic
- [ ] Import contacts with only URNs and verify they appear in Elastic
- [ ] Run existing test suites for `web/contact`, `core/imports`, and `core/tasks/ctasks`