### PR TITLE
Write airtime transfer status changes as event tags to the history table

### DIFF
--- a/core/models/airtime.go
+++ b/core/models/airtime.go
@@ -2,9 +2,12 @@ package models
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"time"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
@@ -53,6 +56,20 @@ const (
 	// AirtimeTransferStatusDeclined — the operator declined the transaction.
 	AirtimeTransferStatusDeclined AirtimeTransferStatus = "D"
 )
+
+// airtimeTransferStatusNames maps each status to the lowercase name written to the history table and read
+// back by clients (see https://github.com/nyaruka/temba-components). Clients inject this as the _status of
+// the airtime_created event, mirroring how courier records msg_created status changes.
+var airtimeTransferStatusNames = map[AirtimeTransferStatus]string{
+	AirtimeTransferStatusCreated:   "created",
+	AirtimeTransferStatusConfirmed: "confirmed",
+	AirtimeTransferStatusSubmitted: "submitted",
+	AirtimeTransferStatusCompleted: "completed",
+	AirtimeTransferStatusReversed:  "reversed",
+	AirtimeTransferStatusRejected:  "rejected",
+	AirtimeTransferStatusCancelled: "cancelled",
+	AirtimeTransferStatusDeclined:  "declined",
+}
 
 // AirtimeTransfer is our type for an airtime transfer
 type AirtimeTransfer struct {
@@ -133,26 +150,47 @@ func InsertAirtimeTransfers(ctx context.Context, db DBorTx, transfers []*Airtime
 }
 
 const sqlUpdateAirtimeTransferStatus = `
-UPDATE airtime_airtimetransfer SET status = $2 WHERE uuid = $1 AND external_id = $3
-`
+   UPDATE airtime_airtimetransfer t SET status = $2
+     FROM contacts_contact c
+    WHERE t.uuid = $1 AND t.external_id = $3 AND c.id = t.contact_id
+RETURNING t.org_id AS org_id, c.uuid AS contact_uuid`
 
-// UpdateAirtimeTransferStatus writes the given status to the airtime transfer keyed by (uuid, external_id),
-// returning true if a row was actually updated. external_id must match the row as defense in depth for the
-// public callback path — a forged callback with a leaked UUID still can't mutate a row whose tx id it
-// doesn't know. There's no status-transition guard: provider callbacks can arrive out of order or with
-// gaps in the lifecycle (e.g. a Reversed callback for a transfer we never saw Completed for), and dropping
-// those would strand the row in its prior state forever. We'd rather a late callback overwrite with stale
-// state than silently lose a real terminal status update.
-func UpdateAirtimeTransferStatus(ctx context.Context, db DBorTx, uuid flows.EventUUID, externalID string, next AirtimeTransferStatus) (bool, error) {
-	res, err := db.ExecContext(ctx, sqlUpdateAirtimeTransferStatus, uuid, next, externalID)
-	if err != nil {
-		return false, err
+// UpdateAirtimeTransferStatus writes the given status to the airtime transfer keyed by (uuid, external_id).
+// It returns an event tag recording the change for the contact's history (to be queued to the history table),
+// or nil if no row was updated. external_id must match the row as defense in depth for the public callback
+// path — a forged callback with a leaked UUID still can't mutate a row whose tx id it doesn't know. There's
+// no status-transition guard: provider callbacks can arrive out of order or with gaps in the lifecycle (e.g.
+// a Reversed callback for a transfer we never saw Completed for), and dropping those would strand the row in
+// its prior state forever. We'd rather a late callback overwrite with stale state than silently lose a real
+// terminal status update.
+func UpdateAirtimeTransferStatus(ctx context.Context, db DBorTx, uuid flows.EventUUID, externalID string, next AirtimeTransferStatus) (*EventTag, error) {
+	row := &struct {
+		OrgID       OrgID             `db:"org_id"`
+		ContactUUID flows.ContactUUID `db:"contact_uuid"`
+	}{}
+	if err := db.GetContext(ctx, row, sqlUpdateAirtimeTransferStatus, uuid, next, externalID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
 	}
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return false, err
+	return NewAirtimeStatusTag(row.OrgID, row.ContactUUID, uuid, next), nil
+}
+
+// NewAirtimeStatusTag creates the history-table event tag that records a transfer's status change. It's keyed
+// by the same UUID as the transfer's airtime_created event (and shares a sort key across changes, so the
+// latest overwrites) allowing clients to inject the current _status when rendering that event.
+func NewAirtimeStatusTag(orgID OrgID, contactUUID flows.ContactUUID, transferUUID flows.EventUUID, status AirtimeTransferStatus) *EventTag {
+	return &EventTag{
+		OrgID:       orgID,
+		ContactUUID: contactUUID,
+		EventUUID:   transferUUID,
+		Tag:         eventTagStatus,
+		Data: map[string]any{
+			"created_on": dates.Now(),
+			"status":     airtimeTransferStatusNames[status],
+		},
 	}
-	return rows > 0, nil
 }
 
 func (i *AirtimeTransferID) Scan(value any) error         { return null.ScanInt(value, i) }

--- a/core/models/airtime_test.go
+++ b/core/models/airtime_test.go
@@ -43,14 +43,21 @@ func TestAirtimeTransfers(t *testing.T) {
 
 	// callback whose provider tx id doesn't match the row's external_id is a no-op (defense in depth —
 	// a forged callback would have to know both the UUID and DT One's id to mutate the row)
-	updated, err := models.UpdateAirtimeTransferStatus(ctx, rt.DB, transfer.UUID(), "wrong-tx-id", models.AirtimeTransferStatusCompleted)
+	tag, err := models.UpdateAirtimeTransferStatus(ctx, rt.DB, transfer.UUID(), "wrong-tx-id", models.AirtimeTransferStatusCompleted)
 	assert.NoError(t, err)
-	assert.False(t, updated)
+	assert.Nil(t, tag, "no row should be updated when the provider tx id doesn't match")
 
-	// callback transitions pending → success when both UUID and provider tx id line up
-	updated, err = models.UpdateAirtimeTransferStatus(ctx, rt.DB, transfer.UUID(), "2237512891", models.AirtimeTransferStatusCompleted)
+	// callback transitions pending → success when both UUID and provider tx id line up, returning an
+	// event tag that records the change for the contact's history
+	tag, err = models.UpdateAirtimeTransferStatus(ctx, rt.DB, transfer.UUID(), "2237512891", models.AirtimeTransferStatusCompleted)
 	assert.NoError(t, err)
-	assert.True(t, updated)
+	if assert.NotNil(t, tag) {
+		assert.Equal(t, testdb.Org1.ID, tag.OrgID)
+		assert.Equal(t, testdb.Ann.UUID, tag.ContactUUID)
+		assert.Equal(t, transfer.UUID(), tag.EventUUID)
+		assert.Equal(t, "sts", tag.Tag)
+		assert.Equal(t, "completed", tag.Data["status"])
+	}
 
 	assertdb.Query(t, rt.DB, `SELECT status FROM airtime_airtimetransfer WHERE id = $1`, transfer.ID()).
 		Columns(map[string]any{"status": "S"})
@@ -58,9 +65,11 @@ func TestAirtimeTransfers(t *testing.T) {
 	// any status update with matching uuid + external_id is applied — no transition guard, since
 	// dropping out-of-order callbacks could strand the row (e.g. a Reversed callback for a transfer
 	// we never saw Completed for)
-	updated, err = models.UpdateAirtimeTransferStatus(ctx, rt.DB, transfer.UUID(), "2237512891", models.AirtimeTransferStatusReversed)
+	tag, err = models.UpdateAirtimeTransferStatus(ctx, rt.DB, transfer.UUID(), "2237512891", models.AirtimeTransferStatusReversed)
 	assert.NoError(t, err)
-	assert.True(t, updated)
+	if assert.NotNil(t, tag) {
+		assert.Equal(t, "reversed", tag.Data["status"])
+	}
 
 	assertdb.Query(t, rt.DB, `SELECT status FROM airtime_airtimetransfer WHERE id = $1`, transfer.ID()).
 		Columns(map[string]any{"status": "R"})

--- a/core/models/airtime_test.go
+++ b/core/models/airtime_test.go
@@ -74,3 +74,29 @@ func TestAirtimeTransfers(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT status FROM airtime_airtimetransfer WHERE id = $1`, transfer.ID()).
 		Columns(map[string]any{"status": "R"})
 }
+
+func TestNewAirtimeStatusTag(t *testing.T) {
+	// every status must map to a non-empty external name (consumed as the event's _status by clients) —
+	// an unmapped status would silently write `"status": ""` and render as an empty badge with no error.
+	// Any new AirtimeTransferStatus constant must be added here.
+	names := map[models.AirtimeTransferStatus]string{
+		models.AirtimeTransferStatusCreated:   "created",
+		models.AirtimeTransferStatusConfirmed: "confirmed",
+		models.AirtimeTransferStatusSubmitted: "submitted",
+		models.AirtimeTransferStatusCompleted: "completed",
+		models.AirtimeTransferStatusReversed:  "reversed",
+		models.AirtimeTransferStatusRejected:  "rejected",
+		models.AirtimeTransferStatusCancelled: "cancelled",
+		models.AirtimeTransferStatusDeclined:  "declined",
+	}
+
+	for status, name := range names {
+		tag := models.NewAirtimeStatusTag(testdb.Org1.ID, testdb.Ann.UUID, "0197b335-6ded-79a4-95a6-3af85b57f108", status)
+		assert.Equal(t, testdb.Org1.ID, tag.OrgID)
+		assert.Equal(t, testdb.Ann.UUID, tag.ContactUUID)
+		assert.Equal(t, flows.EventUUID("0197b335-6ded-79a4-95a6-3af85b57f108"), tag.EventUUID)
+		assert.Equal(t, "sts", tag.Tag)
+		assert.Equal(t, name, tag.Data["status"], "unexpected name for status %q", status)
+		assert.NotEmpty(t, tag.Data["status"], "status %q has no external name", status)
+	}
+}

--- a/core/models/event.go
+++ b/core/models/event.go
@@ -29,6 +29,7 @@ const (
 	eternity time.Duration = -1
 
 	eventTagDeletion = "del"
+	eventTagStatus   = "sts"
 )
 
 var eventPersistence = map[string]time.Duration{

--- a/core/models/event_test.go
+++ b/core/models/event_test.go
@@ -149,4 +149,11 @@ func TestEventTags(t *testing.T) {
 		"created_on": time.Date(2025, time.May, 4, 12, 30, 46, 123456789, time.UTC),
 		"by_contact": true,
 	}, tag.Data)
+
+	tag = models.NewAirtimeStatusTag(testdb.Org1.ID, testdb.Ann.UUID, "0197b335-6ded-79a4-95a6-3af85b57f108", models.AirtimeTransferStatusCompleted)
+	assert.Equal(t, "sts", tag.Tag)
+	assert.Equal(t, map[string]any{
+		"created_on": time.Date(2025, time.May, 4, 12, 30, 47, 123456789, time.UTC),
+		"status":     "completed",
+	}, tag.Data)
 }

--- a/core/models/testdata/eventtag_to_dynamo.json
+++ b/core/models/testdata/eventtag_to_dynamo.json
@@ -66,5 +66,34 @@
                 }
             }
         }
+    },
+    {
+        "event_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+        "tag": "sts",
+        "data": {
+            "created_on": "2025-05-04T12:30:46.123456789Z",
+            "status": "completed"
+        },
+        "dynamo": {
+            "PK": {
+                "S": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf"
+            },
+            "SK": {
+                "S": "evt#0197b335-6ded-79a4-95a6-3af85b57f108#sts"
+            },
+            "OrgID": {
+                "N": "1"
+            },
+            "Data": {
+                "M": {
+                    "created_on": {
+                        "S": "2025-05-04T12:30:46.123456789Z"
+                    },
+                    "status": {
+                        "S": "completed"
+                    }
+                }
+            }
+        }
     }
 ]

--- a/web/public/airtime.go
+++ b/web/public/airtime.go
@@ -84,15 +84,21 @@ func handleDTOneStatus(ctx context.Context, rt *runtime.Runtime, r *http.Request
 	// unknown, the provider id doesn't match what we stored, or the row's current status doesn't admit
 	// this transition (duplicate / out-of-order callback). The right reply to the provider is 2XX
 	// either way so it stops retrying — the distinction isn't actionable for DT One.
-	updated, err := models.UpdateAirtimeTransferStatus(ctx, rt.DB, transferUUID, providerID, newStatus)
+	tag, err := models.UpdateAirtimeTransferStatus(ctx, rt.DB, transferUUID, providerID, newStatus)
 	if err != nil {
 		return fmt.Errorf("error updating airtime transfer status: %w", err)
 	}
-	if !updated {
+	if tag == nil {
 		// debug rather than info — the UUID is a capability token and we don't want to surface it in
 		// aggregated logs by default
 		slog.Debug("ignoring no-op dtone callback", "transfer", transferUUID, "to", newStatus)
 		return web.WriteMarshalled(w, http.StatusOK, map[string]string{"status": "ignored"})
+	}
+
+	// record the change as an event tag in the contact's history (keyed by the airtime_created event UUID)
+	// so clients can inject the transfer's current _status when rendering that event
+	if _, err := rt.Dynamo.History.Queue(tag); err != nil {
+		return fmt.Errorf("error queuing airtime status tag: %w", err)
 	}
 
 	return web.WriteMarshalled(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/web/public/airtime_test.go
+++ b/web/public/airtime_test.go
@@ -68,6 +68,9 @@ func TestDTOneStatusCallback(t *testing.T) {
 		return fmt.Sprintf(`{"id":2237512891,"external_id":%q,"status":{"class":{"id":%d,"message":%q}}}`, string(uuid), classID, msg)
 	}
 
+	// start from a clean history table so we can assert exactly what each callback writes
+	testsuite.GetHistoryItems(t, rt, true, time.Time{})
+
 	// happy path through the lifecycle: P → C → B → S → R
 	uuid := seed(t)
 	assert.Equal(t, http.StatusOK, post(t, body(uuid, 2, "CONFIRMED")))
@@ -79,10 +82,30 @@ func TestDTOneStatusCallback(t *testing.T) {
 	assert.Equal(t, http.StatusOK, post(t, body(uuid, 8, "REVERSED")))
 	assert.Equal(t, models.AirtimeTransferStatusReversed, rowStatus(t, uuid))
 
-	// each terminal failure class maps to its own status
+	// each successful transition is recorded as an `sts` event tag keyed by the transfer's UUID; the
+	// tags share a sort key so the latest callback overwrites, leaving one tag at the current status
+	items := testsuite.GetHistoryItems(t, rt, true, time.Time{})
+	if assert.Len(t, items, 1) {
+		assert.Equal(t, fmt.Sprintf("con#%s", testdb.Ann.UUID), items[0].PK)
+		assert.Equal(t, fmt.Sprintf("evt#%s#sts", uuid), items[0].SK)
+		data, err := items[0].GetData()
+		require.NoError(t, err)
+		assert.Equal(t, "reversed", data["status"])
+		assert.NotEmpty(t, data["created_on"])
+	}
+
+	// each terminal failure class maps to its own status, and writes its own status tag
 	uuid = seed(t)
 	assert.Equal(t, http.StatusOK, post(t, body(uuid, 3, "REJECTED")))
 	assert.Equal(t, models.AirtimeTransferStatusRejected, rowStatus(t, uuid))
+
+	items = testsuite.GetHistoryItems(t, rt, true, time.Time{})
+	if assert.Len(t, items, 1) {
+		assert.Equal(t, fmt.Sprintf("evt#%s#sts", uuid), items[0].SK)
+		data, err := items[0].GetData()
+		require.NoError(t, err)
+		assert.Equal(t, "rejected", data["status"])
+	}
 
 	uuid = seed(t)
 	assert.Equal(t, http.StatusOK, post(t, body(uuid, 9, "DECLINED")))
@@ -92,10 +115,13 @@ func TestDTOneStatusCallback(t *testing.T) {
 	assert.Equal(t, http.StatusOK, post(t, body(uuid, 4, "CANCELLED")))
 	assert.Equal(t, models.AirtimeTransferStatusCancelled, rowStatus(t, uuid))
 
-	// CREATED status class (1) on a callback is ignored — that's just the initial state we set the row to
+	// CREATED status class (1) on a callback is ignored — that's just the initial state we set the row
+	// to — and an ignored callback writes nothing to history
+	testsuite.GetHistoryItems(t, rt, true, time.Time{}) // clear prior writes
 	uuid = seed(t)
 	assert.Equal(t, http.StatusOK, post(t, body(uuid, 1, "CREATED")))
 	assert.Equal(t, models.AirtimeTransferStatusCreated, rowStatus(t, uuid))
+	assert.Empty(t, testsuite.GetHistoryItems(t, rt, true, time.Time{}), "ignored CREATED-class callback should not write history")
 
 	// a Reversed callback that arrives without a preceding Completed still applies — better to record
 	// the eventual reversal than silently drop it because the lifecycle skipped a stage
@@ -103,8 +129,11 @@ func TestDTOneStatusCallback(t *testing.T) {
 	assert.Equal(t, models.AirtimeTransferStatusReversed, rowStatus(t, uuid))
 
 	// unknown UUID → 200 ignored (the CAS finds no row to update; the distinction isn't actionable
-	// for DT One and the matching response shape doubles as an anti-enumeration shield)
+	// for DT One and the matching response shape doubles as an anti-enumeration shield), and writes
+	// nothing to history
+	testsuite.GetHistoryItems(t, rt, true, time.Time{}) // clear prior writes
 	assert.Equal(t, http.StatusOK, post(t, body(flows.NewEventUUID(), 7, "COMPLETED")))
+	assert.Empty(t, testsuite.GetHistoryItems(t, rt, true, time.Time{}), "ignored unknown-UUID callback should not write history")
 
 	// a forged callback with a real UUID but wrong DT One tx id is a no-op (defense in depth — the
 	// matching CAS requires both halves)


### PR DESCRIPTION
## What

Records each airtime transfer status change as an `sts` event tag in the contact's DynamoDB history, keyed by the same UUID as the transfer's `airtime_created` event — the same `evt#<uuid>#sts` shape courier writes for message status changes.

## Why

We already update the transfer row in the database when a provider status callback arrives. Writing a parallel status tag to the history table lets clients inject the transfer's current `_status` into the `airtime_created` event when rendering it, mirroring how `msg_created` status is surfaced (see nyaruka/temba-components#1020). The tag's `status` is the lowercase name clients expect: `created`, `confirmed`, `submitted`, `completed`, `reversed`, `rejected`, `cancelled`, `declined`.

## How

- **`UpdateAirtimeTransferStatus`** now returns a `*EventTag` recording the change (or `nil` if no row matched), replacing the old `bool`. It uses `UPDATE airtime_airtimetransfer ... FROM contacts_contact ... RETURNING org_id, contact_uuid` so it gets the org and contact UUID needed for the history partition key in the same statement. The `(uuid, external_id)` compare-and-swap semantics and the deliberate absence of a status-transition guard are unchanged.
- **`NewAirtimeStatusTag`** is a new constructor parallel to `NewMsgDeletionTag`, producing an `EventTag` with tag `sts` and data `{created_on, status}`.
- The **DT One status callback handler** queues the returned tag to the history writer on a successful update; ignored/no-op callbacks write nothing, as before.

Because all status changes for a transfer share the `evt#<uuid>#sts` sort key, the latest callback overwrites — the history holds a single tag at the transfer's current status.

## Notes for reviewers

- Mailroom has no `_status` read-path itself; its only event fetch (`SearchMessages`) reads `evt#<uuid>` and ignores `#sts` siblings. The injection happens consumer-side, so this change is purely about *producing* the tag in the right shape.

## Testing

- Extended `TestAirtimeTransfers` (tag returned on update, nil on no-op, correct fields), `TestEventTags` (`NewAirtimeStatusTag`), the `eventtag_to_dynamo.json` snapshot (an `sts` case), and `TestDTOneStatusCallback` (asserts history keys/status name, overwrite-on-resend, and that ignored callbacks write nothing).
- `go build ./...`, `go vet`, and `go test ./core/models/... ./web/public/...` all pass.