### PR TITLE
Trim webhook User-Agent to avoid leaking build details

### DIFF
--- a/core/goflow/engine.go
+++ b/core/goflow/engine.go
@@ -2,6 +2,7 @@ package goflow
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"text/template"
 
@@ -68,11 +69,21 @@ func RegisterLLMPrompts(p map[string]*template.Template) {
 	llmPrompts = p
 }
 
+// userAgent returns the User-Agent header value for webhook calls. Only the major.minor
+// portion of the version is included to avoid leaking specific build details.
+func userAgent(version string) string {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) >= 2 {
+		return "Mailroom/" + parts[0] + "." + parts[1]
+	}
+	return "Mailroom/" + version
+}
+
 // Engine returns the global engine instance for use with real sessions
 func Engine(rt *runtime.Runtime) flows.Engine {
 	engInit.Do(func() {
 		webhookHeaders := map[string]string{
-			"User-Agent":      "RapidProMailroom/" + rt.Config.Version,
+			"User-Agent":      userAgent(rt.Config.Version),
 			"X-Mailroom-Mode": "normal",
 		}
 
@@ -101,7 +112,7 @@ func Engine(rt *runtime.Runtime) flows.Engine {
 func Simulator(ctx context.Context, rt *runtime.Runtime) flows.Engine {
 	simulatorInit.Do(func() {
 		webhookHeaders := map[string]string{
-			"User-Agent":      "RapidProMailroom/" + rt.Config.Version,
+			"User-Agent":      userAgent(rt.Config.Version),
 			"X-Mailroom-Mode": "simulation",
 		}
 

--- a/core/goflow/engine_test.go
+++ b/core/goflow/engine_test.go
@@ -31,7 +31,7 @@ func TestEngineWebhook(t *testing.T) {
 	call, err := svc.Call(request)
 	assert.NoError(t, err)
 	assert.NotNil(t, call)
-	assert.Equal(t, "GET / HTTP/1.1\r\nHost: rapidpro.io\r\nUser-Agent: RapidProMailroom/Dev\r\nX-Mailroom-Mode: normal\r\nAccept-Encoding: gzip\r\n\r\n", string(call.RequestTrace))
+	assert.Equal(t, "GET / HTTP/1.1\r\nHost: rapidpro.io\r\nUser-Agent: Mailroom/Dev\r\nX-Mailroom-Mode: normal\r\nAccept-Encoding: gzip\r\n\r\n", string(call.RequestTrace))
 	assert.Equal(t, "HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\n", string(call.ResponseTrace))
 	assert.Equal(t, "OK", string(call.ResponseBody))
 }
@@ -72,7 +72,7 @@ func TestSimulatorWebhook(t *testing.T) {
 	call, err := svc.Call(request)
 	assert.NoError(t, err)
 	assert.NotNil(t, call)
-	assert.Equal(t, "GET / HTTP/1.1\r\nHost: rapidpro.io\r\nUser-Agent: RapidProMailroom/Dev\r\nX-Mailroom-Mode: simulation\r\nAccept-Encoding: gzip\r\n\r\n", string(call.RequestTrace))
+	assert.Equal(t, "GET / HTTP/1.1\r\nHost: rapidpro.io\r\nUser-Agent: Mailroom/Dev\r\nX-Mailroom-Mode: simulation\r\nAccept-Encoding: gzip\r\n\r\n", string(call.RequestTrace))
 	assert.Equal(t, "HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\n", string(call.ResponseTrace))
 	assert.Equal(t, "OK", string(call.ResponseBody))
 }


### PR DESCRIPTION
## Summary

Webhook calls were sending `User-Agent: RapidProMailroom/<full-version>`, where the version string includes both the patch level and the goreleaser-injected build timestamp — e.g. `RapidProMailroom/26.1.121-202605202105`. That leaks a deployment-specific build identifier to every webhook endpoint.

This trims the header to `Mailroom/<major>.<minor>` (e.g. `Mailroom/26.1`):

- Drops the `RapidPro` prefix.
- Strips the patch level and build-date suffix, keeping a single major.minor token so receivers can still coarsely gate on version if they want to.
- Falls back to the raw version when it isn't dotted (so the `Dev` default in tests/local runs stays as `Mailroom/Dev`).

The format remains a valid single `product = token "/" product-version` per RFC 9110 §10.1.5.

## Test plan

- [x] `go test -p=1 ./core/goflow/...` — existing engine tests updated and passing
- [ ] After deploy, verify a real webhook receives `User-Agent: Mailroom/26.1` (no patch, no build date)