### PR TITLE
Drop /mr/ backwards-compat mounts for internal endpoints

### DIFF
--- a/web/server.go
+++ b/web/server.go
@@ -38,9 +38,6 @@ func PublicRoute(method string, pattern string, handler Handler) {
 // InternalRoute registers a route that handles internal requests between components
 func InternalRoute(method string, pattern string, handler Handler) {
 	routes = append(routes, &route{method, "/mi" + pattern, requireAuthToken(handler)})
-
-	// for backwards compatibility
-	routes = append(routes, &route{method, "/mr" + pattern, requireAuthToken(handler)})
 }
 
 type Server struct {

--- a/web/simulation/simulation_test.go
+++ b/web/simulation/simulation_test.go
@@ -177,18 +177,18 @@ func TestServer(t *testing.T) {
 		ExpectedStatus   int
 		ExpectedResponse string
 	}{
-		{"/mr/sim/start", "GET", "", "", 405, "illegal"},
-		{"/mr/sim/start", "POST", startBody, "", 200, "What is your favorite color?"},
-		{"/mr/sim/resume", "POST", resumeBody, "I like blue!", 200, "Good choice, I like Blue too! What is your favorite beer?"},
+		{"/mi/sim/start", "GET", "", "", 405, "illegal"},
+		{"/mi/sim/start", "POST", startBody, "", 200, "What is your favorite color?"},
+		{"/mi/sim/resume", "POST", resumeBody, "I like blue!", 200, "Good choice, I like Blue too! What is your favorite beer?"},
 
 		// start flow again but resume with a message that matches the campaign flow trigger
-		{"/mr/sim/start", "POST", startBody, "", 200, "What is your favorite color?"},
-		{"/mr/sim/resume", "POST", resumeBody, "trigger", 200, "Nothing to see here"},
-		{"/mr/sim/resume", "POST", resumeBody, "I like blue!", 200, "Nothing to see here"},
+		{"/mi/sim/start", "POST", startBody, "", 200, "What is your favorite color?"},
+		{"/mi/sim/resume", "POST", resumeBody, "trigger", 200, "Nothing to see here"},
+		{"/mi/sim/resume", "POST", resumeBody, "I like blue!", 200, "Nothing to see here"},
 
 		// start favorties again but this time resume with a message that matches the IVR flow trigger
-		{"/mr/sim/start", "POST", startBody, "", 200, "What is your favorite color?"},
-		{"/mr/sim/resume", "POST", resumeBody, "ivr", 200, "Hello there. Please enter one or two."},
+		{"/mi/sim/start", "POST", startBody, "", 200, "What is your favorite color?"},
+		{"/mi/sim/resume", "POST", resumeBody, "ivr", 200, "Hello there. Please enter one or two."},
 	}
 
 	for i, tc := range tcs {


### PR DESCRIPTION
## Summary

- `InternalRoute` was registering each internal endpoint at both `/mi/<pattern>` and `/mr/<pattern>` for backwards compatibility. RapidPro has been updated to call `/mi/*`, so the `/mr/` duplicate is no longer needed and is removed.
- `PublicRoute` is untouched: public-facing endpoints (IVR webhooks, Prometheus metrics, docs) continue to live at `/mr/` only.
- Updated the simulation test's hardcoded `/mr/sim/...` paths to `/mi/sim/...` — every other internal endpoint's tests (JSON-driven) already used `/mi/`.

## Test plan

- [x] `go build ./cmd/mailroom`
- [x] `go test -p=1 ./web/...` — all packages pass, including `web/simulation` (hits `/mi/sim/...` now) and `web/public` (still hits `/mr/org/.../metrics`, `/mr/docs`, IVR webhooks)