### PR TITLE
Serve health response at / on both listeners

### DIFF
--- a/web/server.go
+++ b/web/server.go
@@ -65,8 +65,8 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	publicRouter.Use(requestLogger("public"))
 	publicRouter.NotFound(handle404)
 	publicRouter.MethodNotAllowed(handle405)
-	publicRouter.Get("/", s.WrapHandler(handleIndex))
-	publicRouter.Get("/ping", handlePing)
+	publicRouter.Get("/", s.WrapHandler(handleHealth))
+	publicRouter.Get("/ping", s.WrapHandler(handleHealth)) // temporary back-compat alias for /
 	for _, route := range publicRoutes {
 		publicRouter.Method(route.method, "/mr"+route.pattern, s.WrapHandler(route.handler))
 	}
@@ -86,7 +86,8 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 		slog.Error("internal 405", "method", r.Method, "path", r.URL.Path)
 		handle405(w, r)
 	})
-	internalRouter.Get("/ping", handlePing)
+	internalRouter.Get("/", s.WrapHandler(handleHealth))
+	internalRouter.Get("/ping", s.WrapHandler(handleHealth)) // temporary back-compat alias for /
 	for _, route := range internalRoutes {
 		internalRouter.Method(route.method, "/mi"+route.pattern, s.WrapHandler(route.handler))
 	}
@@ -173,19 +174,15 @@ func (s *Server) Stop() {
 	}
 }
 
-func handleIndex(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error {
+// handleHealth is the liveness probe used by ALB health checks. Registered at the root of
+// both listeners and not under any /mr or /mi prefix, so no listener rule routes client
+// traffic to it — only direct ALB→target health probes reach it. Also returns the running
+// version so it doubles as a debug endpoint.
+func handleHealth(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error {
 	return WriteMarshalled(w, http.StatusOK, map[string]string{
-		"url":       r.URL.String(),
 		"component": "mailroom",
 		"version":   rt.Config.Version,
 	})
-}
-
-// handlePing is a lightweight liveness probe used by ALB health checks. Registered at the
-// root of both listeners and not under any /mr or /mi prefix, so no ALB listener rule routes
-// client traffic to it — only direct ALB→target health probes reach it.
-func handlePing(w http.ResponseWriter, r *http.Request) {
-	WriteMarshalled(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func handle404(w http.ResponseWriter, r *http.Request) {

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -58,15 +58,15 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: index, public routes, ping — no /mi/* routes
-		{"public: index", "GET", publicURL + "/", 200},
+		// public listener: health at / and /ping, public routes — no /mi/* routes
+		{"public: health", "GET", publicURL + "/", 200},
 		{"public: ping", "GET", publicURL + "/ping", 200},
 		{"public: public route", "GET", publicURL + "/mr/docs", 301},
 		{"public: internal route not exposed", "GET", publicURL + "/mi/contact/parse_query", 404},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
-		// internal listener: only /mi/* routes and /ping, no index, no /mr/*
-		{"internal: index", "GET", internalURL + "/", 404},
+		// internal listener: health at / and /ping, /mi/* routes — no /mr/*
+		{"internal: health", "GET", internalURL + "/", 200},
 		{"internal: ping", "GET", internalURL + "/ping", 200},
 		{"internal: internal route via GET (wrong method)", "GET", internalURL + "/mi/contact/parse_query", 405},
 		{"internal: public route not exposed", "GET", internalURL + "/mr/docs", 404},

--- a/web/testdata/server.json
+++ b/web/testdata/server.json
@@ -9,22 +9,22 @@
         }
     },
     {
-        "label": "illegal method if POST to root",
-        "method": "POST",
-        "path": "/",
-        "status": 405,
-        "response": {
-            "error": "illegal method: POST"
-        }
-    },
-    {
-        "label": "status page if GET root",
+        "label": "health at root returns component and version",
         "method": "GET",
         "path": "/",
         "status": 200,
         "response": {
             "component": "mailroom",
-            "url": "/",
+            "version": "Dev"
+        }
+    },
+    {
+        "label": "health at /ping returns the same (temporary back-compat)",
+        "method": "GET",
+        "path": "/ping",
+        "status": 200,
+        "response": {
+            "component": "mailroom",
             "version": "Dev"
         }
     }

--- a/web/testdata/server.json
+++ b/web/testdata/server.json
@@ -19,6 +19,15 @@
         }
     },
     {
+        "label": "illegal method if POST to root",
+        "method": "POST",
+        "path": "/",
+        "status": 405,
+        "response": {
+            "error": "illegal method: POST"
+        }
+    },
+    {
         "label": "health at /ping returns the same (temporary back-compat)",
         "method": "GET",
         "path": "/ping",


### PR DESCRIPTION
## Summary

- Replace the public index handler and unrouted internal `/` with a shared `handleHealth` returning `{component, version}` on both listeners.
- `/ping` continues to serve the same body as a temporary back-compat alias so existing health-check configurations keep working while they migrate to `/`.
- Update `TestListeners` and `testdata/server.json` accordingly.

## Test plan

- [ ] `go test -p=1 ./web/...` passes (couldn't run locally — dependency containers were stopped)
- [ ] Hit `/` and `/ping` on a running instance for each listener and confirm the JSON body