### PR TITLE
Revert inbound IVR TwiML answer pause

### DIFF
--- a/services/ivr/twiml/client.go
+++ b/services/ivr/twiml/client.go
@@ -22,11 +22,6 @@ type Hangup struct {
 	XMLName string `xml:"Hangup"`
 }
 
-type Pause struct {
-	XMLName string `xml:"Pause"`
-	Length  int    `xml:"length,attr,omitempty"`
-}
-
 type Redirect struct {
 	XMLName string `xml:"Redirect"`
 	URL     string `xml:",chardata"`

--- a/services/ivr/twiml/service.go
+++ b/services/ivr/twiml/service.go
@@ -54,9 +54,8 @@ const (
 
 	statusFailed = "failed"
 
-	gatherTimeout     = 30
-	recordTimeout     = 600
-	answerPauseLength = 1
+	gatherTimeout = 30
+	recordTimeout = 600
 
 	accountSIDConfig = "account_sid"
 	authTokenConfig  = "auth_token"
@@ -398,12 +397,8 @@ func (s *service) WriteSessionResponse(ctx context.Context, rt *runtime.Runtime,
 		return fmt.Errorf("cannot write IVR response for failed session")
 	}
 
-	// prepend a brief pause on initial inbound responses so Twilio doesn't start speaking before
-	// forwarded calls (e.g. Google Voice -> Twilio) have fully connected
-	isIncoming := strings.HasSuffix(r.URL.Path, "/incoming")
-
 	// get our response
-	response, err := ResponseForSprint(rt, oa.Env(), number, resumeURL, scene.Sprint.Events(), isIncoming, true)
+	response, err := ResponseForSprint(rt, oa.Env(), number, resumeURL, scene.Sprint.Events(), true)
 	if err != nil {
 		return fmt.Errorf("unable to build response for IVR call: %w", err)
 	}
@@ -491,14 +486,10 @@ func twCalculateSignature(url string, form url.Values, authToken string) ([]byte
 
 // TWIML building utilities
 
-func ResponseForSprint(rt *runtime.Runtime, env envs.Environment, urn urns.URN, resumeURL string, es []flows.Event, prependPause bool, indent bool) (string, error) {
+func ResponseForSprint(rt *runtime.Runtime, env envs.Environment, urn urns.URN, resumeURL string, es []flows.Event, indent bool) (string, error) {
 	r := &Response{}
 	commands := make([]any, 0)
 	hasWait := false
-
-	if prependPause {
-		commands = append(commands, Pause{Length: answerPauseLength})
-	}
 
 	for _, e := range es {
 		switch event := e.(type) {

--- a/services/ivr/twiml/service_test.go
+++ b/services/ivr/twiml/service_test.go
@@ -37,9 +37,8 @@ func TestResponseForSprint(t *testing.T) {
 	defer func() { rt.Config.AttachmentDomain = "" }()
 
 	tcs := []struct {
-		events       []flows.Event
-		prependPause bool
-		expected     string
+		events   []flows.Event
+		expected string
 	}{
 		{
 			// ivr msg, no text language specified
@@ -47,14 +46,6 @@ func TestResponseForSprint(t *testing.T) {
 				events.NewIVRCreated(flows.NewIVRMsgOut(urn, channelRef, "Hi there", "", "")),
 			},
 			expected: `<Response><Say language="en-US">Hi there</Say><Hangup></Hangup></Response>`,
-		},
-		{
-			// initial inbound response gets a leading pause so forwarded calls have time to connect
-			events: []flows.Event{
-				events.NewIVRCreated(flows.NewIVRMsgOut(urn, channelRef, "Hi there", "", "")),
-			},
-			prependPause: true,
-			expected:     `<Response><Pause length="1"></Pause><Say language="en-US">Hi there</Say><Hangup></Hangup></Response>`,
 		},
 		{
 			// ivr msg, supported text language specified
@@ -119,7 +110,7 @@ func TestResponseForSprint(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		response, err := twiml.ResponseForSprint(rt, env, urn, resumeURL, tc.events, tc.prependPause, false)
+		response, err := twiml.ResponseForSprint(rt, env, urn, resumeURL, tc.events, false)
 		assert.NoError(t, err, "%d: unexpected error")
 		assert.Equal(t, xml.Header+tc.expected, response, "%d: unexpected response", i)
 	}

--- a/web/public/testdata/ivr_twilio.json
+++ b/web/public/testdata/ivr_twilio.json
@@ -665,7 +665,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/incoming",
         "body": "CallSid=Call4&CallStatus=ringing&Caller=%2B16055741111",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather\">\n    <Pause length=\"1\"></Pause>\n    <Say language=\"en-US\">Hello there. Please enter one or two.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",


### PR DESCRIPTION
Reverts #1048. The initial pause before inbound IVR responses isn't needed after all.