### PR TITLE
Allow disabling task processing per queue by setting workers to zero

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -32,9 +32,9 @@ type Config struct {
 	AttachmentDomain string `help:"the domain that will be used for relative attachment"`
 	SpoolDir         string `help:"the directory to use for spool files"`
 
-	WorkersRealtime  int     `help:"the number of workers for the realtime task queue"`
-	WorkersBatch     int     `help:"the number of workers for the batch task queue"`
-	WorkersThrottled int     `help:"the number of workers for the throttled task queue"`
+	WorkersRealtime  int     `help:"the number of workers for the realtime task queue (set to 0 to disable processing of realtime tasks on this node)"`
+	WorkersBatch     int     `help:"the number of workers for the batch task queue (set to 0 to disable processing of batch tasks on this node)"`
+	WorkersThrottled int     `help:"the number of workers for the throttled task queue (set to 0 to disable processing of throttled tasks on this node)"`
 	WorkerOwnerLimit float64 `help:"the maximum number of workers, across nodes, available to a single owner, as a fraction of the per node worker counts"`
 
 	WebhooksTimeout              int     `help:"the timeout in milliseconds for webhook calls from engine"`

--- a/workers.go
+++ b/workers.go
@@ -44,6 +44,11 @@ func NewForeman(rt *runtime.Runtime, q queues.Fair, maxWorkers int) *Foreman {
 
 // Start starts the foreman and all its workers, assigning jobs while there are some
 func (f *Foreman) Start(wg *sync.WaitGroup) {
+	if len(f.workers) == 0 {
+		slog.Info("foreman disabled, no workers configured", "foreman", f.queue)
+		return
+	}
+
 	for _, worker := range f.workers {
 		worker.Start(wg)
 	}
@@ -52,6 +57,10 @@ func (f *Foreman) Start(wg *sync.WaitGroup) {
 
 // Stop stops the foreman, waiting for assignment to finish. The workers notify on the main mailroom wait group when they are done.
 func (f *Foreman) Stop() {
+	if len(f.workers) == 0 {
+		return
+	}
+
 	// tell our assignment loop to stop
 	close(f.quit)
 

--- a/workers_test.go
+++ b/workers_test.go
@@ -81,3 +81,35 @@ func TestForemanAndWorkers(t *testing.T) {
 
 	assertvk.ZGetAll(t, vc, "{tasks:test}:active", map[string]float64{})
 }
+
+func TestForemanWithZeroWorkers(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	wg := &sync.WaitGroup{}
+	q := queues.NewFair("test", 0)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	tasks.RegisterType("test", func() tasks.Task { return &testTask{} })
+
+	// queue a task - it should not be processed because there are no workers
+	q.Push(ctx, vc, "test", 1, &testTask{}, false)
+
+	fm := mailroom.NewForeman(rt, q, 0)
+	fm.Start(wg) // must not spawn an Assign goroutine
+	fm.Stop()    // must not block waiting on a goroutine that was never started
+
+	wg.Wait() // returns immediately
+
+	// task should still be queued, never popped
+	size, err := q.Size(ctx, vc)
+	if err != nil {
+		t.Fatalf("error getting queue size: %v", err)
+	}
+	if size != 1 {
+		t.Fatalf("expected queue size 1, got %d", size)
+	}
+}


### PR DESCRIPTION
## Summary

- A node with `WorkersRealtime`, `WorkersBatch`, or `WorkersThrottled` set to `0` now skips foreman startup for that queue entirely — no `Assign` goroutine, no tasks popped from Valkey.
- Useful for dev/test instances that should serve the web API and run crons without competing with prod for queued work, or fighting tests for tasks.
- Pushes from web endpoints and crons keep working (`vkutil.Fair.Push` doesn't consult the per-owner active limit, only `Pop` does).

Run with no task processing: `MAILROOM_WORKERS_REALTIME=0 MAILROOM_WORKERS_BATCH=0 MAILROOM_WORKERS_THROTTLED=0 ./mailroom`.

## Test plan

- [x] `TestForemanAndWorkers` still passes (existing path, non-zero workers)
- [x] New `TestForemanWithZeroWorkers` covers `Start`/`Stop` with no workers and confirms a queued task is not popped
- [ ] Manual: start one mailroom with all workers=0 and another with defaults against the same Valkey; confirm only the second drains the queue