### PR TITLE
Expose internal endpoints on a separate listener port

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -27,6 +27,8 @@ type Config struct {
 
 	Address          string `help:"the address to bind our web server to"`
 	Port             int    `help:"the port to bind our web server to"`
+	InternalAddress  string `help:"the address to bind our internal web server to"`
+	InternalPort     int    `help:"the port to bind our internal web server to"`
 	AuthToken        string `help:"the token clients will need to authenticate web requests"`
 	Domain           string `help:"the domain that mailroom is listening on"`
 	AttachmentDomain string `help:"the domain that will be used for relative attachment"`
@@ -102,9 +104,11 @@ func NewDefaultConfig() *Config {
 		DBPoolSize: 36,
 		Valkey:     "valkey://valkey:6379/15",
 
-		Address:  "localhost",
-		Port:     8090,
-		SpoolDir: "./_spool",
+		Address:         "localhost",
+		Port:            8090,
+		InternalAddress: "localhost",
+		InternalPort:    8190,
+		SpoolDir:        "./_spool",
 
 		CourierEndpoint: "http://localhost:8080",
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -25,8 +25,8 @@ type Config struct {
 	Valkey     string `validate:"url,startswith=valkey:"             help:"URL for your Valkey instance"`
 	SentryDSN  string `                                              help:"the DSN used for logging errors to Sentry"`
 
-	Address          string `help:"the address to bind our web server to"`
-	Port             int    `help:"the port to bind our web server to"`
+	PublicAddress    string `help:"the address to bind our public web server to"`
+	PublicPort       int    `help:"the port to bind our public web server to"`
 	InternalAddress  string `help:"the address to bind our internal web server to"`
 	InternalPort     int    `help:"the port to bind our internal web server to"`
 	AuthToken        string `help:"the token clients will need to authenticate web requests"`
@@ -104,8 +104,8 @@ func NewDefaultConfig() *Config {
 		DBPoolSize: 36,
 		Valkey:     "valkey://valkey:6379/15",
 
-		Address:         "localhost",
-		Port:            8090,
+		PublicAddress:   "localhost",
+		PublicPort:      8090,
 		InternalAddress: "localhost",
 		InternalPort:    8091,
 		SpoolDir:        "./_spool",

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -107,7 +107,7 @@ func NewDefaultConfig() *Config {
 		Address:         "localhost",
 		Port:            8090,
 		InternalAddress: "localhost",
-		InternalPort:    8190,
+		InternalPort:    8091,
 		SpoolDir:        "./_spool",
 
 		CourierEndpoint: "http://localhost:8080",

--- a/services/ivr/vonage/service_test.go
+++ b/services/ivr/vonage/service_test.go
@@ -49,7 +49,7 @@ func TestResponseForSprint(t *testing.T) {
 	rt.DB.MustExec(`UPDATE channels_channel SET is_active = FALSE WHERE id = $1`, testdb.TwilioChannel.ID)
 
 	// update callback domain and roles for channel
-	rt.DB.MustExec(`UPDATE channels_channel SET config = config || '{"callback_domain": "localhost:8091"}'::jsonb, role='SRCA' WHERE id = $1`, testdb.VonageChannel.ID)
+	rt.DB.MustExec(`UPDATE channels_channel SET config = config || '{"callback_domain": "localhost:8190"}'::jsonb, role='SRCA' WHERE id = $1`, testdb.VonageChannel.ID)
 
 	// set our UUID generator
 	uuids.SetGenerator(uuids.NewSeededGenerator(0, time.Now))

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -67,6 +67,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DeploymentID = "test"
 	cfg.Port = 8091
+	cfg.InternalPort = 8092
 	cfg.DB = "postgres://mailroom_test:temba@postgres/mailroom_test?sslmode=disable&Timezone=UTC"
 	cfg.Valkey = "valkey://valkey:6379/10" // use a different DB from the default so a locally-running courier can't pop from queues we're asserting on
 

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -66,8 +66,8 @@ func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DeploymentID = "test"
-	cfg.Port = 8091
-	cfg.InternalPort = 8092
+	cfg.Port = 8190
+	cfg.InternalPort = 8191
 	cfg.DB = "postgres://mailroom_test:temba@postgres/mailroom_test?sslmode=disable&Timezone=UTC"
 	cfg.Valkey = "valkey://valkey:6379/10" // use a different DB from the default so a locally-running courier can't pop from queues we're asserting on
 

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -66,7 +66,7 @@ func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DeploymentID = "test"
-	cfg.Port = 8190
+	cfg.PublicPort = 8190
 	cfg.InternalPort = 8191
 	cfg.DB = "postgres://mailroom_test:temba@postgres/mailroom_test?sslmode=disable&Timezone=UTC"
 	cfg.Valkey = "valkey://valkey:6379/10" // use a different DB from the default so a locally-running courier can't pop from queues we're asserting on

--- a/testsuite/web.go
+++ b/testsuite/web.go
@@ -81,7 +81,7 @@ func RunWebTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 			httpx.SetRequestor(httpx.DefaultRequestor)
 		}
 
-		testURL := "http://localhost:8091" + tc.Path
+		testURL := "http://localhost:8190" + tc.Path
 		var req *http.Request
 		if tc.BodyEncode == "multipart" {
 			var parts []MultiPartPart

--- a/web/middleware.go
+++ b/web/middleware.go
@@ -12,42 +12,48 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-func requestLogger(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-		start := time.Now()
+func requestLogger(listener string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			start := time.Now()
 
-		next.ServeHTTP(ww, r)
+			next.ServeHTTP(ww, r)
 
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
 
-		elapsed := time.Since(start)
-		uri := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
-		ww.Header().Set("X-Elapsed-NS", strconv.FormatInt(int64(elapsed), 10))
+			elapsed := time.Since(start)
+			uri := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
+			ww.Header().Set("X-Elapsed-NS", strconv.FormatInt(int64(elapsed), 10))
 
-		if r.RequestURI != "/" {
-			slog.Info("request completed", "method", r.Method, "status", ww.Status(), "elapsed", elapsed, "length", ww.BytesWritten(), "url", uri, "user_agent", r.UserAgent())
-
-		}
-	})
+			if r.RequestURI != "/" {
+				slog.Info("request completed", "listener", listener, "method", r.Method, "status", ww.Status(), "elapsed", elapsed, "length", ww.BytesWritten(), "url", uri, "user_agent", r.UserAgent())
+			}
+		})
+	}
 }
 
 // recovers from panics, logs them to sentry and returns an HTTP 500 response
-func panicRecovery(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			if panicVal := recover(); panicVal != nil {
-				debug.PrintStack()
+func panicRecovery(listener string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if panicVal := recover(); panicVal != nil {
+					debug.PrintStack()
 
-				sentry.CurrentHub().Recover(panicVal)
+					sentry.CurrentHub().WithScope(func(scope *sentry.Scope) {
+						scope.SetTag("listener", listener)
+						sentry.CurrentHub().Recover(panicVal)
+					})
 
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			}
-		}()
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
+			}()
 
-		next.ServeHTTP(w, r)
-	})
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/web/public/base_test.go
+++ b/web/public/base_test.go
@@ -46,35 +46,35 @@ func TestMetrics(t *testing.T) {
 	}{
 		{
 			Label:    "no auth provided",
-			URL:      fmt.Sprintf("http://localhost:8091/mr/org/%s/metrics", testdb.Org1.UUID),
+			URL:      fmt.Sprintf("http://localhost:8190/mr/org/%s/metrics", testdb.Org1.UUID),
 			Username: "",
 			Password: "",
 			Response: `{"error": "invalid authentication"}`,
 		},
 		{
 			Label:    "invalid password (token)",
-			URL:      fmt.Sprintf("http://localhost:8091/mr/org/%s/metrics", testdb.Org1.UUID),
+			URL:      fmt.Sprintf("http://localhost:8190/mr/org/%s/metrics", testdb.Org1.UUID),
 			Username: "metrics",
 			Password: "invalid",
 			Response: `{"error": "invalid authentication"}`,
 		},
 		{
 			Label:    "invalid username (always metrics)",
-			URL:      fmt.Sprintf("http://localhost:8091/mr/org/%s/metrics", testdb.Org1.UUID),
+			URL:      fmt.Sprintf("http://localhost:8190/mr/org/%s/metrics", testdb.Org1.UUID),
 			Username: "invalid",
 			Password: promToken,
 			Response: `{"error": "invalid authentication"}`,
 		},
 		{
 			Label:    "valid token but wrong org",
-			URL:      fmt.Sprintf("http://localhost:8091/mr/org/%s/metrics", testdb.Org2.UUID),
+			URL:      fmt.Sprintf("http://localhost:8190/mr/org/%s/metrics", testdb.Org2.UUID),
 			Username: "metrics",
 			Password: promToken,
 			Response: `{"error": "invalid authentication"}`,
 		},
 		{
 			Label:    "valid auth",
-			URL:      fmt.Sprintf("http://localhost:8091/mr/org/%s/metrics", testdb.Org1.UUID),
+			URL:      fmt.Sprintf("http://localhost:8190/mr/org/%s/metrics", testdb.Org1.UUID),
 			Username: "metrics",
 			Password: promToken,
 			Contains: []string{

--- a/web/public/ivr_test.go
+++ b/web/public/ivr_test.go
@@ -67,7 +67,7 @@ func TestTwilioIVR(t *testing.T) {
 	testdb.InsertIncomingCallTrigger(t, rt, testdb.Org1, testdb.IVRFlow, []*testdb.Group{testdb.DoctorsGroup}, nil, nil)
 
 	// set callback domain and enable machine detection
-	rt.DB.MustExec(`UPDATE channels_channel SET config = config || '{"callback_domain": "localhost:8091", "machine_detection": true}'::jsonb WHERE id = $1`, testdb.TwilioChannel.ID)
+	rt.DB.MustExec(`UPDATE channels_channel SET config = config || '{"callback_domain": "localhost:8190", "machine_detection": true}'::jsonb WHERE id = $1`, testdb.TwilioChannel.ID)
 
 	// create a flow start for Ann, Bob, and Cat
 	parentSummary := []byte(`{
@@ -174,7 +174,7 @@ func TestVonageIVR(t *testing.T) {
 	rt.DB.MustExec(`UPDATE channels_channel SET is_active = FALSE WHERE id = $1`, testdb.TwilioChannel.ID)
 
 	// update callback domain and role
-	rt.DB.MustExec(`UPDATE channels_channel SET config = config || '{"callback_domain": "localhost:8091"}'::jsonb, role='SRCA' WHERE id = $1`, testdb.VonageChannel.ID)
+	rt.DB.MustExec(`UPDATE channels_channel SET config = config || '{"callback_domain": "localhost:8190"}'::jsonb, role='SRCA' WHERE id = $1`, testdb.VonageChannel.ID)
 
 	// start mocked API server
 	mockVonage := test.NewHTTPServer(50002, http.HandlerFunc(mockVonageHandler))

--- a/web/public/testdata/ivr_twilio.json
+++ b/web/public/testdata/ivr_twilio.json
@@ -5,7 +5,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=start&call=01969b47-190b-76f8-92a3-d648ab64bccb",
         "body": "",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.  This flow was triggered by Ann</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.  This flow was triggered by Ann</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -88,7 +88,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&call=01969b47-190b-76f8-92a3-d648ab64bccb",
         "body": "CallStatus=in-progress&timeout=true&wait_type=gather",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Sorry, that is not one or two, try again.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Sorry, that is not one or two, try again.</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -134,7 +134,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&call=01969b47-190b-76f8-92a3-d648ab64bccb",
         "body": "CallStatus=in-progress&Digits=1&wait_type=gather",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Great! You said One. Ok, now enter a number 1 to 100 then press pound.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Great! You said One. Ok, now enter a number 1 to 100 then press pound.</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -205,7 +205,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&call=01969b47-190b-76f8-92a3-d648ab64bccb",
         "body": "CallStatus=in-progress&Digits=101&wait_type=gather",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Sorry, that&#39;s too big. Enter a number 1 to 100 then press pound.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather\">\n    <Say language=\"en-US\">Sorry, that&#39;s too big. Enter a number 1 to 100 then press pound.</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -281,7 +281,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&call=01969b47-190b-76f8-92a3-d648ab64bccb",
         "body": "CallStatus=in-progress&Digits=56&wait_type=gather",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Say language=\"en-US\">You picked the number 56, excellent choice. Ok now tell me briefly why you are happy today.</Say>\n  <Record action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=record\" maxLength=\"600\"></Record>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=record&amp;empty=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Say language=\"en-US\">You picked the number 56, excellent choice. Ok now tell me briefly why you are happy today.</Say>\n  <Record action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=record\" maxLength=\"600\"></Record>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=record&amp;empty=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -357,7 +357,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&call=01969b47-190b-76f8-92a3-d648ab64bccb",
         "body": "CallStatus=in-progress&wait_type=record",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Say language=\"en-US\">You said</Say>\n  <Say language=\"en-US\">I hope hearing that makes you feel better. Good day and good bye.</Say>\n  <Dial action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=dial\" timeout=\"60\" timeLimit=\"7200\">+12065551212</Dial>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Say language=\"en-US\">You said</Say>\n  <Say language=\"en-US\">I hope hearing that makes you feel better. Good day and good bye.</Say>\n  <Dial action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-190b-76f8-92a3-d648ab64bccb&amp;wait_type=dial\" timeout=\"60\" timeLimit=\"7200\">+12065551212</Dial>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -493,7 +493,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=start&call=01969b47-2c93-76f8-8f41-6b2d9f33d623",
         "body": "",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-2c93-76f8-8f41-6b2d9f33d623&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.  This flow was triggered by Ann</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-2c93-76f8-8f41-6b2d9f33d623&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-2c93-76f8-8f41-6b2d9f33d623&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.  This flow was triggered by Ann</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b47-2c93-76f8-8f41-6b2d9f33d623&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -668,7 +668,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/incoming",
         "body": "CallSid=Call4&CallStatus=ringing&Caller=%2B16055741111",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather numDigits=\"1\" timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather\">\n    <Say language=\"en-US\">Hello there. Please enter one or two.</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",
@@ -752,7 +752,7 @@
         "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&call=01969b4a-a733-76f8-9676-22cd6062f002",
         "body": "CallStatus=in-progress&Digits=2&wait_type=gather",
         "status": 200,
-        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather timeout=\"30\" action=\"https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather\">\n    <Say language=\"en-US\">Great! You said Two. Ok, now enter a number 1 to 100 then press pound.</Say>\n  </Gather>\n  <Redirect>https://localhost:8091/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n  <Gather timeout=\"30\" action=\"https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather\">\n    <Say language=\"en-US\">Great! You said Two. Ok, now enter a number 1 to 100 then press pound.</Say>\n  </Gather>\n  <Redirect>https://localhost:8190/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/handle?action=resume&amp;call=01969b4a-a733-76f8-9676-22cd6062f002&amp;wait_type=gather&amp;timeout=true</Redirect>\n</Response>",
         "db_assertions": [
             {
                 "query": "SELECT external_id, status FROM ivr_call",

--- a/web/public/testdata/ivr_vonage.json
+++ b/web/public/testdata/ivr_vonage.json
@@ -22,7 +22,7 @@
                 "submitOnHash": true,
                 "timeOut": 30,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=zRlLI%2B84luUb4KLdMN525WprJ1Q%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=WXyNzgCUMQkDLQ4Zd1cmXI8fZj4%3D"
                 ],
                 "eventMethod": "POST"
             }
@@ -125,7 +125,7 @@
                 "submitOnHash": true,
                 "timeOut": 30,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=zRlLI%2B84luUb4KLdMN525WprJ1Q%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=WXyNzgCUMQkDLQ4Zd1cmXI8fZj4%3D"
                 ],
                 "eventMethod": "POST"
             }
@@ -205,7 +205,7 @@
                 "submitOnHash": true,
                 "timeOut": 30,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=zRlLI%2B84luUb4KLdMN525WprJ1Q%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=WXyNzgCUMQkDLQ4Zd1cmXI8fZj4%3D"
                 ],
                 "eventMethod": "POST"
             }
@@ -272,7 +272,7 @@
                 "submitOnHash": true,
                 "timeOut": 30,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=zRlLI%2B84luUb4KLdMN525WprJ1Q%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=gather\u0026sig=WXyNzgCUMQkDLQ4Zd1cmXI8fZj4%3D"
                 ],
                 "eventMethod": "POST"
             }
@@ -347,7 +347,7 @@
                 "timeOut": 600,
                 "endOnSilence": 5,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=recording_url\u0026recording_uuid=76c98188-cfe6-4072-bf05-63393fd408f5\u0026sig=phCC1y2PSeAk0b3dXudT%2B6Ss9ws%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=recording_url\u0026recording_uuid=76c98188-cfe6-4072-bf05-63393fd408f5\u0026sig=PJYtnhezTMUWsi3VmusI25PA0no%3D"
                 ],
                 "eventMethod": "POST"
             },
@@ -356,7 +356,7 @@
                 "submitOnHash": true,
                 "timeOut": 1,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=record\u0026recording_uuid=76c98188-cfe6-4072-bf05-63393fd408f5\u0026sig=%2BPzNDgKWNw52ZL13AmOF32QVhGU%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-190b-76f8-92a3-d648ab64bccb\u0026wait_type=record\u0026recording_uuid=76c98188-cfe6-4072-bf05-63393fd408f5\u0026sig=fV18U%2BDGBUp1kd0A%2F%2BAxsBXFMaQ%3D"
                 ],
                 "eventMethod": "POST"
             }
@@ -690,7 +690,7 @@
                 "submitOnHash": true,
                 "timeOut": 30,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-2c93-76f8-8f41-6b2d9f33d623\u0026wait_type=gather\u0026sig=smTf79il%2Bj7jiRYv0EvcL9e6084%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-2c93-76f8-8f41-6b2d9f33d623\u0026wait_type=gather\u0026sig=Fmsu6Oki5jXzSJLPXBxzDkmnHAU%3D"
                 ],
                 "eventMethod": "POST"
             }
@@ -781,7 +781,7 @@
                 "submitOnHash": true,
                 "timeOut": 30,
                 "eventUrl": [
-                    "https://localhost:8091/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-2c93-76f8-8f41-6b2d9f33d623\u0026wait_type=gather\u0026sig=smTf79il%2Bj7jiRYv0EvcL9e6084%3D"
+                    "https://localhost:8190/mr/ivr/c/19012bfd-3ce3-4cae-9bb9-76cf92c73d49/handle?action=resume\u0026call=01969b47-2c93-76f8-8f41-6b2d9f33d623\u0026wait_type=gather\u0026sig=Fmsu6Oki5jXzSJLPXBxzDkmnHAU%3D"
                 ],
                 "eventMethod": "POST"
             }

--- a/web/server.go
+++ b/web/server.go
@@ -92,7 +92,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	}
 
 	s.publicServer = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", rt.Config.Address, rt.Config.Port),
+		Addr:         fmt.Sprintf("%s:%d", rt.Config.PublicAddress, rt.Config.PublicPort),
 		Handler:      publicRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,

--- a/web/server.go
+++ b/web/server.go
@@ -23,21 +23,22 @@ const (
 type Handler func(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error
 
 type route struct {
-	method  string
-	pattern string
-	handler Handler
+	method   string
+	pattern  string
+	handler  Handler
+	internal bool
 }
 
 var routes []*route
 
 // PublicRoute registers a route that handles direct requests from the internet
 func PublicRoute(method string, pattern string, handler Handler) {
-	routes = append(routes, &route{method, "/mr" + pattern, handler})
+	routes = append(routes, &route{method: method, pattern: "/mr" + pattern, handler: handler})
 }
 
 // InternalRoute registers a route that handles internal requests between components
 func InternalRoute(method string, pattern string, handler Handler) {
-	routes = append(routes, &route{method, "/mi" + pattern, requireAuthToken(handler)})
+	routes = append(routes, &route{method: method, pattern: "/mi" + pattern, handler: requireAuthToken(handler), internal: true})
 }
 
 type Server struct {
@@ -46,37 +47,60 @@ type Server struct {
 
 	wg *sync.WaitGroup
 
-	httpServer *http.Server
+	publicServer   *http.Server
+	internalServer *http.Server
 }
 
 // NewServer creates a new web server, it will need to be started after being created
 func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Server {
 	s := &Server{ctx: ctx, rt: rt, wg: wg}
 
-	router := chi.NewRouter()
-
-	//  set up our middlewares
-	router.Use(middleware.Compress(flate.DefaultCompression))
-	router.Use(middleware.RequestID)
-	router.Use(middleware.RealIP)
-	router.Use(panicRecovery)
-	router.Use(middleware.Timeout(60 * time.Second))
-	router.Use(requestLogger)
-
-	// wire up our main pages
-	router.NotFound(handle404)
-	router.MethodNotAllowed(handle405)
-	router.Get("/", s.WrapHandler(handleIndex))
-
-	// and all registered routes
+	// public listener — exposes /mr/* and (during transition) /mi/* as well
+	publicRouter := chi.NewRouter()
+	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
+	publicRouter.Use(middleware.RequestID)
+	publicRouter.Use(middleware.RealIP)
+	publicRouter.Use(panicRecovery("public"))
+	publicRouter.Use(middleware.Timeout(60 * time.Second))
+	publicRouter.Use(requestLogger("public"))
+	publicRouter.NotFound(handle404)
+	publicRouter.MethodNotAllowed(handle405)
+	publicRouter.Get("/", s.WrapHandler(handleIndex))
 	for _, route := range routes {
-		router.Method(route.method, route.pattern, s.WrapHandler(route.handler))
+		publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
 	}
 
-	// configure our http server
-	s.httpServer = &http.Server{
+	// internal listener — only /mi/* routes, no public-facing concerns
+	internalRouter := chi.NewRouter()
+	internalRouter.Use(middleware.Compress(flate.DefaultCompression))
+	internalRouter.Use(middleware.RequestID)
+	internalRouter.Use(panicRecovery("internal"))
+	internalRouter.Use(middleware.Timeout(60 * time.Second))
+	internalRouter.Use(requestLogger("internal"))
+	internalRouter.NotFound(func(w http.ResponseWriter, r *http.Request) {
+		slog.Error("internal 404", "method", r.Method, "path", r.URL.Path)
+		handle404(w, r)
+	})
+	internalRouter.MethodNotAllowed(func(w http.ResponseWriter, r *http.Request) {
+		slog.Error("internal 405", "method", r.Method, "path", r.URL.Path)
+		handle405(w, r)
+	})
+	for _, route := range routes {
+		if route.internal {
+			internalRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
+		}
+	}
+
+	s.publicServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", rt.Config.Address, rt.Config.Port),
-		Handler:      router,
+		Handler:      publicRouter,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  90 * time.Second,
+	}
+	s.internalServer = &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", rt.Config.InternalAddress, rt.Config.InternalPort),
+		Handler:      internalRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  90 * time.Second,
@@ -107,32 +131,45 @@ func (s *Server) WrapHandler(handler Handler) http.HandlerFunc {
 
 // Start starts our web server, listening for new requests
 func (s *Server) Start() {
-	log := slog.With("comp", "server", "address", s.rt.Config.Address, "port", s.rt.Config.Port)
+	s.wg.Add(2)
 
-	s.wg.Add(1)
-
-	// start serving HTTP
 	go func() {
 		defer s.wg.Done()
 
-		err := s.httpServer.ListenAndServe()
+		log := slog.With("comp", "server", "listener", "public", "address", s.publicServer.Addr)
+		log.Info("server started")
+
+		err := s.publicServer.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
 			log.Error("error listening", "error", err)
 		}
 	}()
 
-	log.Info("server started")
+	go func() {
+		defer s.wg.Done()
+
+		log := slog.With("comp", "server", "listener", "internal", "address", s.internalServer.Addr)
+		log.Info("server started")
+
+		err := s.internalServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error listening", "error", err)
+		}
+	}()
 }
 
 // Stop stops our web server
 func (s *Server) Stop() {
-	log := slog.With("comp", "server")
-
-	// shut down our HTTP server
-	if err := s.httpServer.Shutdown(context.Background()); err != nil {
-		log.Error("error shutting down server", "error", err)
+	if err := s.publicServer.Shutdown(context.Background()); err != nil {
+		slog.Error("error shutting down server", "comp", "server", "listener", "public", "error", err)
 	} else {
-		log.Info("server stopped")
+		slog.Info("server stopped", "comp", "server", "listener", "public")
+	}
+
+	if err := s.internalServer.Shutdown(context.Background()); err != nil {
+		slog.Error("error shutting down server", "comp", "server", "listener", "internal", "error", err)
+	} else {
+		slog.Info("server stopped", "comp", "server", "listener", "internal")
 	}
 }
 

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,6 +1,7 @@
 package web_test
 
 import (
+	"net"
 	"net/http"
 	"sync"
 	"testing"
@@ -11,8 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	// blank-imported so TestListeners has a registered internal route to probe
+	// blank-imported so TestListeners has both a registered internal and public route to probe
 	_ "github.com/nyaruka/mailroom/v26/web/contact"
+	_ "github.com/nyaruka/mailroom/v26/web/public"
 )
 
 func TestServer(t *testing.T) {
@@ -31,10 +33,24 @@ func TestListeners(t *testing.T) {
 	server.Start()
 	defer server.Stop()
 
-	time.Sleep(100 * time.Millisecond)
+	for _, addr := range []string{"localhost:8190", "localhost:8191"} {
+		require.Eventually(t, func() bool {
+			c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+			if err != nil {
+				return false
+			}
+			c.Close()
+			return true
+		}, 5*time.Second, 10*time.Millisecond, "listener at %s never came up", addr)
+	}
 
 	const publicURL = "http://localhost:8190"
 	const internalURL = "http://localhost:8191"
+
+	// don't follow redirects so we can assert on the 301 from /mr/docs
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 
 	tcs := []struct {
 		label  string
@@ -44,6 +60,7 @@ func TestListeners(t *testing.T) {
 	}{
 		// public listener: index, public routes, and (during transition) internal routes
 		{"public: index", "GET", publicURL + "/", 200},
+		{"public: public route", "GET", publicURL + "/mr/docs", 301},
 		{"public: internal route via GET (wrong method)", "GET", publicURL + "/mi/contact/parse_query", 405},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
@@ -58,7 +75,7 @@ func TestListeners(t *testing.T) {
 		req, err := http.NewRequest(tc.method, tc.url, nil)
 		require.NoError(t, err, tc.label)
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		require.NoError(t, err, tc.label)
 		resp.Body.Close()
 

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -33,8 +33,8 @@ func TestListeners(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	const publicURL = "http://localhost:8091"
-	const internalURL = "http://localhost:8092"
+	const publicURL = "http://localhost:8190"
+	const internalURL = "http://localhost:8191"
 
 	tcs := []struct {
 		label  string

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,13 +1,67 @@
 package web_test
 
 import (
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/mailroom/v26/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// blank-imported so TestListeners has a registered internal route to probe
+	_ "github.com/nyaruka/mailroom/v26/web/contact"
 )
 
 func TestServer(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
 	testsuite.RunWebTests(t, rt, "testdata/server.json")
+}
+
+// TestListeners verifies that public and internal endpoints are correctly split
+// between the two listener ports during the dual-exposure phase.
+func TestListeners(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	wg := &sync.WaitGroup{}
+	server := web.NewServer(ctx, rt, wg)
+	server.Start()
+	defer server.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	const publicURL = "http://localhost:8091"
+	const internalURL = "http://localhost:8092"
+
+	tcs := []struct {
+		label  string
+		method string
+		url    string
+		status int
+	}{
+		// public listener: index, public routes, and (during transition) internal routes
+		{"public: index", "GET", publicURL + "/", 200},
+		{"public: internal route via GET (wrong method)", "GET", publicURL + "/mi/contact/parse_query", 405},
+		{"public: unknown path", "GET", publicURL + "/nope", 404},
+
+		// internal listener: only /mi/* routes, no index, no /mr/*
+		{"internal: index", "GET", internalURL + "/", 404},
+		{"internal: internal route via GET (wrong method)", "GET", internalURL + "/mi/contact/parse_query", 405},
+		{"internal: public route not exposed", "GET", internalURL + "/mr/docs", 404},
+		{"internal: unknown path", "GET", internalURL + "/nope", 404},
+	}
+
+	for _, tc := range tcs {
+		req, err := http.NewRequest(tc.method, tc.url, nil)
+		require.NoError(t, err, tc.label)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err, tc.label)
+		resp.Body.Close()
+
+		assert.Equal(t, tc.status, resp.StatusCode, tc.label)
+	}
 }

--- a/web/simulation/simulation_test.go
+++ b/web/simulation/simulation_test.go
@@ -202,7 +202,7 @@ func TestServer(t *testing.T) {
 			body = bytes.NewReader([]byte(bodyStr))
 		}
 
-		req, err := http.NewRequest(tc.Method, "http://localhost:8091"+tc.URL, body)
+		req, err := http.NewRequest(tc.Method, "http://localhost:8190"+tc.URL, body)
 		assert.NoError(t, err, "%d: error creating request", i)
 
 		resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
## Summary

- Adds a second `http.Server` bound to `InternalAddress`/`InternalPort` (default `localhost:8190`, test port `8092`) that serves only `/mi/*` routes.
- The existing public listener continues to serve `/mr/*` **and** `/mi/*` during the transition, so internal callers can be migrated to the new port via ALB/SG changes without downtime. Phase 3 (separate PR) will drop `/mi/*` registration from the public router.
- Middleware is parameterized on a `listener` label (`"public"` / `"internal"`) so log lines and sentry events distinguish the two from day one — even though output is otherwise identical right now.

## What's different on the internal listener

- No `RealIP` middleware — there's no proxy in front and trusting `X-Forwarded-For` from internal callers is a small hardening regression.
- No index handler at `/` (returns 404 — there's nothing useful at the root of the internal port).
- 404/405 responses are logged via `slog.Error` (sentry-routed via `slogsentry`) — these indicate caller-side bugs in rapidpro/courier and are worth alerting on.

## Test plan

- [x] `go test ./web/...` passes, including new `TestListeners` which verifies:
  - public port serves `/`, `/mr/*`, and (transition) `/mi/*`
  - internal port serves only `/mi/*`; `/`, `/mr/*`, and unknown paths all 404
- [x] Existing tests hitting `/mi/*` on `localhost:8091` keep passing (dual-exposure proves the new wiring is non-breaking).
- [x] `gofmt -w` on all touched files.

## Phase-3 cutover

Once the ALB/SG flip is done and `/mi/*` traffic on the public port has gone to zero, drop the internal-route registration from `publicRouter` in `web/server.go` — a single-line change.