### PR TITLE
Cap LLM max_output_tokens at 32000

### DIFF
--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -23,6 +23,9 @@ type LLMID int
 // NilLLMID is nil value for LLM IDs
 const NilLLMID = LLMID(0)
 
+// maxOutputTokensLimit is the hard ceiling we apply to any LLM's configured max_output_tokens.
+const maxOutputTokensLimit = 32000
+
 var registeredLLMServices = map[string]func(*runtime.Runtime, *LLM, *http.Client) (flows.LLMService, error){}
 
 // Register a LLM service factory with the engine
@@ -65,7 +68,7 @@ func (l *LLM) Name() string            { return l.Name_ }
 func (l *LLM) Type() string            { return l.Type_ }
 func (l *LLM) Model() string           { return l.Model_ }
 func (l *LLM) Config() Config          { return l.Config_ }
-func (l *LLM) MaxOutputTokens() int    { return l.MaxOutputTokens_ }
+func (l *LLM) MaxOutputTokens() int    { return min(l.MaxOutputTokens_, maxOutputTokensLimit) }
 func (l *LLM) Roles() []assets.LLMRole { return l.Roles_ }
 
 func (l *LLM) AsService(rt *runtime.Runtime, client *http.Client) (flows.LLMService, error) {

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -45,3 +45,20 @@ func TestLLMs(t *testing.T) {
 	assert.Equal(t, "Claude", oa.LLMByID(testdb.Anthropic.ID).Name())
 	assert.Nil(t, oa.LLMByID(1235))
 }
+
+func TestLLMMaxOutputTokens(t *testing.T) {
+	tcs := []struct {
+		configured int
+		expected   int
+	}{
+		{4096, 4096},
+		{32000, 32000},
+		{32001, 32000},
+		{128000, 32000},
+	}
+
+	for _, tc := range tcs {
+		l := &models.LLM{MaxOutputTokens_: tc.configured}
+		assert.Equal(t, tc.expected, l.MaxOutputTokens(), "configured=%d", tc.configured)
+	}
+}


### PR DESCRIPTION
## Summary
- Some models advertise output limits well above what we ever want to generate in a single response (Claude Sonnet 4 = 64K, some models 128K+).
- Apply a hard ceiling of 32000 in `LLM.MaxOutputTokens()` so every LLM service inherits the cap without per-provider changes.
- Configured values at or below the cap pass through unchanged.

## Test plan
- [x] `go test ./core/models/...` passes
- [x] New `TestLLMMaxOutputTokens` covers under, at, and over the cap