### PR TITLE
Route user-controlled webhook calls through optional outbound HTTP proxy

### DIFF
--- a/core/goflow/engine.go
+++ b/core/goflow/engine.go
@@ -26,6 +26,8 @@ var llmPrompts map[string]*template.Template
 
 func Reset() {
 	engInit, eng = sync.Once{}, nil
+	simulatorInit, simulator = sync.Once{}, nil
+	httpInit, httpClient, httpAccess = sync.Once{}, nil, nil
 }
 
 func RegisterCheckSendable(f func(*runtime.Runtime) flows.CheckSendableCallback) {

--- a/core/goflow/http.go
+++ b/core/goflow/http.go
@@ -2,9 +2,7 @@ package goflow
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
-	"net/url"
 	"sync"
 	"time"
 
@@ -19,7 +17,8 @@ var httpAccess *httpx.AccessConfig
 
 // HTTP returns the http.Client and SSRF access config used by the engine for user-controlled
 // webhook calls (flow call_webhook actions and resthook deliveries). When cfg.WebhookProxyURL
-// is set, the client routes through that forward HTTP proxy; the SSRF IP blocklist is still
+// is set, the client routes through that forward HTTP proxy; otherwise no proxy is used (the
+// transport ignores HTTP_PROXY/HTTPS_PROXY env vars by design). The SSRF IP blocklist is
 // applied as defense-in-depth.
 func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
 	httpInit.Do(func() {
@@ -31,12 +30,10 @@ func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
 			Renegotiation: tls.RenegotiateOnceAsClient, // support single TLS renegotiation
 		}
 
-		if cfg.WebhookProxyURL != "" {
-			u, err := url.Parse(cfg.WebhookProxyURL)
-			if err != nil {
-				panic(fmt.Errorf("invalid WebhookProxyURL %q: %w", cfg.WebhookProxyURL, err))
-			}
-			t.Proxy = http.ProxyURL(u)
+		if cfg.WebhookProxyURLParsed != nil {
+			t.Proxy = http.ProxyURL(cfg.WebhookProxyURLParsed)
+		} else {
+			t.Proxy = nil
 		}
 
 		httpClient = &http.Client{

--- a/core/goflow/http.go
+++ b/core/goflow/http.go
@@ -18,7 +18,7 @@ var httpClient *http.Client
 var httpAccess *httpx.AccessConfig
 
 // HTTP returns the http.Client and SSRF access config used by the engine for user-controlled
-// webhook calls (flow call_webhook actions and resthook deliveries). When cfg.OutboundProxyURL
+// webhook calls (flow call_webhook actions and resthook deliveries). When cfg.WebhookProxyURL
 // is set, the client routes through that forward HTTP proxy; the SSRF IP blocklist is still
 // applied as defense-in-depth.
 func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
@@ -31,10 +31,10 @@ func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
 			Renegotiation: tls.RenegotiateOnceAsClient, // support single TLS renegotiation
 		}
 
-		if cfg.OutboundProxyURL != "" {
-			u, err := url.Parse(cfg.OutboundProxyURL)
+		if cfg.WebhookProxyURL != "" {
+			u, err := url.Parse(cfg.WebhookProxyURL)
 			if err != nil {
-				panic(fmt.Errorf("invalid OutboundProxyURL %q: %w", cfg.OutboundProxyURL, err))
+				panic(fmt.Errorf("invalid WebhookProxyURL %q: %w", cfg.WebhookProxyURL, err))
 			}
 			t.Proxy = http.ProxyURL(u)
 		}

--- a/core/goflow/http.go
+++ b/core/goflow/http.go
@@ -2,7 +2,9 @@ package goflow
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -15,10 +17,12 @@ var httpInit sync.Once
 var httpClient *http.Client
 var httpAccess *httpx.AccessConfig
 
-// HTTP returns the configuration objects for HTTP calls from the engine and its services
+// HTTP returns the http.Client and SSRF access config used by the engine for user-controlled
+// webhook calls (flow call_webhook actions and resthook deliveries). When cfg.OutboundProxyURL
+// is set, the client routes through that forward HTTP proxy; the SSRF IP blocklist is still
+// applied as defense-in-depth.
 func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
 	httpInit.Do(func() {
-		// customize the default golang transport
 		t := http.DefaultTransport.(*http.Transport).Clone()
 		t.MaxIdleConns = 32
 		t.MaxIdleConnsPerHost = 8
@@ -27,13 +31,20 @@ func HTTP(cfg *runtime.Config) (*http.Client, *httpx.AccessConfig) {
 			Renegotiation: tls.RenegotiateOnceAsClient, // support single TLS renegotiation
 		}
 
+		if cfg.OutboundProxyURL != "" {
+			u, err := url.Parse(cfg.OutboundProxyURL)
+			if err != nil {
+				panic(fmt.Errorf("invalid OutboundProxyURL %q: %w", cfg.OutboundProxyURL, err))
+			}
+			t.Proxy = http.ProxyURL(u)
+		}
+
 		httpClient = &http.Client{
 			Transport: t,
 			Timeout:   time.Duration(cfg.WebhooksTimeout) * time.Millisecond,
 		}
 
-		disallowedIPs, disallowedNets := cfg.DisallowedIPs, cfg.DisallowedNets
-		httpAccess = httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
+		httpAccess = httpx.NewAccessConfig(10*time.Second, cfg.DisallowedIPs, cfg.DisallowedNets)
 	})
 	return httpClient, httpAccess
 }

--- a/core/goflow/http_internal_test.go
+++ b/core/goflow/http_internal_test.go
@@ -1,0 +1,57 @@
+package goflow
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPWithProxyConfigured(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+
+	cfg := runtime.NewDefaultConfig()
+	cfg.OutboundProxyURL = "http://proxy.example.com:3128"
+
+	client, access := HTTP(cfg)
+	require.NotNil(t, access)
+
+	req, _ := http.NewRequest("POST", "https://example.org/hook", nil)
+	proxy, err := client.Transport.(*http.Transport).Proxy(req)
+	require.NoError(t, err)
+	require.NotNil(t, proxy, "transport should resolve a proxy URL when OutboundProxyURL is set")
+	assert.Equal(t, "proxy.example.com:3128", proxy.Host)
+	assert.Equal(t, "http", proxy.Scheme)
+}
+
+func TestHTTPWithoutProxy(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+
+	cfg := runtime.NewDefaultConfig()
+	cfg.OutboundProxyURL = ""
+
+	client, _ := HTTP(cfg)
+
+	req, _ := http.NewRequest("POST", "https://example.org/hook", nil)
+	// transport.Proxy is the cloned default (ProxyFromEnvironment); with no env-var proxy and
+	// no OutboundProxyURL configured, it must resolve to no proxy.
+	proxy, err := client.Transport.(*http.Transport).Proxy(req)
+	require.NoError(t, err)
+	assert.Nil(t, proxy)
+}
+
+func TestHTTPInvalidProxyURLPanics(t *testing.T) {
+	t.Cleanup(Reset)
+	Reset()
+
+	cfg := runtime.NewDefaultConfig()
+	cfg.OutboundProxyURL = "://not a url"
+
+	assert.Panics(t, func() {
+		HTTP(cfg)
+	})
+}

--- a/core/goflow/http_internal_test.go
+++ b/core/goflow/http_internal_test.go
@@ -14,7 +14,7 @@ func TestHTTPWithProxyConfigured(t *testing.T) {
 	Reset()
 
 	cfg := runtime.NewDefaultConfig()
-	cfg.OutboundProxyURL = "http://proxy.example.com:3128"
+	cfg.WebhookProxyURL = "http://proxy.example.com:3128"
 
 	client, access := HTTP(cfg)
 	require.NotNil(t, access)
@@ -22,7 +22,7 @@ func TestHTTPWithProxyConfigured(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://example.org/hook", nil)
 	proxy, err := client.Transport.(*http.Transport).Proxy(req)
 	require.NoError(t, err)
-	require.NotNil(t, proxy, "transport should resolve a proxy URL when OutboundProxyURL is set")
+	require.NotNil(t, proxy, "transport should resolve a proxy URL when WebhookProxyURL is set")
 	assert.Equal(t, "proxy.example.com:3128", proxy.Host)
 	assert.Equal(t, "http", proxy.Scheme)
 }
@@ -32,13 +32,13 @@ func TestHTTPWithoutProxy(t *testing.T) {
 	Reset()
 
 	cfg := runtime.NewDefaultConfig()
-	cfg.OutboundProxyURL = ""
+	cfg.WebhookProxyURL = ""
 
 	client, _ := HTTP(cfg)
 
 	req, _ := http.NewRequest("POST", "https://example.org/hook", nil)
 	// transport.Proxy is the cloned default (ProxyFromEnvironment); with no env-var proxy and
-	// no OutboundProxyURL configured, it must resolve to no proxy.
+	// no WebhookProxyURL configured, it must resolve to no proxy.
 	proxy, err := client.Transport.(*http.Transport).Proxy(req)
 	require.NoError(t, err)
 	assert.Nil(t, proxy)
@@ -49,7 +49,7 @@ func TestHTTPInvalidProxyURLPanics(t *testing.T) {
 	Reset()
 
 	cfg := runtime.NewDefaultConfig()
-	cfg.OutboundProxyURL = "://not a url"
+	cfg.WebhookProxyURL = "://not a url"
 
 	assert.Panics(t, func() {
 		HTTP(cfg)

--- a/core/goflow/http_internal_test.go
+++ b/core/goflow/http_internal_test.go
@@ -2,6 +2,7 @@ package goflow
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/nyaruka/mailroom/v26/runtime"
@@ -14,7 +15,9 @@ func TestHTTPWithProxyConfigured(t *testing.T) {
 	Reset()
 
 	cfg := runtime.NewDefaultConfig()
-	cfg.WebhookProxyURL = "http://proxy.example.com:3128"
+	u, err := url.Parse("http://proxy.example.com:3128")
+	require.NoError(t, err)
+	cfg.WebhookProxyURLParsed = u
 
 	client, access := HTTP(cfg)
 	require.NotNil(t, access)
@@ -32,26 +35,8 @@ func TestHTTPWithoutProxy(t *testing.T) {
 	Reset()
 
 	cfg := runtime.NewDefaultConfig()
-	cfg.WebhookProxyURL = ""
-
+	// WebhookProxyURLParsed is nil — transport must have nil Proxy regardless of host env vars
 	client, _ := HTTP(cfg)
 
-	req, _ := http.NewRequest("POST", "https://example.org/hook", nil)
-	// transport.Proxy is the cloned default (ProxyFromEnvironment); with no env-var proxy and
-	// no WebhookProxyURL configured, it must resolve to no proxy.
-	proxy, err := client.Transport.(*http.Transport).Proxy(req)
-	require.NoError(t, err)
-	assert.Nil(t, proxy)
-}
-
-func TestHTTPInvalidProxyURLPanics(t *testing.T) {
-	t.Cleanup(Reset)
-	Reset()
-
-	cfg := runtime.NewDefaultConfig()
-	cfg.WebhookProxyURL = "://not a url"
-
-	assert.Panics(t, func() {
-		HTTP(cfg)
-	})
+	assert.Nil(t, client.Transport.(*http.Transport).Proxy)
 }

--- a/core/models/classifier.go
+++ b/core/models/classifier.go
@@ -48,7 +48,7 @@ func init() {
 
 func classificationServiceFactory(rt *runtime.Runtime) engine.ClassificationServiceFactory {
 	return func(classifier *flows.Classifier) (flows.ClassificationService, error) {
-		return classifier.Asset().(*Classifier).AsService(rt.Config, classifier)
+		return classifier.Asset().(*Classifier).AsService(rt, classifier)
 	}
 }
 
@@ -83,16 +83,14 @@ func (c *Classifier) Intents() []string { return c.intentNames }
 func (c *Classifier) Type() string { return c.Type_ }
 
 // AsService builds the corresponding ClassificationService for the passed in Classifier
-func (c *Classifier) AsService(cfg *runtime.Config, classifier *flows.Classifier) (flows.ClassificationService, error) {
-	httpClient, _ := goflow.HTTP(cfg)
-
+func (c *Classifier) AsService(rt *runtime.Runtime, classifier *flows.Classifier) (flows.ClassificationService, error) {
 	switch c.Type() {
 	case ClassifierTypeWit:
 		accessToken := c.Config_[WitConfigAccessToken]
 		if accessToken == "" {
 			return nil, fmt.Errorf("missing %s for Wit classifier: %s", WitConfigAccessToken, c.UUID())
 		}
-		return wit.NewService(httpClient, nil, classifier, accessToken), nil
+		return wit.NewService(rt.HTTP, nil, classifier, accessToken), nil
 
 	default:
 		return nil, fmt.Errorf("unknown classifier type '%s' for classifier: %s", c.Type(), c.UUID())

--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -45,10 +45,8 @@ func RegisterLLMService(typ string, fn func(*runtime.Runtime, *LLM, *http.Client
 }
 
 func llmServiceFactory(rt *runtime.Runtime) engine.LLMServiceFactory {
-	httpClient, _ := goflow.HTTP(rt.Config)
-
 	return func(llm *flows.LLM) (flows.LLMService, error) {
-		return llm.Asset().(*LLM).AsService(rt, httpClient)
+		return llm.Asset().(*LLM).AsService(rt, rt.HTTP)
 	}
 }
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -48,6 +48,7 @@ type Config struct {
 
 	SMTPServer           string   `help:"the default SMTP configuration for sending flow emails, e.g. smtp://user%40password@server:port/?from=foo%40gmail.com"`
 	DisallowedNetworks   []string `help:"comma separated list of IP addresses and networks which engine can't make HTTP calls to"`
+	OutboundProxyURL     string   `validate:"omitempty,url" help:"optional URL of a forward HTTP proxy to use for user-controlled webhook calls, e.g. http://proxy.example.com:3128"`
 	MaxStepsPerSprint    int      `help:"the maximum number of steps allowed per engine sprint"`
 	MaxSprintsPerSession int      `help:"the maximum number of sprints allowed per engine session"`
 	MaxValueLength       int      `help:"the maximum size in characters for contact field values and run result values"`

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -48,7 +48,7 @@ type Config struct {
 
 	SMTPServer           string   `help:"the default SMTP configuration for sending flow emails, e.g. smtp://user%40password@server:port/?from=foo%40gmail.com"`
 	DisallowedNetworks   []string `help:"comma separated list of IP addresses and networks which engine can't make HTTP calls to"`
-	OutboundProxyURL     string   `validate:"omitempty,url" help:"optional URL of a forward HTTP proxy to use for user-controlled webhook calls, e.g. http://proxy.example.com:3128"`
+	WebhookProxyURL      string   `validate:"omitempty,url" help:"optional URL of a forward HTTP proxy to use for user-controlled webhook calls, e.g. http://proxy.example.com:3128"`
 	MaxStepsPerSprint    int      `help:"the maximum number of steps allowed per engine sprint"`
 	MaxSprintsPerSession int      `help:"the maximum number of sprints allowed per engine session"`
 	MaxValueLength       int      `help:"the maximum size in characters for contact field values and run result values"`

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 
 	"github.com/go-playground/validator/v10"
@@ -48,7 +49,7 @@ type Config struct {
 
 	SMTPServer           string   `help:"the default SMTP configuration for sending flow emails, e.g. smtp://user%40password@server:port/?from=foo%40gmail.com"`
 	DisallowedNetworks   []string `help:"comma separated list of IP addresses and networks which engine can't make HTTP calls to"`
-	WebhookProxyURL      string   `validate:"omitempty,url" help:"optional URL of a forward HTTP proxy to use for user-controlled webhook calls, e.g. http://proxy.example.com:3128"`
+	WebhookProxyURL      string   `validate:"omitempty,http_url" help:"optional URL of a forward HTTP proxy to use for user-controlled webhook calls, e.g. http://proxy.example.com:3128"`
 	MaxStepsPerSprint    int      `help:"the maximum number of steps allowed per engine sprint"`
 	MaxSprintsPerSession int      `help:"the maximum number of sprints allowed per engine session"`
 	MaxValueLength       int      `help:"the maximum size in characters for contact field values and run result values"`
@@ -93,6 +94,7 @@ type Config struct {
 	DisallowedIPs          []net.IP
 	DisallowedNets         []*net.IPNet
 	IDObfuscationKeyParsed [4]uint32
+	WebhookProxyURLParsed  *url.URL
 }
 
 // NewDefaultConfig returns a new default configuration object
@@ -183,6 +185,15 @@ func (c *Config) Parse() error {
 	// parse our disallowed networks
 	if err := c.parseDisallowedNetworks(); err != nil {
 		return fmt.Errorf("invalid disallowed networks: %w", err)
+	}
+
+	// parse the optional webhook proxy URL (validator already enforced http/https scheme)
+	if c.WebhookProxyURL != "" {
+		u, err := url.Parse(c.WebhookProxyURL)
+		if err != nil {
+			return fmt.Errorf("invalid webhook proxy URL: %w", err)
+		}
+		c.WebhookProxyURLParsed = u
 	}
 
 	// parse our ID obfuscation key

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2,8 +2,10 @@ package runtime
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"fmt"
+	"net/http"
 	"time"
 
 	"firebase.google.com/go/v4/messaging"
@@ -33,6 +35,11 @@ type Runtime struct {
 
 	Queues *Queues
 	Stats  *StatsCollector
+
+	// HTTP is the shared http.Client for outbound calls to fixed third-party services (e.g. LLM
+	// provider APIs). It does NOT go through the outbound webhook proxy — that is reserved for
+	// user-controlled URLs and lives on the engine's HTTP client (see core/goflow.HTTP).
+	HTTP *http.Client
 }
 
 // FCMClient is an interface to allow mocking in tests
@@ -88,8 +95,23 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 
 	rt.Queues = newQueues(cfg)
 	rt.Stats = NewStatsCollector(rt.VK, cfg.LatencyExcludedOrgs)
+	rt.HTTP = newHTTPClient(cfg)
 
 	return rt, nil
+}
+
+func newHTTPClient(cfg *Config) *http.Client {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 32
+	t.MaxIdleConnsPerHost = 8
+	t.IdleConnTimeout = 30 * time.Second
+	t.TLSClientConfig = &tls.Config{
+		Renegotiation: tls.RenegotiateOnceAsClient,
+	}
+	return &http.Client{
+		Transport: t,
+		Timeout:   time.Duration(cfg.WebhooksTimeout) * time.Millisecond,
+	}
 }
 
 func (r *Runtime) Start() error {


### PR DESCRIPTION
## Summary

- Adds an optional `WebhookProxyURL` config field (env `MAILROOM_WEBHOOK_PROXY_URL`). When set, the engine HTTP client used for user-controlled webhook calls (flow `call_webhook` actions and resthook deliveries) routes outbound requests through that forward HTTP proxy. When empty, behavior is unchanged.
- Operators can use this to send user-controlled webhook traffic through a forward proxy that they control (e.g. one that denies egress to internal networks at the network layer), so a user can't aim a webhook at internal infrastructure.
- The existing `DisallowedNetworks` IP blocklist stays in place as defense-in-depth; this PR doesn't change SSRF behavior. Retiring the blocklist can be done in a separate PR once the proxy has been running in production for a while.
- Splits the engine HTTP client cleanly: `core/goflow.HTTP()` now always returns the (potentially proxied) client used by the webhook service factory. A new `Runtime.HTTP` client serves outbound calls to fixed third-party APIs (LLM providers, Wit.ai classifier) and never goes through the proxy.
- Other HTTP call sites (Courier, airtime, IVR providers, AWS SDK, Elasticsearch) already use their own clients and are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New unit tests in `core/goflow/http_internal_test.go` cover the proxied and unproxied transport configurations.