### PR TITLE
Support templates on message-type campaign events

### DIFF
--- a/core/models/campaign.go
+++ b/core/models/campaign.go
@@ -82,9 +82,11 @@ type CampaignPoint struct {
 	Unit          PointUnit `json:"unit"`
 	DeliveryHour  int       `json:"delivery_hour"`
 
-	FlowID       FlowID                      `json:"flow_id"`
-	Translations flows.BroadcastTranslations `json:"translations"`
-	BaseLanguage null.String                 `json:"base_language"`
+	FlowID            FlowID                      `json:"flow_id"`
+	Translations      flows.BroadcastTranslations `json:"translations"`
+	BaseLanguage      null.String                 `json:"base_language"`
+	TemplateID        TemplateID                  `json:"template_id"`
+	TemplateVariables []string                    `json:"template_variables"`
 
 	campaign *Campaign
 }
@@ -231,7 +233,7 @@ SELECT ROW_TO_JSON(r) FROM (SELECT
     c.name,
     c.group_id,
     (SELECT ARRAY_AGG(evs) FROM (
-        SELECT e.id, e.uuid, e.event_type, e.status, e.fire_version, e.start_mode, e.relative_to_id, f.key AS relative_to_key, e.offset, e.unit, e.delivery_hour, e.flow_id, e.translations, e.base_language
+        SELECT e.id, e.uuid, e.event_type, e.status, e.fire_version, e.start_mode, e.relative_to_id, f.key AS relative_to_key, e.offset, e.unit, e.delivery_hour, e.flow_id, e.translations, e.base_language, e.template_id, e.template_variables
           FROM campaigns_campaignevent e
           JOIN contacts_contactfield f ON f.id = e.relative_to_id
          WHERE e.campaign_id = c.id AND e.is_active = TRUE AND f.is_active = TRUE

--- a/core/models/campaign_test.go
+++ b/core/models/campaign_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/testsuite"
@@ -16,7 +17,9 @@ import (
 func TestLoadCampaigns(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, 1, models.RefreshChannels)
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, 1, models.RefreshCampaigns)
 	require.NoError(t, err)
 
 	event1 := oa.CampaignPointByID(testdb.RemindersPoint1.ID)
@@ -31,9 +34,24 @@ func TestLoadCampaigns(t *testing.T) {
 		"fra": &flows.MsgContent{Text: "Bonjour @contact.name, il est temps de consulter vos patients."},
 	}, event2.Translations)
 	assert.Equal(t, null.String("eng"), event2.BaseLanguage)
+	assert.Equal(t, models.NilTemplateID, event2.TemplateID)
+	assert.Nil(t, event2.TemplateVariables)
 
 	event3 := oa.CampaignPointByID(testdb.RemindersPoint3.ID)
 	assert.Equal(t, testdb.RemindersPoint3.UUID, event3.UUID)
+
+	// set template and template_variables on event 2 and reload
+	rt.DB.MustExec(
+		`UPDATE campaigns_campaignevent SET template_id = $1, template_variables = $2 WHERE id = $3`,
+		testdb.GoodbyeTemplate.ID, pq.StringArray{"@contact.name", "foo"}, testdb.RemindersPoint2.ID,
+	)
+
+	oa, err = models.GetOrgAssetsWithRefresh(ctx, rt, 1, models.RefreshCampaigns)
+	require.NoError(t, err)
+
+	event2 = oa.CampaignPointByID(testdb.RemindersPoint2.ID)
+	assert.Equal(t, testdb.GoodbyeTemplate.ID, event2.TemplateID)
+	assert.Equal(t, []string{"@contact.name", "foo"}, event2.TemplateVariables)
 }
 
 func TestScheduleForTime(t *testing.T) {

--- a/core/tasks/bulk_campaign_trigger.go
+++ b/core/tasks/bulk_campaign_trigger.go
@@ -160,6 +160,8 @@ func (t *BulkCampaignTrigger) triggerFlow(ctx context.Context, rt *runtime.Runti
 
 func (t *BulkCampaignTrigger) triggerBroadcast(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, p *models.CampaignPoint, contactIDs []models.ContactID) ([]models.ContactID, error) {
 	bcast := models.NewBroadcast(oa.OrgID(), p.Translations, i18n.Language(p.BaseLanguage), true, models.NilOptInID, nil, contactIDs, nil, "", models.NoExclusions, models.NilUserID)
+	bcast.TemplateID = p.TemplateID
+	bcast.TemplateVariables = p.TemplateVariables
 
 	scenes, skipped, err := runner.BroadcastWithLock(ctx, rt, oa, bcast, &models.BroadcastBatch{ContactIDs: contactIDs}, p.StartMode)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `TemplateID` and `TemplateVariables` to `CampaignPoint` and loads them from `campaigns_campaignevent` (columns introduced in [rapidpro#6571](https://github.com/nyaruka/rapidpro/pull/6571)).
- Passes these through to the `Broadcast` in `BulkCampaignTrigger.triggerBroadcast`, so a fired message event that references a WhatsApp template renders correctly via the existing `CreateMsgOut` path.
- Extends `TestLoadCampaigns` to cover the new columns (zero by default, then set via `UPDATE` and reloaded).

## Test plan
- [x] `go test -p=1 ./core/models/ ./core/tasks/ ./core/crons/ ./web/campaign/`