### PR TITLE
Reject /llm/translate requests when LLM lacks translation role

### DIFF
--- a/services/llm/anthropic/service_test.go
+++ b/services/llm/anthropic/service_test.go
@@ -17,8 +17,8 @@ func TestService(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "anthropic", "claude", "Bad Config", map[string]any{})
-	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "anthropic", "claude", "Good", map[string]any{"api_key": "sesame"})
+	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "anthropic", "claude", "Bad Config", map[string]any{}, "TF")
+	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "anthropic", "claude", "Good", map[string]any{"api_key": "sesame"}, "TF")
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/deepseek/service_test.go
+++ b/services/llm/deepseek/service_test.go
@@ -17,8 +17,8 @@ func TestService(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "deepseek", "chat", "Bad Config", map[string]any{})
-	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "deepseek", "chat", "Good", map[string]any{"api_key": "sesame"})
+	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "deepseek", "chat", "Bad Config", map[string]any{}, "TF")
+	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "deepseek", "chat", "Good", map[string]any{"api_key": "sesame"}, "TF")
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/google/service_test.go
+++ b/services/llm/google/service_test.go
@@ -15,8 +15,8 @@ func TestService(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "google", "gemini", "Bad Config", map[string]any{})
-	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "google", "gemini", "Good", map[string]any{"api_key": "sesame"})
+	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "google", "gemini", "Bad Config", map[string]any{}, "TF")
+	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "google", "gemini", "Good", map[string]any{"api_key": "sesame"}, "TF")
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/openai/service_test.go
+++ b/services/llm/openai/service_test.go
@@ -17,8 +17,8 @@ func TestService(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai", "gpt-4", "Bad Config", map[string]any{})
-	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai", "gpt-4", "Good", map[string]any{"api_key": "sesame"})
+	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai", "gpt-4", "Bad Config", map[string]any{}, "TF")
+	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai", "gpt-4", "Good", map[string]any{"api_key": "sesame"}, "TF")
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/services/llm/openai_azure/service_test.go
+++ b/services/llm/openai_azure/service_test.go
@@ -17,8 +17,8 @@ func TestService(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai_azure", "gpt-4", "Bad Config", map[string]any{})
-	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai_azure", "gpt-4", "Good", map[string]any{"endpoint": "http://azure.com/ai", "api_key": "sesame"})
+	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai_azure", "gpt-4", "Bad Config", map[string]any{}, "TF")
+	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai_azure", "gpt-4", "Good", map[string]any{"endpoint": "http://azure.com/ai", "api_key": "sesame"}, "TF")
 
 	oa := testdb.Org1.Load(t, rt)
 	badLLM := oa.LLMByID(bad.ID)

--- a/testsuite/testdb/llms.go
+++ b/testsuite/testdb/llms.go
@@ -15,11 +15,11 @@ type LLM struct {
 }
 
 // InsertLLM inserts an LLM
-func InsertLLM(t *testing.T, rt *runtime.Runtime, org *Org, uuid assets.LLMUUID, typ string, model, name string, config map[string]any) *LLM {
+func InsertLLM(t *testing.T, rt *runtime.Runtime, org *Org, uuid assets.LLMUUID, typ string, model, name string, config map[string]any, roles string) *LLM {
 	var id models.LLMID
 	err := rt.DB.Get(&id,
 		`INSERT INTO ai_llm(org_id, uuid, llm_type, model, name, config, max_output_tokens, roles, is_system, is_active, created_on, modified_on, created_by_id, modified_by_id)
-		VALUES($1, $2, $3, $4, $5, $6, 4096, 'TF', FALSE, TRUE, NOW(), NOW(), 1, 1) RETURNING id`, org.ID, uuid, typ, model, name, models.JSONB[map[string]any]{V: config},
+		VALUES($1, $2, $3, $4, $5, $6, 4096, $7, FALSE, TRUE, NOW(), NOW(), 1, 1) RETURNING id`, org.ID, uuid, typ, model, name, models.JSONB[map[string]any]{V: config}, roles,
 	)
 	require.NoError(t, err)
 	return &LLM{ID: id, UUID: uuid}

--- a/web/llm/base_test.go
+++ b/web/llm/base_test.go
@@ -4,10 +4,16 @@ import (
 	"testing"
 
 	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 )
 
 func TestTranslate(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	// LLM without the translation role - id will be 30000
+	testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "test", "gpt-4", "Flows Only", map[string]any{}, "F")
 
 	testsuite.RunWebTests(t, rt, "testdata/translate.json")
 }

--- a/web/llm/testdata/translate.json
+++ b/web/llm/testdata/translate.json
@@ -45,6 +45,24 @@
         }
     },
     {
+        "label": "LLM without translation role",
+        "method": "POST",
+        "path": "/mi/llm/translate",
+        "body": {
+            "org_id": 1,
+            "llm_id": 30000,
+            "source": "eng",
+            "target": "spa",
+            "items": {
+                "a1f0e2c4-5b3e-4d7a-9c2f-1e8d6a4b7c35:text": ["Hello world"]
+            }
+        },
+        "status": 500,
+        "response": {
+            "error": "LLM with ID 30000 does not support translation"
+        }
+    },
+    {
         "label": "empty items",
         "method": "POST",
         "path": "/mi/llm/translate",

--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/i18n"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/mailroom/v26/core/ai"
 	"github.com/nyaruka/mailroom/v26/core/ai/prompts"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -64,6 +65,9 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 	llm := oa.LLMByID(r.LLMID)
 	if llm == nil {
 		return nil, 0, fmt.Errorf("no such LLM with ID %d", r.LLMID)
+	}
+	if !slices.Contains(llm.Roles(), assets.LLMRoleTranslation) {
+		return nil, 0, fmt.Errorf("LLM with ID %d does not support translation", r.LLMID)
 	}
 
 	llmSvc, err := llm.AsService(http.DefaultClient)


### PR DESCRIPTION
## Summary
- `/llm/translate` now checks that the selected LLM has the `translation` role and rejects with a 500 + `"LLM with ID N does not support translation"` if not, mirroring the existing missing-LLM error pattern
- Extended `testdb.InsertLLM` with a `roles` parameter so tests can be explicit; updated existing service-test call sites to pass `"TF"`
- Added a JSON test case backed by an inserted flows-only LLM (id 30000) to exercise the new rejection path

## Test plan
- [x] `go test -p=1 ./core/models/... ./services/llm/... ./web/llm/...`