### PR TITLE
Drop deprecated temperature param from Anthropic LLM calls

### DIFF
--- a/services/llm/anthropic/service.go
+++ b/services/llm/anthropic/service.go
@@ -57,8 +57,7 @@ func (s *service) Response(ctx context.Context, instructions, input string, maxT
 				},
 			},
 		},
-		Temperature: anthropic.Float(0.000001),
-		MaxTokens:   int64(maxTokens),
+		MaxTokens: int64(maxTokens),
 	})
 	if err != nil {
 		return nil, s.error(err, instructions, input)


### PR DESCRIPTION
The Anthropic API now rejects requests for newer Claude models with `400 invalid_request_error: temperature is deprecated for this model.` Remove the `Temperature` field from the message params so requests succeed across all supported models.

The SDK still allows setting `Temperature`; this is purely a server-side deprecation, so no SDK bump is needed.