### PR TITLE
Rename Elastic config field to ElasticEndpoint

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	MaxSprintsPerSession int      `help:"the maximum number of sprints allowed per engine session"`
 	MaxValueLength       int      `help:"the maximum size in characters for contact field values and run result values"`
 
-	Elastic              string `validate:"url" help:"the URL of your ElasticSearch instance"`
+	ElasticEndpoint      string `validate:"url" help:"the URL of your ElasticSearch instance"`
 	ElasticUsername      string `help:"the username for ElasticSearch if using basic auth"`
 	ElasticPassword      string `help:"the password for ElasticSearch if using basic auth"`
 	ElasticContactsIndex string `help:"the name of the contacts index written by mailroom"`
@@ -123,7 +123,7 @@ func NewDefaultConfig() *Config {
 		MaxSprintsPerSession: 250,
 		MaxValueLength:       640,
 
-		Elastic:              "http://elastic:9200",
+		ElasticEndpoint:      "http://elastic:9200",
 		ElasticUsername:      "",
 		ElasticPassword:      "",
 		ElasticContactsIndex: "contacts-v1",

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	_, err := runtime.LoadConfig(`--db=??`, `--readonly-db=??`, `--valkey=??`, `--elastic=??`)
-	assert.EqualError(t, err, "invalid configuration: field 'DB' is not a valid URL, field 'ReadonlyDB' is not a valid URL, field 'Valkey' is not a valid URL, field 'Elastic' is not a valid URL")
+	_, err := runtime.LoadConfig(`--db=??`, `--readonly-db=??`, `--valkey=??`, `--elastic-endpoint=??`)
+	assert.EqualError(t, err, "invalid configuration: field 'DB' is not a valid URL, field 'ReadonlyDB' is not a valid URL, field 'Valkey' is not a valid URL, field 'ElasticEndpoint' is not a valid URL")
 
 	_, err = runtime.LoadConfig(`--db=mysql://temba:temba@postgres/temba`, `--valkey=bluedis://valkey:6379/15`)
 	assert.EqualError(t, err, "invalid configuration: field 'DB' must start with 'postgres:', field 'Valkey' must start with 'valkey:'")

--- a/runtime/search.go
+++ b/runtime/search.go
@@ -16,7 +16,7 @@ type Elastic struct {
 }
 
 func newElastic(cfg *Config) (*Elastic, error) {
-	client, err := elastic.NewClient(cfg.Elastic, cfg.ElasticUsername, cfg.ElasticPassword)
+	client, err := elastic.NewClient(cfg.ElasticEndpoint, cfg.ElasticUsername, cfg.ElasticPassword)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Elasticsearch client: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Renames `Config.Elastic` to `Config.ElasticEndpoint` so the ElasticSearch URL field matches the `*Endpoint` naming already used for `DynamoEndpoint`, `S3Endpoint`, `CourierEndpoint`, and `CentrifugoEndpoint`.
- Env var `MAILROOM_ELASTIC` becomes `MAILROOM_ELASTIC_ENDPOINT`; CLI flag `--elastic` becomes `--elastic-endpoint`.

**Breaking change for deployments**: `MAILROOM_ELASTIC` must be updated to `MAILROOM_ELASTIC_ENDPOINT` at release time. No fallback. Other `Elastic*` fields (`ElasticUsername`, `ElasticPassword`, `ElasticContactsIndex`, `ElasticMessagesIndex`) are unchanged. Scope kept narrow: `DB`/`ReadonlyDB`/`Valkey` are connection strings (with credentials, params, db number) rather than plain endpoints, so they were left alone.

## Test plan

- [x] `go build` clean
- [x] Full test suite passes (`go test -p=1 ./...`)
- [x] `TestValidate` updated and passes
- [x] grep confirms no stale `cfg.Elastic` / `MAILROOM_ELASTIC` (bare) / `--elastic=` references remain