### PR TITLE
Add /ping liveness endpoint on both listeners

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -29,7 +29,7 @@ func requestLogger(listener string) func(http.Handler) http.Handler {
 			uri := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
 			ww.Header().Set("X-Elapsed-NS", strconv.FormatInt(int64(elapsed), 10))
 
-			if r.RequestURI != "/" {
+			if r.RequestURI != "/" && r.RequestURI != "/ping" {
 				slog.Info("request completed", "listener", listener, "method", r.Method, "status", ww.Status(), "elapsed", elapsed, "length", ww.BytesWritten(), "url", uri, "user_agent", r.UserAgent())
 			}
 		})

--- a/web/server.go
+++ b/web/server.go
@@ -66,6 +66,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	publicRouter.NotFound(handle404)
 	publicRouter.MethodNotAllowed(handle405)
 	publicRouter.Get("/", s.WrapHandler(handleIndex))
+	publicRouter.Get("/ping", handlePing)
 	for _, route := range routes {
 		publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
 	}
@@ -85,6 +86,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 		slog.Error("internal 405", "method", r.Method, "path", r.URL.Path)
 		handle405(w, r)
 	})
+	internalRouter.Get("/ping", handlePing)
 	for _, route := range routes {
 		if route.internal {
 			internalRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
@@ -179,6 +181,13 @@ func handleIndex(ctx context.Context, rt *runtime.Runtime, r *http.Request, w ht
 		"component": "mailroom",
 		"version":   rt.Config.Version,
 	})
+}
+
+// handlePing is a lightweight liveness probe used by ALB health checks. Registered at the
+// root of both listeners and not under any /mr or /mi prefix, so no ALB listener rule routes
+// client traffic to it — only direct ALB→target health probes reach it.
+func handlePing(w http.ResponseWriter, r *http.Request) {
+	WriteMarshalled(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func handle404(w http.ResponseWriter, r *http.Request) {

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -58,14 +58,16 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: index, public routes, and (during transition) internal routes
+		// public listener: index, public routes, ping, and (during transition) internal routes
 		{"public: index", "GET", publicURL + "/", 200},
+		{"public: ping", "GET", publicURL + "/ping", 200},
 		{"public: public route", "GET", publicURL + "/mr/docs", 301},
 		{"public: internal route via GET (wrong method)", "GET", publicURL + "/mi/contact/parse_query", 405},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
-		// internal listener: only /mi/* routes, no index, no /mr/*
+		// internal listener: only /mi/* routes and /ping, no index, no /mr/*
 		{"internal: index", "GET", internalURL + "/", 404},
+		{"internal: ping", "GET", internalURL + "/ping", 200},
 		{"internal: internal route via GET (wrong method)", "GET", internalURL + "/mi/contact/parse_query", 405},
 		{"internal: public route not exposed", "GET", internalURL + "/mr/docs", 404},
 		{"internal: unknown path", "GET", internalURL + "/nope", 404},


### PR DESCRIPTION
## Summary

- Adds a no-auth `GET /ping` handler at the root of both the public (`:8090`) and internal (`:8091`) routers, intended as an ALB target-group health-check target.
- Returns `{"status": "ok"}` with HTTP 200.
- Extends `TestListeners` to assert `/ping` returns 200 on both listeners.

## Why

Now that mailroom has separate public and internal listeners, the ALB target groups that hit the internal listener need a health-check path that returns 200 on `:8091`. The previous default of `GET /` doesn't work — the internal router has no root handler and would log an `internal 404` ERROR on every probe.

Putting `/ping` at the **root** (no `/mr` or `/mi` prefix) is deliberate: the ALB listener rules only route `/mr/*` to the public mailroom listener and `/mi/*` to the internal one, so `/ping` is unreachable from any client via either ALB — only the ALB's direct target-group health probes can hit it.

This lets us point all 6 mailroom TGs (3 deployments × internal + internet) at `/ping` once this ships.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./web/` clean
- [x] `go test ./web/` compiles (full run needs devcontainer for Postgres/Localstack)
- [ ] CI runs `TestListeners` against full env
- [ ] After release: flip TG health-check path to `/ping` on staging first, then prod