### PR TITLE
Pass runtime.Runtime to LLM service constructors

### DIFF
--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -23,11 +23,11 @@ type LLMID int
 // NilLLMID is nil value for LLM IDs
 const NilLLMID = LLMID(0)
 
-var registeredLLMServices = map[string]func(*LLM, *http.Client) (flows.LLMService, error){}
+var registeredLLMServices = map[string]func(*runtime.Runtime, *LLM, *http.Client) (flows.LLMService, error){}
 
 // Register a LLM service factory with the engine
 func init() {
-	RegisterLLMService("test", func(*LLM, *http.Client) (flows.LLMService, error) {
+	RegisterLLMService("test", func(*runtime.Runtime, *LLM, *http.Client) (flows.LLMService, error) {
 		return services.NewLLM(), nil
 	})
 
@@ -35,7 +35,7 @@ func init() {
 }
 
 // RegisterLLMService registers a LLM service for the given type code
-func RegisterLLMService(typ string, fn func(*LLM, *http.Client) (flows.LLMService, error)) {
+func RegisterLLMService(typ string, fn func(*runtime.Runtime, *LLM, *http.Client) (flows.LLMService, error)) {
 	registeredLLMServices[typ] = fn
 }
 
@@ -43,7 +43,7 @@ func llmServiceFactory(rt *runtime.Runtime) engine.LLMServiceFactory {
 	httpClient, _ := goflow.HTTP(rt.Config)
 
 	return func(llm *flows.LLM) (flows.LLMService, error) {
-		return llm.Asset().(*LLM).AsService(httpClient)
+		return llm.Asset().(*LLM).AsService(rt, httpClient)
 	}
 }
 
@@ -68,12 +68,12 @@ func (l *LLM) Config() Config          { return l.Config_ }
 func (l *LLM) MaxOutputTokens() int    { return l.MaxOutputTokens_ }
 func (l *LLM) Roles() []assets.LLMRole { return l.Roles_ }
 
-func (l *LLM) AsService(client *http.Client) (flows.LLMService, error) {
+func (l *LLM) AsService(rt *runtime.Runtime, client *http.Client) (flows.LLMService, error) {
 	fn := registeredLLMServices[l.Type()]
 	if fn == nil {
 		return nil, fmt.Errorf("unknown type '%s' for LLM: %s", l.Type(), l.UUID())
 	}
-	return fn(l, client)
+	return fn(rt, l, client)
 }
 
 func (l *LLM) RecordCall(rt *runtime.Runtime, d time.Duration, tokensUsed int64) {

--- a/services/llm/anthropic/service.go
+++ b/services/llm/anthropic/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/ai"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
 const (
@@ -30,7 +31,7 @@ type service struct {
 	model  string
 }
 
-func New(m *models.LLM, c *http.Client) (flows.LLMService, error) {
+func New(rt *runtime.Runtime, m *models.LLM, c *http.Client) (flows.LLMService, error) {
 	apiKey := m.Config().GetString(configAPIKey, "")
 	if apiKey == "" {
 		return nil, fmt.Errorf("config incomplete for LLM: %s", m.UUID())

--- a/services/llm/anthropic/service_test.go
+++ b/services/llm/anthropic/service_test.go
@@ -34,11 +34,11 @@ func TestService(t *testing.T) {
 	})}
 
 	// can't create service with bad config
-	svc, err := anthropic.New(badLLM, client)
+	svc, err := anthropic.New(rt, badLLM, client)
 	assert.EqualError(t, err, "config incomplete for LLM: c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc")
 	assert.Nil(t, svc)
 
-	svc, err = anthropic.New(goodLLM, client)
+	svc, err = anthropic.New(rt, goodLLM, client)
 	assert.NoError(t, err)
 	assert.NotNil(t, svc)
 

--- a/services/llm/deepseek/service.go
+++ b/services/llm/deepseek/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/ai"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/responses"
@@ -32,7 +33,7 @@ type service struct {
 	model  string
 }
 
-func New(m *models.LLM, c *http.Client) (flows.LLMService, error) {
+func New(rt *runtime.Runtime, m *models.LLM, c *http.Client) (flows.LLMService, error) {
 	apiKey := m.Config().GetString(configAPIKey, "")
 	if apiKey == "" {
 		return nil, fmt.Errorf("config incomplete for LLM: %s", m.UUID())

--- a/services/llm/deepseek/service_test.go
+++ b/services/llm/deepseek/service_test.go
@@ -34,11 +34,11 @@ func TestService(t *testing.T) {
 	})}
 
 	// can't create service with bad config
-	svc, err := deepseek.New(badLLM, client)
+	svc, err := deepseek.New(rt, badLLM, client)
 	assert.EqualError(t, err, "config incomplete for LLM: c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc")
 	assert.Nil(t, svc)
 
-	svc, err = deepseek.New(goodLLM, client)
+	svc, err = deepseek.New(rt, goodLLM, client)
 	assert.NoError(t, err)
 	assert.NotNil(t, svc)
 

--- a/services/llm/google/service.go
+++ b/services/llm/google/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/ai"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 	"google.golang.org/genai"
 )
 
@@ -29,7 +30,7 @@ type service struct {
 	model  string
 }
 
-func New(m *models.LLM, c *http.Client) (flows.LLMService, error) {
+func New(rt *runtime.Runtime, m *models.LLM, c *http.Client) (flows.LLMService, error) {
 	apiKey := m.Config().GetString(configAPIKey, "")
 	if apiKey == "" {
 		return nil, fmt.Errorf("config incomplete for LLM: %s", m.UUID())

--- a/services/llm/google/service_test.go
+++ b/services/llm/google/service_test.go
@@ -23,11 +23,11 @@ func TestService(t *testing.T) {
 	goodLLM := oa.LLMByID(good.ID)
 
 	// can't create service with bad config
-	svc, err := google.New(badLLM, http.DefaultClient)
+	svc, err := google.New(rt, badLLM, http.DefaultClient)
 	assert.EqualError(t, err, "config incomplete for LLM: c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc")
 	assert.Nil(t, svc)
 
-	svc, err = google.New(goodLLM, http.DefaultClient)
+	svc, err = google.New(rt, goodLLM, http.DefaultClient)
 	assert.NoError(t, err)
 	assert.NotNil(t, svc)
 }

--- a/services/llm/openai/service.go
+++ b/services/llm/openai/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/ai"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/responses"
@@ -32,7 +33,7 @@ type service struct {
 	model  string
 }
 
-func New(m *models.LLM, c *http.Client) (flows.LLMService, error) {
+func New(rt *runtime.Runtime, m *models.LLM, c *http.Client) (flows.LLMService, error) {
 	apiKey := m.Config().GetString(configAPIKey, "")
 	if apiKey == "" {
 		return nil, fmt.Errorf("config incomplete for LLM: %s", m.UUID())

--- a/services/llm/openai/service_test.go
+++ b/services/llm/openai/service_test.go
@@ -86,11 +86,11 @@ func TestService(t *testing.T) {
 	})}
 
 	// can't create service with bad config
-	svc, err := openai.New(badLLM, client)
+	svc, err := openai.New(rt, badLLM, client)
 	assert.EqualError(t, err, "config incomplete for LLM: c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc")
 	assert.Nil(t, svc)
 
-	svc, err = openai.New(goodLLM, client)
+	svc, err = openai.New(rt, goodLLM, client)
 	assert.NoError(t, err)
 	assert.NotNil(t, svc)
 

--- a/services/llm/openai_azure/service.go
+++ b/services/llm/openai_azure/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/ai"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/azure"
 	"github.com/openai/openai-go/option"
@@ -37,7 +38,7 @@ type service struct {
 	model  string
 }
 
-func New(m *models.LLM, c *http.Client) (flows.LLMService, error) {
+func New(rt *runtime.Runtime, m *models.LLM, c *http.Client) (flows.LLMService, error) {
 	apiKey := m.Config().GetString(configAPIKey, "")
 	endpoint := m.Config().GetString(configEndpoint, "")
 	parsedEndpoint, err := url.Parse(endpoint)

--- a/services/llm/openai_azure/service_test.go
+++ b/services/llm/openai_azure/service_test.go
@@ -34,11 +34,11 @@ func TestService(t *testing.T) {
 	})}
 
 	// can't create service with bad config
-	svc, err := openai_azure.New(badLLM, client)
+	svc, err := openai_azure.New(rt, badLLM, client)
 	assert.EqualError(t, err, "config incomplete for LLM: c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc")
 	assert.Nil(t, svc)
 
-	svc, err = openai_azure.New(goodLLM, client)
+	svc, err = openai_azure.New(rt, goodLLM, client)
 	assert.NoError(t, err)
 	assert.NotNil(t, svc)
 

--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -70,7 +70,7 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 		return nil, 0, fmt.Errorf("LLM with ID %d does not support translation", r.LLMID)
 	}
 
-	llmSvc, err := llm.AsService(http.DefaultClient)
+	llmSvc, err := llm.AsService(rt, http.DefaultClient)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating LLM service: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `RegisterLLMService` and the per-type `New` functions for OpenAI, Anthropic, Google, DeepSeek and OpenAI/Azure now take `*runtime.Runtime` as their first argument.
- `(*LLM).AsService` and `llmServiceFactory` updated to thread the runtime through.
- `web/llm/translate.go` passes `rt` when materializing the service.

The runtime parameter is unused inside each `New` for now — this just makes it available so future LLM service work (config lookups, stats, etc.) doesn't need another signature change.

## Test plan

- [x] `go build ./...`
- [x] `go test -p=1 ./services/llm/... ./core/models/... ./web/llm/...`