### PR TITLE
Stop exposing internal /mi/* routes on the public listener

### DIFF
--- a/testsuite/web.go
+++ b/testsuite/web.go
@@ -81,7 +81,12 @@ func RunWebTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 			httpx.SetRequestor(httpx.DefaultRequestor)
 		}
 
-		testURL := "http://localhost:8190" + tc.Path
+		// route /mi/* requests to the internal listener and everything else to the public listener
+		host := "http://localhost:8190"
+		if strings.HasPrefix(tc.Path, "/mi/") {
+			host = "http://localhost:8191"
+		}
+		testURL := host + tc.Path
 		var req *http.Request
 		if tc.BodyEncode == "multipart" {
 			var parts []MultiPartPart

--- a/web/server.go
+++ b/web/server.go
@@ -23,22 +23,22 @@ const (
 type Handler func(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error
 
 type route struct {
-	method   string
-	pattern  string
-	handler  Handler
-	internal bool
+	method  string
+	pattern string
+	handler Handler
 }
 
-var routes []*route
+var publicRoutes []*route
+var internalRoutes []*route
 
 // PublicRoute registers a route that handles direct requests from the internet
 func PublicRoute(method string, pattern string, handler Handler) {
-	routes = append(routes, &route{method: method, pattern: "/mr" + pattern, handler: handler})
+	publicRoutes = append(publicRoutes, &route{method: method, pattern: "/mr" + pattern, handler: handler})
 }
 
 // InternalRoute registers a route that handles internal requests between components
 func InternalRoute(method string, pattern string, handler Handler) {
-	routes = append(routes, &route{method: method, pattern: "/mi" + pattern, handler: requireAuthToken(handler), internal: true})
+	internalRoutes = append(internalRoutes, &route{method: method, pattern: "/mi" + pattern, handler: requireAuthToken(handler)})
 }
 
 type Server struct {
@@ -67,10 +67,8 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	publicRouter.MethodNotAllowed(handle405)
 	publicRouter.Get("/", s.WrapHandler(handleIndex))
 	publicRouter.Get("/ping", handlePing)
-	for _, route := range routes {
-		if !route.internal {
-			publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
-		}
+	for _, route := range publicRoutes {
+		publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
 	}
 
 	// internal listener — only /mi/* routes, no public-facing concerns
@@ -89,10 +87,8 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 		handle405(w, r)
 	})
 	internalRouter.Get("/ping", handlePing)
-	for _, route := range routes {
-		if route.internal {
-			internalRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
-		}
+	for _, route := range internalRoutes {
+		internalRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
 	}
 
 	s.publicServer = &http.Server{

--- a/web/server.go
+++ b/web/server.go
@@ -55,7 +55,7 @@ type Server struct {
 func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Server {
 	s := &Server{ctx: ctx, rt: rt, wg: wg}
 
-	// public listener — exposes /mr/* and (during transition) /mi/* as well
+	// public listener — exposes only /mr/* routes
 	publicRouter := chi.NewRouter()
 	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
 	publicRouter.Use(middleware.RequestID)
@@ -68,7 +68,9 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	publicRouter.Get("/", s.WrapHandler(handleIndex))
 	publicRouter.Get("/ping", handlePing)
 	for _, route := range routes {
-		publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
+		if !route.internal {
+			publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
+		}
 	}
 
 	// internal listener — only /mi/* routes, no public-facing concerns

--- a/web/server.go
+++ b/web/server.go
@@ -33,12 +33,12 @@ var internalRoutes []*route
 
 // PublicRoute registers a route that handles direct requests from the internet
 func PublicRoute(method string, pattern string, handler Handler) {
-	publicRoutes = append(publicRoutes, &route{method: method, pattern: "/mr" + pattern, handler: handler})
+	publicRoutes = append(publicRoutes, &route{method: method, pattern: pattern, handler: handler})
 }
 
 // InternalRoute registers a route that handles internal requests between components
 func InternalRoute(method string, pattern string, handler Handler) {
-	internalRoutes = append(internalRoutes, &route{method: method, pattern: "/mi" + pattern, handler: requireAuthToken(handler)})
+	internalRoutes = append(internalRoutes, &route{method: method, pattern: pattern, handler: requireAuthToken(handler)})
 }
 
 type Server struct {
@@ -68,7 +68,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	publicRouter.Get("/", s.WrapHandler(handleIndex))
 	publicRouter.Get("/ping", handlePing)
 	for _, route := range publicRoutes {
-		publicRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
+		publicRouter.Method(route.method, "/mr"+route.pattern, s.WrapHandler(route.handler))
 	}
 
 	// internal listener — only /mi/* routes, no public-facing concerns
@@ -88,7 +88,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	})
 	internalRouter.Get("/ping", handlePing)
 	for _, route := range internalRoutes {
-		internalRouter.Method(route.method, route.pattern, s.WrapHandler(route.handler))
+		internalRouter.Method(route.method, "/mi"+route.pattern, s.WrapHandler(route.handler))
 	}
 
 	s.publicServer = &http.Server{

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -24,7 +24,7 @@ func TestServer(t *testing.T) {
 }
 
 // TestListeners verifies that public and internal endpoints are correctly split
-// between the two listener ports during the dual-exposure phase.
+// between the two listener ports.
 func TestListeners(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
@@ -58,11 +58,11 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: index, public routes, ping, and (during transition) internal routes
+		// public listener: index, public routes, ping — no /mi/* routes
 		{"public: index", "GET", publicURL + "/", 200},
 		{"public: ping", "GET", publicURL + "/ping", 200},
 		{"public: public route", "GET", publicURL + "/mr/docs", 301},
-		{"public: internal route via GET (wrong method)", "GET", publicURL + "/mi/contact/parse_query", 405},
+		{"public: internal route not exposed", "GET", publicURL + "/mi/contact/parse_query", 404},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
 		// internal listener: only /mi/* routes and /ping, no index, no /mr/*

--- a/web/simulation/simulation_test.go
+++ b/web/simulation/simulation_test.go
@@ -202,7 +202,7 @@ func TestServer(t *testing.T) {
 			body = bytes.NewReader([]byte(bodyStr))
 		}
 
-		req, err := http.NewRequest(tc.Method, "http://localhost:8190"+tc.URL, body)
+		req, err := http.NewRequest(tc.Method, "http://localhost:8191"+tc.URL, body)
 		assert.NoError(t, err, "%d: error creating request", i)
 
 		resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
## Summary
- Internal `/mi/*` routes are now served exclusively on the internal listener; the public listener serves only `/mr/*`, `/`, and `/ping`.
- The previous setup also exposed `/mi/*` on the public listener during the split transition — that dual exposure is removed.
- Test plumbing (`testsuite.RunWebTests` and the simulation test) is updated to route `/mi/*` requests at the internal listener port.

## Test plan
- [x] `go test -p=1 ./...` passes
- [x] `TestListeners` confirms `/mi/*` returns 404 on the public listener and works on the internal listener