### PR TITLE
Drop /ping back-compat alias

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -29,7 +29,7 @@ func requestLogger(listener string) func(http.Handler) http.Handler {
 			uri := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
 			ww.Header().Set("X-Elapsed-NS", strconv.FormatInt(int64(elapsed), 10))
 
-			if r.RequestURI != "/" && r.RequestURI != "/ping" {
+			if r.RequestURI != "/" {
 				slog.Info("request completed", "listener", listener, "method", r.Method, "status", ww.Status(), "elapsed", elapsed, "length", ww.BytesWritten(), "url", uri, "user_agent", r.UserAgent())
 			}
 		})

--- a/web/server.go
+++ b/web/server.go
@@ -66,7 +66,6 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	publicRouter.NotFound(handle404)
 	publicRouter.MethodNotAllowed(handle405)
 	publicRouter.Get("/", s.WrapHandler(handleHealth))
-	publicRouter.Get("/ping", s.WrapHandler(handleHealth)) // temporary back-compat alias for /
 	for _, route := range publicRoutes {
 		publicRouter.Method(route.method, "/mr"+route.pattern, s.WrapHandler(route.handler))
 	}
@@ -87,7 +86,6 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 		handle405(w, r)
 	})
 	internalRouter.Get("/", s.WrapHandler(handleHealth))
-	internalRouter.Get("/ping", s.WrapHandler(handleHealth)) // temporary back-compat alias for /
 	for _, route := range internalRoutes {
 		internalRouter.Method(route.method, "/mi"+route.pattern, s.WrapHandler(route.handler))
 	}

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -58,16 +58,14 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: health at / and /ping, public routes — no /mi/* routes
+		// public listener: health at /, public routes — no /mi/* routes
 		{"public: health", "GET", publicURL + "/", 200},
-		{"public: ping", "GET", publicURL + "/ping", 200},
 		{"public: public route", "GET", publicURL + "/mr/docs", 301},
 		{"public: internal route not exposed", "GET", publicURL + "/mi/contact/parse_query", 404},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
-		// internal listener: health at / and /ping, /mi/* routes — no /mr/*
+		// internal listener: health at /, /mi/* routes — no /mr/*
 		{"internal: health", "GET", internalURL + "/", 200},
-		{"internal: ping", "GET", internalURL + "/ping", 200},
 		{"internal: internal route via GET (wrong method)", "GET", internalURL + "/mi/contact/parse_query", 405},
 		{"internal: public route not exposed", "GET", internalURL + "/mr/docs", 404},
 		{"internal: unknown path", "GET", internalURL + "/nope", 404},

--- a/web/testdata/server.json
+++ b/web/testdata/server.json
@@ -26,15 +26,5 @@
         "response": {
             "error": "illegal method: POST"
         }
-    },
-    {
-        "label": "health at /ping returns the same (temporary back-compat)",
-        "method": "GET",
-        "path": "/ping",
-        "status": 200,
-        "response": {
-            "component": "mailroom",
-            "version": "Dev"
-        }
     }
 ]


### PR DESCRIPTION
## Summary

- Follow-up to [#1083](https://github.com/nyaruka/mailroom/pull/1083), which moved the health response to `/` and kept `/ping` as a temporary alias.
- Removes the `/ping` route from both listeners; `/` is now the sole health endpoint.
- Drops the matching test cases and the `/ping` entry from the request-logger skip filter.

Open this once external health-check configurations have been switched over to `/`.

## Test plan

- [ ] `go test -p=1 ./web/...` passes
- [ ] Confirm any external `/ping` consumers have been migrated to `/` before merging