### PR TITLE
Record daily LLM call and token counts

### DIFF
--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/engine"
@@ -80,11 +81,32 @@ func (l *LLM) AsService(rt *runtime.Runtime, client *http.Client) (flows.LLMServ
 	return fn(rt, l, client)
 }
 
-func (l *LLM) RecordCall(rt *runtime.Runtime, e *events.LLMCalled) {
-	// TODO write daily LLMCount rows for tokens:in / tokens:out / calls once the model exists
-
+func (l *LLM) RecordCall(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, e *events.LLMCalled) error {
 	rt.Stats.RecordLLMCall(l.Type(), l.Model(), time.Duration(e.ElapsedMS)*time.Millisecond)
+
+	day := dates.ExtractDate(dates.Now().In(oa.Env().Timezone()))
+	counts := []*LLMDailyCount{{LLMID: l.ID(), Day: day, Scope: "calls", Count: 1}}
+	if e.Tokens.Input > 0 {
+		counts = append(counts, &LLMDailyCount{LLMID: l.ID(), Day: day, Scope: "tokens:in", Count: e.Tokens.Input})
+	}
+	if e.Tokens.Output > 0 {
+		counts = append(counts, &LLMDailyCount{LLMID: l.ID(), Day: day, Scope: "tokens:out", Count: e.Tokens.Output})
+	}
+
+	if err := BulkQuery(ctx, "inserted llm daily counts", rt.DB, sqlInsertLLMDailyCount, counts); err != nil {
+		return fmt.Errorf("error inserting llm daily counts: %w", err)
+	}
+	return nil
 }
+
+type LLMDailyCount struct {
+	LLMID LLMID      `db:"llm_id"`
+	Day   dates.Date `db:"day"`
+	Scope string     `db:"scope"`
+	Count int64      `db:"count"`
+}
+
+const sqlInsertLLMDailyCount = `INSERT INTO ai_llmcount(llm_id, scope, day, count, is_squashed) VALUES(:llm_id, :scope, :day, :count, FALSE)`
 
 // loads the LLMs for the passed in org
 func loadLLMs(ctx context.Context, db *sql.DB, orgID OrgID) ([]assets.LLM, error) {

--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -81,7 +81,8 @@ func (l *LLM) AsService(rt *runtime.Runtime, client *http.Client) (flows.LLMServ
 	return fn(rt, l, client)
 }
 
-func (l *LLM) RecordCall(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, e *events.LLMCalled) error {
+// RecordCall records stats for an LLM call and returns the daily count rows to be inserted.
+func (l *LLM) RecordCall(rt *runtime.Runtime, oa *OrgAssets, e *events.LLMCalled) []*LLMDailyCount {
 	rt.Stats.RecordLLMCall(l.Type(), l.Model(), time.Duration(e.ElapsedMS)*time.Millisecond)
 
 	day := dates.ExtractDate(dates.Now().In(oa.Env().Timezone()))
@@ -92,11 +93,7 @@ func (l *LLM) RecordCall(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets
 	if e.Tokens.Output > 0 {
 		counts = append(counts, &LLMDailyCount{LLMID: l.ID(), Day: day, Scope: "tokens:out", Count: e.Tokens.Output})
 	}
-
-	if err := BulkQuery(ctx, "inserted llm daily counts", rt.DB, sqlInsertLLMDailyCount, counts); err != nil {
-		return fmt.Errorf("error inserting llm daily counts: %w", err)
-	}
-	return nil
+	return counts
 }
 
 type LLMDailyCount struct {
@@ -107,6 +104,14 @@ type LLMDailyCount struct {
 }
 
 const sqlInsertLLMDailyCount = `INSERT INTO ai_llmcount(llm_id, scope, day, count, is_squashed) VALUES(:llm_id, :scope, :day, :count, FALSE)`
+
+// InsertLLMDailyCounts inserts the given LLM daily count rows.
+func InsertLLMDailyCounts(ctx context.Context, tx DBorTx, counts []*LLMDailyCount) error {
+	if len(counts) == 0 {
+		return nil
+	}
+	return BulkQuery(ctx, "inserted llm daily counts", tx, sqlInsertLLMDailyCount, counts)
+}
 
 // loads the LLMs for the passed in org
 func loadLLMs(ctx context.Context, db *sql.DB, orgID OrgID) ([]assets.LLM, error) {

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -2,8 +2,13 @@ package models_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
@@ -44,6 +49,34 @@ func TestLLMs(t *testing.T) {
 
 	assert.Equal(t, "Claude", oa.LLMByID(testdb.Anthropic.ID).Name())
 	assert.Nil(t, oa.LLMByID(1235))
+}
+
+func TestLLMRecordCall(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	dates.SetNowFunc(dates.NewFixedNow(time.Date(2026, 5, 4, 13, 14, 30, 0, time.UTC)))
+	defer dates.SetNowFunc(time.Now)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	llm := oa.LLMByID(testdb.OpenAI.ID)
+	require.NotNil(t, llm)
+
+	mkEvent := func(in, out int64) *events.LLMCalled {
+		return events.NewLLMCalled(flows.NewLLM(llm), "instructions", "input", &flows.LLMResponse{Output: "output", TokensInput: in, TokensOutput: out}, 250*time.Millisecond)
+	}
+
+	require.NoError(t, llm.RecordCall(ctx, rt, oa, mkEvent(120, 340)))
+	require.NoError(t, llm.RecordCall(ctx, rt, oa, mkEvent(80, 200)))
+	require.NoError(t, llm.RecordCall(ctx, rt, oa, mkEvent(0, 0)))
+
+	assertdb.Query(t, rt.DB, `SELECT COUNT(*) FROM ai_llmcount WHERE llm_id = $1`, testdb.OpenAI.ID).Returns(7)
+	assertdb.Query(t, rt.DB, `SELECT COALESCE(SUM(count), 0)::bigint FROM ai_llmcount WHERE llm_id = $1 AND scope = 'calls'`, testdb.OpenAI.ID).Returns(int64(3))
+	assertdb.Query(t, rt.DB, `SELECT COALESCE(SUM(count), 0)::bigint FROM ai_llmcount WHERE llm_id = $1 AND scope = 'tokens:in'`, testdb.OpenAI.ID).Returns(int64(200))
+	assertdb.Query(t, rt.DB, `SELECT COALESCE(SUM(count), 0)::bigint FROM ai_llmcount WHERE llm_id = $1 AND scope = 'tokens:out'`, testdb.OpenAI.ID).Returns(int64(540))
 }
 
 func TestLLMMaxOutputTokens(t *testing.T) {

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -69,9 +69,16 @@ func TestLLMRecordCall(t *testing.T) {
 		return events.NewLLMCalled(flows.NewLLM(llm), "instructions", "input", &flows.LLMResponse{Output: "output", TokensInput: in, TokensOutput: out}, 250*time.Millisecond)
 	}
 
-	require.NoError(t, llm.RecordCall(ctx, rt, oa, mkEvent(120, 340)))
-	require.NoError(t, llm.RecordCall(ctx, rt, oa, mkEvent(80, 200)))
-	require.NoError(t, llm.RecordCall(ctx, rt, oa, mkEvent(0, 0)))
+	assert.Len(t, llm.RecordCall(rt, oa, mkEvent(120, 340)), 3)
+	assert.Len(t, llm.RecordCall(rt, oa, mkEvent(80, 200)), 3)
+	assert.Len(t, llm.RecordCall(rt, oa, mkEvent(0, 0)), 1)
+
+	var allCounts []*models.LLMDailyCount
+	allCounts = append(allCounts, llm.RecordCall(rt, oa, mkEvent(120, 340))...)
+	allCounts = append(allCounts, llm.RecordCall(rt, oa, mkEvent(80, 200))...)
+	allCounts = append(allCounts, llm.RecordCall(rt, oa, mkEvent(0, 0))...)
+
+	require.NoError(t, models.InsertLLMDailyCounts(ctx, rt.DB, allCounts))
 
 	assertdb.Query(t, rt.DB, `SELECT COUNT(*) FROM ai_llmcount WHERE llm_id = $1`, testdb.OpenAI.ID).Returns(7)
 	assertdb.Query(t, rt.DB, `SELECT COALESCE(SUM(count), 0)::bigint FROM ai_llmcount WHERE llm_id = $1 AND scope = 'calls'`, testdb.OpenAI.ID).Returns(int64(3))

--- a/core/runner/handlers/llm_called.go
+++ b/core/runner/handlers/llm_called.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/nyaruka/goflow/flows"
@@ -23,7 +24,9 @@ func handleLLMCalled(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 	llm := oa.SessionAssets().LLMs().Get(event.LLM.UUID)
 	if llm != nil {
 		m := llm.Asset().(*models.LLM)
-		m.RecordCall(rt, event)
+		if err := m.RecordCall(ctx, rt, oa, event); err != nil {
+			return fmt.Errorf("error recording llm call: %w", err)
+		}
 	}
 
 	return nil

--- a/core/runner/handlers/llm_called.go
+++ b/core/runner/handlers/llm_called.go
@@ -2,13 +2,13 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/runner/hooks"
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
@@ -24,9 +24,7 @@ func handleLLMCalled(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 	llm := oa.SessionAssets().LLMs().Get(event.LLM.UUID)
 	if llm != nil {
 		m := llm.Asset().(*models.LLM)
-		if err := m.RecordCall(ctx, rt, oa, event); err != nil {
-			return fmt.Errorf("error recording llm call: %w", err)
-		}
+		scene.AttachPreCommitHook(hooks.InsertLLMDailyCounts, m.RecordCall(rt, oa, event))
 	}
 
 	return nil

--- a/core/runner/hooks/insert_llm_daily_counts.go
+++ b/core/runner/hooks/insert_llm_daily_counts.go
@@ -1,0 +1,45 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/vinovest/sqlx"
+)
+
+var InsertLLMDailyCounts runner.PreCommitHook = &insertLLMDailyCounts{}
+
+type insertLLMDailyCounts struct{}
+
+func (h *insertLLMDailyCounts) Order() int { return 10 }
+
+func (h *insertLLMDailyCounts) Execute(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*runner.Scene][]any) error {
+	type key struct {
+		LLMID models.LLMID
+		Day   dates.Date
+		Scope string
+	}
+	sums := make(map[key]int64)
+
+	for _, args := range scenes {
+		for _, a := range args {
+			for _, c := range a.([]*models.LLMDailyCount) {
+				sums[key{c.LLMID, c.Day, c.Scope}] += c.Count
+			}
+		}
+	}
+
+	counts := make([]*models.LLMDailyCount, 0, len(sums))
+	for k, v := range sums {
+		counts = append(counts, &models.LLMDailyCount{LLMID: k.LLMID, Day: k.Day, Scope: k.Scope, Count: v})
+	}
+
+	if err := models.InsertLLMDailyCounts(ctx, tx, counts); err != nil {
+		return fmt.Errorf("error inserting llm daily counts: %w", err)
+	}
+	return nil
+}

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -243,6 +243,7 @@ DELETE FROM flows_flowstart;
 DELETE FROM flows_flowsession;
 DELETE FROM flows_flowrevision WHERE flow_id >= 30000;
 DELETE FROM flows_flow WHERE id >= 30000;
+DELETE FROM ai_llmcount;
 DELETE FROM ai_llm WHERE id >= 30000;
 DELETE FROM ivr_call;
 DELETE FROM msgs_msg_labels;

--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -94,7 +94,8 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 	if resp == nil {
 		resp = &flows.LLMResponse{}
 	}
-	if rerr := llm.RecordCall(ctx, rt, oa, events.NewLLMCalled(flows.NewLLM(llm), instructions, string(inputBytes), resp, time.Since(callStart))); rerr != nil {
+	counts := llm.RecordCall(rt, oa, events.NewLLMCalled(flows.NewLLM(llm), instructions, string(inputBytes), resp, time.Since(callStart)))
+	if rerr := insertLLMCallCounts(ctx, rt, counts); rerr != nil {
 		slog.Error("error recording llm call", "error", rerr, "llm_id", r.LLMID)
 	}
 
@@ -138,4 +139,17 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 	}
 
 	return translateResponse{Items: items}, http.StatusOK, nil
+}
+
+// insertLLMCallCounts inserts the given LLM daily counts in a transaction.
+func insertLLMCallCounts(ctx context.Context, rt *runtime.Runtime, counts []*models.LLMDailyCount) error {
+	tx, err := rt.DB.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error starting transaction: %w", err)
+	}
+	if err := models.InsertLLMDailyCounts(ctx, tx, counts); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }

--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -94,7 +94,9 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 	if resp == nil {
 		resp = &flows.LLMResponse{}
 	}
-	llm.RecordCall(rt, events.NewLLMCalled(flows.NewLLM(llm), instructions, string(inputBytes), resp, time.Since(callStart)))
+	if rerr := llm.RecordCall(ctx, rt, oa, events.NewLLMCalled(flows.NewLLM(llm), instructions, string(inputBytes), resp, time.Since(callStart))); rerr != nil {
+		slog.Error("error recording llm call", "error", rerr, "llm_id", r.LLMID)
+	}
 
 	// An error from the LLM service itself (bad credentials, rate limit, model unavailable, etc.)
 	// is reported as 422 because LLMs are user-configured — it's not necessarily our fault.


### PR DESCRIPTION
## Summary
- `LLM.RecordCall` now writes daily rows to `ai_llmcount` for `calls`, `tokens:in`, and `tokens:out` (zero-token scopes skipped), using the org's local day.
- Updated both call sites (`web/llm/translate` and the `llm_called` runner handler) to pass `ctx` + `oa`; the runner propagates errors, the web handler logs and continues so a count insert failure doesn't break the response.
- Added `ai_llmcount` to the test reset and a `TestLLMRecordCall` covering call/token sums and the skip-zero behavior.

## Test plan
- [x] `go test -p=1 ./core/models/... ./core/runner/handlers/... ./web/llm/...`