### PR TITLE
Add MAILROOM_COURIER_ENDPOINT for internal courier calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ environment variables and parameters and for more details on each option.
 
 - `MAILROOM_ADDRESS`: address to bind our web server to
 - `MAILROOM_DOMAIN`: domain that mailroom is listening on
+- `MAILROOM_COURIER_ENDPOINT`: base URL used for internal calls to courier, e.g. `http://localhost:8080`
 - `MAILROOM_AUTH_TOKEN`: authentication token clients will need to for web requests (should match setting in RapidPro)
 - `MAILROOM_ATTACHMENT_DOMAIN`: domain that will be used for relative attachments in flows
 - `MAILROOM_DB`: URL describing how to connect to the RapidPro database

--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	valkey "github.com/gomodule/redigo/redis"
@@ -347,7 +348,7 @@ func FetchAttachment(ctx context.Context, rt *runtime.Runtime, ch *models.Channe
 		URL:         attURL,
 		MsgUUID:     msgUUID,
 	})
-	req, _ := http.NewRequest("POST", fmt.Sprintf("https://%s/ci/attachment/fetch", rt.Config.Domain), bytes.NewReader(payload))
+	req, _ := http.NewRequest("POST", strings.TrimRight(rt.Config.CourierEndpoint, "/")+"/ci/attachment/fetch", bytes.NewReader(payload))
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.Config.CourierAuthToken))
 
 	resp, err := httpx.DoTrace(courierHttpClient, req, nil, nil, -1)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -67,16 +67,18 @@ type Config struct {
 	S3AttachmentsBucket string `help:"S3 bucket to write attachments to"`
 	S3PathStyle         bool   `help:"S3 should use path style URLs"`
 
+	CourierEndpoint  string `help:"the base URL used for internal calls to courier" validate:"url"`
+	CourierAuthToken string `help:"the authentication token used for requests to Courier"`
+
+	CentrifugoEndpoint string `help:"the endpoint of the Centrifugo server"`
+	CentrifugoKey      string `help:"the API key for the Centrifugo server"`
+
 	LatencyExcludedOrgs []int  `help:"comma separated list of org IDs to exclude from latency metrics"`
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
 	CloudwatchNamespace string `help:"the namespace to use for cloudwatch metrics"`
 	DeploymentID        string `help:"the deployment identifier to use for metrics"`
 	InstanceID          string `help:"the instance identifier to use for metrics"`
 
-	CentrifugoEndpoint string `help:"the endpoint of the Centrifugo server"`
-	CentrifugoKey      string `help:"the API key for the Centrifugo server"`
-
-	CourierAuthToken       string `help:"the authentication token used for requests to Courier"`
 	AndroidCredentialsFile string `help:"path to JSON file with FCM service account credentials used to sync Android relayers"`
 	IDObfuscationKey       string `help:"key used to decode obfuscated IDs, as 4 comma separated integers" validate:"omitempty,hexadecimal,len=32"`
 
@@ -103,6 +105,8 @@ func NewDefaultConfig() *Config {
 		Address:  "localhost",
 		Port:     8090,
 		SpoolDir: "./_spool",
+
+		CourierEndpoint: "http://localhost:8080",
 
 		WorkersRealtime:  32,
 		WorkersBatch:     8,


### PR DESCRIPTION
## Summary

- Splits courier's base URL out of `MAILROOM_DOMAIN`: introduces `MAILROOM_COURIER_ENDPOINT`, a full URL (including scheme) used only for internal mailroom→courier HTTP calls.
- `MAILROOM_DOMAIN` keeps its current role as the public hostname embedded in IVR callback URLs handed to telephony providers — unchanged at [`core/ivr/ivr.go`](../blob/courier-endpoint/core/ivr/ivr.go) and [`web/public/ivr.go`](../blob/courier-endpoint/web/public/ivr.go).
- Because it's a URL not a bare domain, dev environments can use `http://localhost:8080` (no TLS); production sets it to the internal ALB.

## Why

`rt.Config.Domain` was doing double duty: the public ALB hostname (correct for IVR callbacks) was also being used to build the courier attachment-fetch URL, forcing internal traffic to exit and re-enter the VPC via the public ALB. Operators will set `MAILROOM_COURIER_ENDPOINT` via ansible ahead of this rolling out, so there is no fallback to `Domain` in the code — a missing value fails validation at startup.

## Test plan

- [x] `go build ./cmd/mailroom`
- [x] `go test -p=1 ./core/msgio/... ./core/ivr/... ./web/public/... ./services/ivr/... ./runtime/...`
- [ ] Deploy with `MAILROOM_COURIER_ENDPOINT` set, confirm attachment fetch still works against courier