### PR TITLE
Update to goflow v0.273.10 and load LLM roles

### DIFF
--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -49,22 +49,24 @@ func llmServiceFactory(rt *runtime.Runtime) engine.LLMServiceFactory {
 
 // LLM is our type for a large language model
 type LLM struct {
-	ID_              LLMID          `json:"id"`
-	UUID_            assets.LLMUUID `json:"uuid"`
-	Type_            string         `json:"llm_type"`
-	Model_           string         `json:"model"`
-	Name_            string         `json:"name"`
-	Config_          Config         `json:"config"`
-	MaxOutputTokens_ int            `json:"max_output_tokens"`
+	ID_              LLMID            `json:"id"`
+	UUID_            assets.LLMUUID   `json:"uuid"`
+	Type_            string           `json:"llm_type"`
+	Model_           string           `json:"model"`
+	Name_            string           `json:"name"`
+	Config_          Config           `json:"config"`
+	MaxOutputTokens_ int              `json:"max_output_tokens"`
+	Roles_           []assets.LLMRole `json:"roles"`
 }
 
-func (l *LLM) ID() LLMID            { return l.ID_ }
-func (l *LLM) UUID() assets.LLMUUID { return l.UUID_ }
-func (l *LLM) Name() string         { return l.Name_ }
-func (l *LLM) Type() string         { return l.Type_ }
-func (l *LLM) Model() string        { return l.Model_ }
-func (l *LLM) Config() Config       { return l.Config_ }
-func (l *LLM) MaxOutputTokens() int { return l.MaxOutputTokens_ }
+func (l *LLM) ID() LLMID               { return l.ID_ }
+func (l *LLM) UUID() assets.LLMUUID    { return l.UUID_ }
+func (l *LLM) Name() string            { return l.Name_ }
+func (l *LLM) Type() string            { return l.Type_ }
+func (l *LLM) Model() string           { return l.Model_ }
+func (l *LLM) Config() Config          { return l.Config_ }
+func (l *LLM) MaxOutputTokens() int    { return l.MaxOutputTokens_ }
+func (l *LLM) Roles() []assets.LLMRole { return l.Roles_ }
 
 func (l *LLM) AsService(client *http.Client) (flows.LLMService, error) {
 	fn := registeredLLMServices[l.Type()]
@@ -92,7 +94,8 @@ func loadLLMs(ctx context.Context, db *sql.DB, orgID OrgID) ([]assets.LLM, error
 
 const sqlSelectLLMs = `
 SELECT ROW_TO_JSON(r) FROM (
-      SELECT l.id, l.uuid, l.name, l.llm_type, l.model, l.config, l.max_output_tokens
+      SELECT l.id, l.uuid, l.name, l.llm_type, l.model, l.config, l.max_output_tokens,
+             (SELECT ARRAY(SELECT CASE r WHEN 'T' THEN 'translation' WHEN 'F' THEN 'flows' END FROM unnest(regexp_split_to_array(l.roles,'')) AS r)) AS roles
         FROM ai_llm l
        WHERE l.org_id = $1 AND l.is_active
     ORDER BY l.created_on ASC

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -21,14 +21,15 @@ func TestLLMs(t *testing.T) {
 	require.NoError(t, err)
 
 	tcs := []struct {
-		id   models.LLMID
-		uuid assets.LLMUUID
-		name string
-		typ  string
+		id    models.LLMID
+		uuid  assets.LLMUUID
+		name  string
+		typ   string
+		roles []assets.LLMRole
 	}{
-		{testdb.OpenAI.ID, testdb.OpenAI.UUID, "GPT-4o", "openai"},
-		{testdb.Anthropic.ID, testdb.Anthropic.UUID, "Claude", "anthropic"},
-		{testdb.TestLLM.ID, testdb.TestLLM.UUID, "Test", "test"},
+		{testdb.OpenAI.ID, testdb.OpenAI.UUID, "GPT-4o", "openai", []assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows}},
+		{testdb.Anthropic.ID, testdb.Anthropic.UUID, "Claude", "anthropic", []assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows}},
+		{testdb.TestLLM.ID, testdb.TestLLM.UUID, "Test", "test", []assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows}},
 	}
 
 	assert.Equal(t, len(tcs), len(llms))
@@ -38,6 +39,7 @@ func TestLLMs(t *testing.T) {
 		assert.Equal(t, tc.id, c.ID())
 		assert.Equal(t, tc.name, c.Name())
 		assert.Equal(t, tc.typ, c.Type())
+		assert.Equal(t, tc.roles, c.Roles())
 	}
 
 	assert.Equal(t, "Claude", oa.LLMByID(testdb.Anthropic.ID).Name())

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/nyaruka/ezconf v0.6.1
 	github.com/nyaruka/gocommon v1.79.0
-	github.com/nyaruka/goflow v0.273.9
+	github.com/nyaruka/goflow v0.273.10
 	github.com/nyaruka/null/v3 v3.0.0
 	github.com/nyaruka/vkutil v0.20.0
 	github.com/openai/openai-go v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/nyaruka/goflow v0.273.8 h1:SoMbbFavhjetVgbE6fGeVj9qQUwIYe7HzO9umiG0Ax
 github.com/nyaruka/goflow v0.273.8/go.mod h1:/rEAg9Jol9OChzUjuGVAr2QaX7zisGaa7yNHMlyu5K0=
 github.com/nyaruka/goflow v0.273.9 h1:HGQDnU+5EEQ+0XF7nUyNWOwqXGgGXSAzHUXIweMZ4sA=
 github.com/nyaruka/goflow v0.273.9/go.mod h1:/rEAg9Jol9OChzUjuGVAr2QaX7zisGaa7yNHMlyu5K0=
+github.com/nyaruka/goflow v0.273.10 h1:L1zq0GGoe4rHs7TzFFeM76nuaNnyZg4sO8bchvkSbUQ=
+github.com/nyaruka/goflow v0.273.10/go.mod h1:/rEAg9Jol9OChzUjuGVAr2QaX7zisGaa7yNHMlyu5K0=
 github.com/nyaruka/null/v3 v3.0.0 h1:JvOiNuKmRBFHxzZFt4sWii+ewmMkCQ1vO7X0clTNn6E=
 github.com/nyaruka/null/v3 v3.0.0/go.mod h1:Sus286RmC8P0VihFuQDDQPib/xJQ7++TsaPLdRuwgVc=
 github.com/nyaruka/phonenumbers v1.7.1 h1:k8FHBMLegwW2tEIhsurC5YJk5Dix++H1k6liu1LUruY=


### PR DESCRIPTION
## Summary
- Bump goflow to v0.273.10, which adds a `Roles()` method to the `assets.LLM` interface
- Load the `roles` char column (e.g. `"TF"`) from `ai_llm` and convert it to goflow's role array (`["translation","flows"]`), mirroring the existing channel-roles pattern
- Add roles assertions to `TestLLMs`

## Test plan
- [x] `go test -p=1 ./...`