### PR TITLE
Detach context when recording LLM call counts

### DIFF
--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -95,7 +95,11 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 		resp = &flows.LLMResponse{}
 	}
 	counts := llm.RecordCall(rt, oa, events.NewLLMCalled(flows.NewLLM(llm), instructions, string(inputBytes), resp, time.Since(callStart)))
-	if rerr := insertLLMCallCounts(ctx, rt, counts); rerr != nil {
+
+	// detach from the request context so a client-side timeout during the LLM call doesn't prevent us from recording usage we already paid for
+	recCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if rerr := insertLLMCallCounts(recCtx, rt, counts); rerr != nil {
 		slog.Error("error recording llm call", "error", rerr, "llm_id", r.LLMID)
 	}
 

--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -96,7 +96,7 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 	}
 	counts := llm.RecordCall(rt, oa, events.NewLLMCalled(flows.NewLLM(llm), instructions, string(inputBytes), resp, time.Since(callStart)))
 
-	// detach from the request context so a client-side timeout during the LLM call doesn't prevent us from recording usage we already paid for
+	// detach from the request context so a client-side timeout during the LLM call doesn't prevent us from recording usage someone may have paid for
 	recCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if rerr := insertLLMCallCounts(recCtx, rt, counts); rerr != nil {


### PR DESCRIPTION
## Summary

If a `/llm/translate` request's context deadline expires *during* the LLM call itself, the subsequent `BeginTxx` in `insertLLMCallCounts` fails immediately with `context deadline exceeded`. Two consequences:

- We lose the daily-count accounting for tokens we already paid the LLM provider for.
- The failure is logged at `slog.Error` and forwarded to Sentry as `"error recording llm call"` — pure noise, since the underlying cause is just a slow upstream LLM, not a DB problem.

Fix: record usage under a detached context (`context.WithoutCancel` + 5s timeout) so a client-side timeout no longer cascades into lost usage tracking.

## Test plan

- [x] `go build ./...`
- [x] `go test -p=1 ./web/llm/...`