### PR TITLE
Use System field for Anthropic instructions, clean output once

### DIFF
--- a/services/llm/anthropic/service.go
+++ b/services/llm/anthropic/service.go
@@ -44,16 +44,9 @@ func New(m *models.LLM, c *http.Client) (flows.LLMService, error) {
 
 func (s *service) Response(ctx context.Context, instructions, input string, maxTokens int) (*flows.LLMResponse, error) {
 	resp, err := s.client.Messages.New(ctx, anthropic.MessageNewParams{
-		Model: anthropic.Model(s.model),
+		Model:  anthropic.Model(s.model),
+		System: []anthropic.TextBlockParam{{Text: instructions}},
 		Messages: []anthropic.MessageParam{
-			{
-				Role: anthropic.MessageParamRoleAssistant,
-				Content: []anthropic.ContentBlockParamUnion{
-					{
-						OfText: &anthropic.TextBlockParam{Text: instructions},
-					},
-				},
-			},
 			{
 				Role: anthropic.MessageParamRoleUser,
 				Content: []anthropic.ContentBlockParamUnion{
@@ -73,11 +66,11 @@ func (s *service) Response(ctx context.Context, instructions, input string, maxT
 	var output strings.Builder
 	for _, content := range resp.Content {
 		if content.Type == "text" {
-			output.WriteString(s.cleanOutput(content.Text))
+			output.WriteString(content.Text)
 		}
 	}
 
-	return &flows.LLMResponse{Output: output.String(), TokensUsed: resp.Usage.InputTokens + resp.Usage.OutputTokens}, nil
+	return &flows.LLMResponse{Output: s.cleanOutput(output.String()), TokensUsed: resp.Usage.InputTokens + resp.Usage.OutputTokens}, nil
 }
 
 func (s *service) error(err error, instructions, input string) error {
@@ -94,7 +87,7 @@ func (s *service) error(err error, instructions, input string) error {
 }
 
 func (s *service) cleanOutput(output string) string {
-	output = strings.Replace(output, "<<ASSISTANT_CONVERSATION_START>>", "", -1)
-	output = strings.Replace(output, "<<ASSISTANT_CONVERSATION_END>>", "", -1)
+	output = strings.ReplaceAll(output, "<<ASSISTANT_CONVERSATION_START>>", "")
+	output = strings.ReplaceAll(output, "<<ASSISTANT_CONVERSATION_END>>", "")
 	return strings.TrimSpace(output)
 }


### PR DESCRIPTION
## Summary

Three small fixes to `services/llm/anthropic/service.go`, surfaced by Copilot review on a downstream wrapper PR ([nyaruka/mailroom-private#6](https://github.com/nyaruka/mailroom-private/pull/6)) where this code was copy-pasted:

- **Use the `System` field for instructions.** Previously instructions were passed as the first message with role `assistant`. That role is semantically "prior model output," and some Anthropic models reject (or misinterpret) a conversation that starts with an assistant turn. The Messages API has a top-level `system` field designed for this; switching to it keeps role semantics correct.
- **Clean the concatenated output once instead of per text block.** `cleanOutput` runs `strings.TrimSpace`, so applying it to each `content.Text` block before concatenation can drop intentional whitespace between adjacent blocks (relevant when responses contain multiple text segments, e.g. with extended thinking). Now we accumulate raw text and clean the joined string.
- **`strings.ReplaceAll`** instead of `strings.Replace(..., -1)` — minor readability nit.

## Test plan

- [x] `go test -p=1 ./services/llm/...` (all five LLM service packages green)
- [x] `go build ./...`