### PR TITLE
Set ExternalID on simulator airtime transfers

### DIFF
--- a/core/goflow/engine.go
+++ b/core/goflow/engine.go
@@ -144,9 +144,11 @@ type simulatorAirtimeService struct{}
 
 func (s *simulatorAirtimeService) Transfer(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP flows.HTTPLogCallback) (*flows.AirtimeTransfer, error) {
 	transfer := &flows.AirtimeTransfer{
-		Sender:    sender,
-		Recipient: recipient,
-		Amount:    decimal.Zero,
+		// fake but non-empty so @locals._new_transfer satisfies has_text and runs route to Success
+		ExternalID: "123456789",
+		Sender:     sender,
+		Recipient:  recipient,
+		Amount:     decimal.Zero,
 	}
 
 	// pick arbitrary currency/amount pair in map

--- a/core/goflow/engine_test.go
+++ b/core/goflow/engine_test.go
@@ -48,10 +48,11 @@ func TestSimulatorAirtime(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, &flows.AirtimeTransfer{
-		Sender:    urns.URN("tel:+593979111111"),
-		Recipient: urns.URN("tel:+593979222222"),
-		Currency:  "USD",
-		Amount:    decimal.RequireFromString(`1.50`),
+		ExternalID: "123456789",
+		Sender:     urns.URN("tel:+593979111111"),
+		Recipient:  urns.URN("tel:+593979222222"),
+		Currency:   "USD",
+		Amount:     decimal.RequireFromString(`1.50`),
 	}, transfer)
 }
 


### PR DESCRIPTION
## Summary
- The simulator's `AirtimeTransfer` returned an empty `ExternalID`, so `transfer_airtime` set `@locals._new_transfer` to `""`.
- That made the `split_by_airtime` router's `has_text` case miss, routing simulated successful transfers to **Failure**.
- Set a fixed, obviously-fake value (`"123456789"`) so simulated runs route to Success.

## Test plan
- [x] `go test -p=1 ./core/goflow/...` passes (including updated `TestSimulatorAirtime`).
- [ ] Open a flow containing a `split_by_airtime` node in the editor preview and confirm the run takes the Success exit.