### PR TITLE
Index urn_path on message documents

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -137,9 +137,10 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 }
 
 const sqlSelectMessagesForSearch = `
-SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid
+SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid, COALESCE(u.path, '') AS urn_path
   FROM msgs_msg m
   JOIN contacts_contact c ON c.id = m.contact_id
+  LEFT JOIN contacts_contacturn u ON u.id = m.contact_urn_id
  WHERE c.last_seen_on IS NOT NULL
    AND LENGTH(m.text) >= $3
    AND m.visibility IN ('V', 'A')
@@ -165,13 +166,13 @@ func indexAllMessages(ctx context.Context, rt *runtime.Runtime, startUUID string
 		var lastCreatedOn time.Time
 
 		for rows.Next() {
-			var msgUUID, contactUUID string
+			var msgUUID, contactUUID, urnPath string
 			var orgID models.OrgID
 			var text string
 			var createdOn time.Time
 			var ticketUUID null.String
 
-			if err := rows.Scan(&msgUUID, &orgID, &text, &createdOn, &ticketUUID, &contactUUID); err != nil {
+			if err := rows.Scan(&msgUUID, &orgID, &text, &createdOn, &ticketUUID, &contactUUID, &urnPath); err != nil {
 				rows.Close()
 				return fmt.Errorf("error scanning message row: %w", err)
 			}
@@ -181,6 +182,7 @@ func indexAllMessages(ctx context.Context, rt *runtime.Runtime, startUUID string
 				UUID:        flows.EventUUID(msgUUID),
 				OrgID:       orgID,
 				ContactUUID: flows.ContactUUID(contactUUID),
+				URNPath:     urnPath,
 				Text:        text,
 				InTicket:    ticketUUID != "",
 			}

--- a/core/runner/handlers/msg_created.go
+++ b/core/runner/handlers/msg_created.go
@@ -66,6 +66,7 @@ func handleMsgCreated(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAs
 			OrgID:       oa.OrgID(),
 			UUID:        event.UUID(),
 			ContactUUID: scene.ContactUUID(),
+			URNPath:     event.Msg.URN().Path(),
 			Text:        event.Msg.Text(),
 			InTicket:    event.TicketUUID != "",
 		})

--- a/core/runner/handlers/msg_received.go
+++ b/core/runner/handlers/msg_received.go
@@ -35,6 +35,7 @@ func handleMsgReceived(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 			OrgID:       oa.OrgID(),
 			UUID:        event.UUID(),
 			ContactUUID: scene.ContactUUID(),
+			URNPath:     event.Msg.URN().Path(),
 			Text:        event.Msg.Text(),
 			InTicket:    event.TicketUUID != "",
 		})

--- a/core/runner/handlers/testdata/campaigns.json
+++ b/core/runner/handlers/testdata/campaigns.json
@@ -408,6 +408,7 @@
                 "_id": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "Hi there"
             }
         ]

--- a/core/runner/handlers/testdata/input_labels_added.json
+++ b/core/runner/handlers/testdata/input_labels_added.json
@@ -141,12 +141,14 @@
                 "_id": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "start"
             },
             {
                 "_id": "01969b47-113b-76f8-9c0b-2014ddc77094",
                 "_routing": "1",
                 "contact_uuid": "b699a406-7e44-49be-9f01-1a82893e8a10",
+                "urn_path": "+16055742222",
                 "text": "start"
             }
         ]

--- a/core/runner/handlers/testdata/msg_created.json
+++ b/core/runner/handlers/testdata/msg_created.json
@@ -354,12 +354,14 @@
                 "_id": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "start"
             },
             {
                 "_id": "01969b47-384b-76f8-be24-6164105d48f2",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "Hello World"
             }
         ]
@@ -501,6 +503,7 @@
                         "name": "Andy Admin"
                     },
                     "msg": {
+                        "urn": "tel:+16055741111",
                         "text": "How are you?"
                     }
                 }
@@ -528,7 +531,8 @@
                     },
                     "created_on": "2025-09-30T12:30:00.123456789Z",
                     "msg": {
-                        "text": "How are you?"
+                        "text": "How are you?",
+                        "urn": "tel:+16055741111"
                     },
                     "type": "msg_created"
                 }
@@ -539,6 +543,7 @@
                 "_id": "01999b52-f8e5-75dd-b63f-5099a530d6c9",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "How are you?"
             }
         ]

--- a/core/runner/handlers/testdata/msg_received.json
+++ b/core/runner/handlers/testdata/msg_received.json
@@ -209,12 +209,14 @@
                 "_id": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "start"
             },
             {
                 "_id": "01969b47-3c33-76f8-8ab7-4a517a86045c",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "Hello World"
             }
         ]

--- a/core/runner/handlers/testdata/optin_requested.json
+++ b/core/runner/handlers/testdata/optin_requested.json
@@ -228,6 +228,7 @@
                 "_id": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "start"
             }
         ]

--- a/core/search/messages.go
+++ b/core/search/messages.go
@@ -28,6 +28,7 @@ type MessageDoc struct {
 	UUID        flows.EventUUID   `json:"-"`          // used as _id
 	OrgID       models.OrgID      `json:"org_id"`
 	ContactUUID flows.ContactUUID `json:"contact_uuid"`
+	URNPath     string            `json:"urn_path,omitempty"`
 	Text        string            `json:"text"`
 	InTicket    bool              `json:"in_ticket"`
 }

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -38,9 +38,10 @@ func IndexMessages(t *testing.T, rt *runtime.Runtime) {
 	ctx := t.Context()
 
 	const query = `
-	SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid
+	SELECT m.uuid, m.org_id, m.text, m.created_on, m.ticket_uuid, c.uuid AS contact_uuid, COALESCE(u.path, '') AS urn_path
 	  FROM msgs_msg m
 	  JOIN contacts_contact c ON c.id = m.contact_id
+	  LEFT JOIN contacts_contacturn u ON u.id = m.contact_urn_id
 	 WHERE c.last_seen_on IS NOT NULL
 	   AND LENGTH(m.text) >= $1
 	   AND m.visibility IN ('V', 'A')
@@ -51,13 +52,13 @@ func IndexMessages(t *testing.T, rt *runtime.Runtime) {
 	defer rows.Close()
 
 	for rows.Next() {
-		var msgUUID, contactUUID string
+		var msgUUID, contactUUID, urnPath string
 		var orgID models.OrgID
 		var text string
 		var createdOn time.Time
 		var ticketUUID null.String
 
-		err := rows.Scan(&msgUUID, &orgID, &text, &createdOn, &ticketUUID, &contactUUID)
+		err := rows.Scan(&msgUUID, &orgID, &text, &createdOn, &ticketUUID, &contactUUID, &urnPath)
 		require.NoError(t, err)
 
 		msg := search.MessageDoc{
@@ -65,6 +66,7 @@ func IndexMessages(t *testing.T, rt *runtime.Runtime) {
 			UUID:        flows.EventUUID(msgUUID),
 			OrgID:       orgID,
 			ContactUUID: flows.ContactUUID(contactUUID),
+			URNPath:     urnPath,
 			Text:        text,
 			InTicket:    ticketUUID != "",
 		}
@@ -141,6 +143,7 @@ type IndexedMessage struct {
 	ID          string `json:"_id"`
 	Routing     string `json:"_routing"`
 	ContactUUID string `json:"contact_uuid"`
+	URNPath     string `json:"urn_path,omitempty"`
 	Text        string `json:"text"`
 }
 

--- a/testsuite/testdata/es_messages.json
+++ b/testsuite/testdata/es_messages.json
@@ -51,6 +51,9 @@
                 "contact_uuid": {
                     "type": "keyword"
                 },
+                "urn_path": {
+                    "type": "keyword"
+                },
                 "text": {
                     "type": "text",
                     "analyzer": "msg_text"

--- a/web/public/testdata/ivr_twilio.json
+++ b/web/public/testdata/ivr_twilio.json
@@ -270,6 +270,7 @@
                 "_id": "01969b48-3633-76f8-9566-6fb2598c32d6",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "101"
             }
         ]
@@ -345,6 +346,7 @@
                 "_id": "01969b48-9fab-76f8-acdc-e181352d44cc",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "56"
             }
         ]
@@ -619,6 +621,7 @@
                 "_id": "01969b4a-1e7b-76f8-8a45-573a4a7a0d0f",
                 "_routing": "1",
                 "contact_uuid": "b699a406-7e44-49be-9f01-1a82893e8a10",
+                "urn_path": "+16055742222",
                 "text": "56"
             }
         ]

--- a/web/public/testdata/ivr_vonage.json
+++ b/web/public/testdata/ivr_vonage.json
@@ -319,6 +319,7 @@
                 "_id": "01969b48-41eb-76f8-a8fd-1537ca860f97",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "101"
             }
         ]
@@ -402,6 +403,7 @@
                 "_id": "01969b48-ab63-76f8-a09e-6806aab9f510",
                 "_routing": "1",
                 "contact_uuid": "a393abc0-283d-4c9b-a1b3-641a035c34bf",
+                "urn_path": "+16055741111",
                 "text": "56"
             }
         ]


### PR DESCRIPTION
## Summary

Adds a `urn_path` keyword field to the message Elasticsearch documents so message search can eventually match against the URN a message was sent to or received from (a step toward matching by phone number / email / etc. without a cross-index JOIN).

- `MessageDoc.URNPath` populated from `event.Msg.URN().Path()` in the `msg_received` and `msg_created` handlers
- `mrindex messages` backfill SQL gains `LEFT JOIN contacts_contacturn` to pull `path` for existing rows
- ES index template adds `urn_path` as `keyword`
- Test indexer (`testsuite.IndexMessages`) does the same JOIN; `IndexedMessage` test struct exposes `URNPath` so handler fixtures can assert it

`SearchMessages` itself is untouched -- a follow-up will extend the query to match `urn_path` alongside `text`.

## Test plan

- [x] `go test -p=1 ./core/search/...`
- [x] `go test -p=1 ./core/runner/handlers/...`
- [x] `go test -p=1 ./web/msg/... ./web/contact/... ./core/crons/...`
- [ ] After merging, run `mrindex messages` to backfill `urn_path` on existing message indexes