### PR TITLE
Add --modified-after flag to mrindex contacts command

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -49,6 +49,11 @@ func Index() error {
 	if mode != "contacts" && mode != "messages" {
 		return fmt.Errorf("usage: mrindex [--start-uuid UUID] [--modified-after TIMESTAMP] <contacts|messages>")
 	}
+	for _, arg := range flags.Args()[1:] {
+		if len(arg) > 0 && arg[0] == '-' {
+			return fmt.Errorf("unexpected flag %q after mode %q: place flags before <contacts|messages>", arg, mode)
+		}
+	}
 
 	ctx := context.TODO()
 
@@ -56,7 +61,7 @@ func Index() error {
 	if *modifiedAfter != "" {
 		t, err := time.Parse(time.RFC3339, *modifiedAfter)
 		if err != nil {
-			return fmt.Errorf("error parsing --modified-after: %w", err)
+			return fmt.Errorf("error parsing --modified-after %q: must be RFC3339: %w", *modifiedAfter, err)
 		}
 		modifiedAfterTime = &t
 	}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -42,25 +42,35 @@ func Index() error {
 	// parse mode from args
 	flags := flag.NewFlagSet("mrindex", flag.ExitOnError)
 	startUUID := flags.String("start-uuid", "", "UUID to start from (messages mode only, works backwards from here)")
+	modifiedAfter := flags.String("modified-after", "", "only index contacts modified after this timestamp (contacts mode only, RFC3339 format)")
 	flags.Parse(os.Args[1:])
 
 	mode := flags.Arg(0)
 	if mode != "contacts" && mode != "messages" {
-		return fmt.Errorf("usage: mrindex [--start-uuid UUID] <contacts|messages>")
+		return fmt.Errorf("usage: mrindex [--start-uuid UUID] [--modified-after TIMESTAMP] <contacts|messages>")
 	}
 
 	ctx := context.TODO()
 
+	var modifiedAfterTime *time.Time
+	if *modifiedAfter != "" {
+		t, err := time.Parse(time.RFC3339, *modifiedAfter)
+		if err != nil {
+			return fmt.Errorf("error parsing --modified-after: %w", err)
+		}
+		modifiedAfterTime = &t
+	}
+
 	switch mode {
 	case "contacts":
-		return indexAllContacts(ctx, rt)
+		return indexAllContacts(ctx, rt, modifiedAfterTime)
 	case "messages":
 		return indexAllMessages(ctx, rt, *startUUID)
 	}
 	return nil
 }
 
-func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
+func indexAllContacts(ctx context.Context, rt *runtime.Runtime, modifiedAfter *time.Time) error {
 	orgIDs, err := models.GetActiveOrgIDs(ctx, rt.DB)
 	if err != nil {
 		return fmt.Errorf("error getting active org IDs: %w", err)
@@ -78,7 +88,12 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 		fmt.Printf(" > Indexing org #%d", orgID)
 
 		for {
-			contactIDs, err := models.GetContactIDsPage(ctx, rt.DB, orgID, afterID, indexBatchSize)
+			var contactIDs []models.ContactID
+			if modifiedAfter != nil {
+				contactIDs, err = models.GetContactIDsPageModifiedAfter(ctx, rt.DB, orgID, afterID, *modifiedAfter, indexBatchSize)
+			} else {
+				contactIDs, err = models.GetContactIDsPage(ctx, rt.DB, orgID, afterID, indexBatchSize)
+			}
 			if err != nil {
 				return fmt.Errorf("error getting contact IDs for org #%d: %w", orgID, err)
 			}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -82,24 +82,41 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime, modifiedAfter *t
 	for _, orgID := range orgIDs {
 		orgIndexed := 0
 		orgSkipped := 0
-		orgBatches := 0
-		afterID := models.NilContactID
 
 		fmt.Printf(" > Indexing org #%d", orgID)
+
+		var allContactIDs []models.ContactID
+		if modifiedAfter != nil {
+			allContactIDs, err = models.GetContactIDsModifiedAfter(ctx, rt.DB, orgID, *modifiedAfter)
+			if err != nil {
+				return fmt.Errorf("error getting modified contact IDs for org #%d: %w", orgID, err)
+			}
+		}
+
+		afterID := models.NilContactID
+		batch := 0
 
 		for {
 			var contactIDs []models.ContactID
 			if modifiedAfter != nil {
-				contactIDs, err = models.GetContactIDsPageModifiedAfter(ctx, rt.DB, orgID, afterID, *modifiedAfter, indexBatchSize)
+				// take next batch from pre-fetched IDs
+				start := batch * indexBatchSize
+				if start >= len(allContactIDs) {
+					break
+				}
+				end := start + indexBatchSize
+				if end > len(allContactIDs) {
+					end = len(allContactIDs)
+				}
+				contactIDs = allContactIDs[start:end]
 			} else {
 				contactIDs, err = models.GetContactIDsPage(ctx, rt.DB, orgID, afterID, indexBatchSize)
-			}
-			if err != nil {
-				return fmt.Errorf("error getting contact IDs for org #%d: %w", orgID, err)
-			}
-
-			if len(contactIDs) == 0 {
-				break
+				if err != nil {
+					return fmt.Errorf("error getting contact IDs for org #%d: %w", orgID, err)
+				}
+				if len(contactIDs) == 0 {
+					break
+				}
 			}
 
 			// get org assets (cached but periodically refreshed for large orgs)
@@ -131,10 +148,10 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime, modifiedAfter *t
 
 			orgIndexed += len(flowContacts)
 			totalIndexed += len(flowContacts)
-			orgBatches++
+			batch++
 			afterID = contactIDs[len(contactIDs)-1]
 
-			if orgBatches%20 == 0 {
+			if batch%20 == 0 {
 				fmt.Print(".")
 			}
 

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -395,6 +395,13 @@ func GetContactIDsPage(ctx context.Context, db Queryer, orgID OrgID, afterID Con
 	return queryContactIDs(ctx, db, sqlSelectContactIDsPage, orgID, int(afterID), limit)
 }
 
+const sqlSelectContactIDsPageModifiedAfter = `SELECT id FROM contacts_contact WHERE org_id = $1 AND is_active = TRUE AND id > $2 AND modified_on > $3 ORDER BY id LIMIT $4`
+
+// GetContactIDsPageModifiedAfter returns a page of contact IDs for the given org that were modified after the given time.
+func GetContactIDsPageModifiedAfter(ctx context.Context, db Queryer, orgID OrgID, afterID ContactID, modifiedAfter time.Time, limit int) ([]ContactID, error) {
+	return queryContactIDs(ctx, db, sqlSelectContactIDsPageModifiedAfter, orgID, int(afterID), modifiedAfter, limit)
+}
+
 type ContactURN struct {
 	ID         URNID            `json:"id"          db:"id"`
 	OrgID      OrgID            `                   db:"org_id"`

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -395,11 +395,11 @@ func GetContactIDsPage(ctx context.Context, db Queryer, orgID OrgID, afterID Con
 	return queryContactIDs(ctx, db, sqlSelectContactIDsPage, orgID, int(afterID), limit)
 }
 
-const sqlSelectContactIDsPageModifiedAfter = `SELECT id FROM contacts_contact WHERE org_id = $1 AND is_active = TRUE AND id > $2 AND modified_on > $3 ORDER BY id LIMIT $4`
+const sqlSelectContactIDsModifiedAfter = `SELECT id FROM contacts_contact WHERE org_id = $1 AND is_active = TRUE AND modified_on > $2 ORDER BY modified_on DESC, id DESC`
 
-// GetContactIDsPageModifiedAfter returns a page of contact IDs for the given org that were modified after the given time.
-func GetContactIDsPageModifiedAfter(ctx context.Context, db Queryer, orgID OrgID, afterID ContactID, modifiedAfter time.Time, limit int) ([]ContactID, error) {
-	return queryContactIDs(ctx, db, sqlSelectContactIDsPageModifiedAfter, orgID, int(afterID), modifiedAfter, limit)
+// GetContactIDsModifiedAfter returns all contact IDs for the given org that were modified after the given time.
+func GetContactIDsModifiedAfter(ctx context.Context, db Queryer, orgID OrgID, modifiedAfter time.Time) ([]ContactID, error) {
+	return queryContactIDs(ctx, db, sqlSelectContactIDsModifiedAfter, orgID, modifiedAfter)
 }
 
 type ContactURN struct {

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -440,6 +440,26 @@ func TestGetContactIDsPage(t *testing.T) {
 	}
 }
 
+func TestGetContactIDsModifiedAfter(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetAll)
+
+	// update Ann's modified_on to a known time
+	recent := time.Now()
+	rt.DB.MustExec(`UPDATE contacts_contact SET modified_on = $1 WHERE id = $2`, recent, testdb.Ann.ID)
+
+	// query with cutoff before the update should include Ann
+	ids, err := models.GetContactIDsModifiedAfter(ctx, rt.DB, testdb.Org1.ID, recent.Add(-time.Second))
+	require.NoError(t, err)
+	assert.Contains(t, ids, testdb.Ann.ID)
+
+	// query with cutoff after the update should not include Ann
+	ids, err = models.GetContactIDsModifiedAfter(ctx, rt.DB, testdb.Org1.ID, recent.Add(time.Second))
+	require.NoError(t, err)
+	assert.NotContains(t, ids, testdb.Ann.ID)
+}
+
 func TestUpdateContactLastSeenAndModifiedOn(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 


### PR DESCRIPTION
## Summary
- Adds a `--modified-after` CLI flag to `mrindex contacts` that accepts an RFC3339 timestamp
- When provided, only contacts with `modified_on` after the given timestamp are reindexed
- Useful for incremental reindexing after a known point in time rather than reindexing all contacts

## Test plan
- [ ] Run `mrindex contacts` without the flag and verify full reindex still works
- [ ] Run `mrindex --modified-after 2026-04-10T00:00:00Z contacts` and verify only recently modified contacts are indexed

🤖 Generated with [Claude Code](https://claude.com/claude-code)