### PR TITLE
Log warning when /mr/* request arrives over plaintext HTTP

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -32,6 +33,20 @@ func requestLogger(next http.Handler) http.Handler {
 			slog.Info("request completed", "method", r.Method, "status", ww.Status(), "elapsed", elapsed, "length", ww.BytesWritten(), "url", uri, "user_agent", r.UserAgent())
 
 		}
+	})
+}
+
+func logPlaintextWebhook(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/mr/") && r.Header.Get("X-Forwarded-Proto") == "http" {
+			slog.Warn("plaintext webhook",
+				"path", r.URL.Path,
+				"method", r.Method,
+				"ua", r.UserAgent(),
+				"from", r.Header.Get("X-Forwarded-For"),
+			)
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -62,6 +62,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	router.Use(panicRecovery)
 	router.Use(middleware.Timeout(60 * time.Second))
 	router.Use(requestLogger)
+	router.Use(logPlaintextWebhook)
 
 	// wire up our main pages
 	router.NotFound(handle404)


### PR DESCRIPTION
## Summary
- Adds a small middleware that emits a `WARN` slog line whenever an incoming request with a `/mr/` path prefix has `X-Forwarded-Proto: http`.
- Captures path, method, user-agent, and `X-Forwarded-For` so we can identify which provider sent it.
- Scoped via path-prefix to `/mr/*` (public routes) — `/mi/*` (internal) and `/` are unaffected.
- Mirrors [nyaruka/courier#1012](https://github.com/nyaruka/courier/pull/1012).

## Why
We're about to flip the ALBs' `:80` default action from `forward` to a 301 redirect to HTTPS. Before doing that on the production ALBs, we want telemetry that tells us if any caller is still hitting plaintext on `/mr/*` (which would break for any client that doesn't follow 301s — typically telephony providers doing IVR callbacks).

## Test plan
- [x] `docker exec dev-mailroom go test -p=1 ./web/...` — all web packages green.
- [ ] After deploy, send a plaintext request to `/mr/<something>` and confirm a `plaintext webhook` warn line appears in the mailroom logs.
- [ ] Confirm normal `https` `/mr/*` traffic and `/mi/*` internal traffic do not log anything.