### PR TITLE
Use new /ci/attachment/fetch courier endpoint

### DIFF
--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -347,7 +347,7 @@ func FetchAttachment(ctx context.Context, rt *runtime.Runtime, ch *models.Channe
 		URL:         attURL,
 		MsgUUID:     msgUUID,
 	})
-	req, _ := http.NewRequest("POST", fmt.Sprintf("https://%s/c/_fetch-attachment", rt.Config.Domain), bytes.NewReader(payload))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("https://%s/ci/attachment/fetch", rt.Config.Domain), bytes.NewReader(payload))
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.Config.CourierAuthToken))
 
 	resp, err := httpx.DoTrace(courierHttpClient, req, nil, nil, -1)


### PR DESCRIPTION
Switches `FetchAttachment` to call courier's `/ci/attachment/fetch` endpoint instead of the deprecated `/c/_fetch-attachment`. Both are token-authed and accept the same payload; courier kept the old path for backwards compatibility, so this is a drop-in change.

## Test plan
- [x] `go build ./...`
- [x] `go test -p=1 ./core/msgio/...`