### PR TITLE
Remove plaintext webhook logging

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -33,20 +32,6 @@ func requestLogger(next http.Handler) http.Handler {
 			slog.Info("request completed", "method", r.Method, "status", ww.Status(), "elapsed", elapsed, "length", ww.BytesWritten(), "url", uri, "user_agent", r.UserAgent())
 
 		}
-	})
-}
-
-func logPlaintextWebhook(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/mr/") && r.Header.Get("X-Forwarded-Proto") == "http" {
-			slog.Warn("plaintext webhook",
-				"path", r.URL.Path,
-				"method", r.Method,
-				"ua", r.UserAgent(),
-				"from", r.Header.Get("X-Forwarded-For"),
-			)
-		}
-		next.ServeHTTP(w, r)
 	})
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -62,7 +62,6 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	router.Use(panicRecovery)
 	router.Use(middleware.Timeout(60 * time.Second))
 	router.Use(requestLogger)
-	router.Use(logPlaintextWebhook)
 
 	// wire up our main pages
 	router.NotFound(handle404)


### PR DESCRIPTION
## Summary
- Removes the `logPlaintextWebhook` middleware added in #1075. The ALB no longer serves plaintext on :80 (it redirects to HTTPS), so we won't see any more `/mr/*` traffic over HTTP and the warning log is no longer informative.

## Test plan
- [x] `go build ./...`