### PR TITLE
Remove codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,6 @@ jobs:
         run: |
           go test -p=1 -coverprofile=coverage.text -covermode=atomic ./...
 
-      - name: Upload coverage
-        if: success()
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
   release:
     name: Release
     needs: [test]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![tag](https://img.shields.io/github/tag/nyaruka/mailroom.svg)](https://github.com/nyaruka/mailroom/releases)
 [![Build Status](https://github.com/nyaruka/mailroom/workflows/CI/badge.svg)](https://github.com/nyaruka/mailroom/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/nyaruka/mailroom/branch/main/graph/badge.svg)](https://codecov.io/gh/nyaruka/mailroom)
 
 Task processor and web service for [RapidPro](https://rapidpro.io) and [TextIt](https://textit.com).
 


### PR DESCRIPTION
Removes codecov as part of CI, matching the equivalent cleanup in [rapidpro#6575](https://github.com/nyaruka/rapidpro/pull/6575).

## Changes
- Drop the `codecov/codecov-action` step from `.github/workflows/ci.yml`.
- Remove the codecov badge from `README.md`.

Note: the Python-specific `--fail-under=100` step from rapidpro#6575 wasn't ported, since Go's test tooling doesn't have a direct equivalent. `go test` continues to print per-package coverage and write `coverage.text`.