### PR TITLE
Add OrgID to LLM model

### DIFF
--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -54,6 +54,7 @@ func llmServiceFactory(rt *runtime.Runtime) engine.LLMServiceFactory {
 type LLM struct {
 	ID_              LLMID            `json:"id"`
 	UUID_            assets.LLMUUID   `json:"uuid"`
+	OrgID_           OrgID            `json:"org_id"`
 	Type_            string           `json:"llm_type"`
 	Model_           string           `json:"model"`
 	Name_            string           `json:"name"`
@@ -63,6 +64,7 @@ type LLM struct {
 }
 
 func (l *LLM) ID() LLMID               { return l.ID_ }
+func (l *LLM) OrgID() OrgID            { return l.OrgID_ }
 func (l *LLM) UUID() assets.LLMUUID    { return l.UUID_ }
 func (l *LLM) Name() string            { return l.Name_ }
 func (l *LLM) Type() string            { return l.Type_ }
@@ -123,7 +125,7 @@ func loadLLMs(ctx context.Context, db *sql.DB, orgID OrgID) ([]assets.LLM, error
 
 const sqlSelectLLMs = `
 SELECT ROW_TO_JSON(r) FROM (
-      SELECT l.id, l.uuid, l.name, l.llm_type, l.model, l.config, l.max_output_tokens,
+      SELECT l.id, l.uuid, l.org_id, l.llm_type, l.model, l.name, l.config, l.max_output_tokens,
              (SELECT ARRAY(SELECT CASE r WHEN 'T' THEN 'editing' WHEN 'F' THEN 'engine' END FROM unnest(regexp_split_to_array(l.roles,'')) AS r)) AS roles
         FROM ai_llm l
        WHERE l.org_id = $1 AND l.is_active

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -45,6 +45,7 @@ func TestLLMs(t *testing.T) {
 		assert.Equal(t, tc.name, c.Name())
 		assert.Equal(t, tc.typ, c.Type())
 		assert.Equal(t, tc.roles, c.Roles())
+		assert.Equal(t, testdb.Org1.ID, c.OrgID())
 	}
 
 	assert.Equal(t, "Claude", oa.LLMByID(testdb.Anthropic.ID).Name())


### PR DESCRIPTION
The `LLM` model now exposes the org it belongs to via a new `OrgID()` accessor.

## Why
LLM service implementations are constructed from a `*models.LLM` (see `AsService` / `RegisterLLMService`), but the model previously carried no org. Service implementations need the org to attribute/log calls (e.g. writing per-call logs keyed by org). The asset is already loaded per-org, so the org id was simply being discarded.

## What changed
- Added an `OrgID_ OrgID` field with a `json:"org_id"` tag and an `OrgID()` accessor.
- Selected `org_id` in the per-org load query so it's populated during the normal JSON scan — no special-casing.

This mirrors how the `Channel` model already exposes its org (`OrgID_ \`json:"org_id\"\`` populated from the load query), keeping the two assets consistent.

## Notes
- Purely additive; verified no asset/web snapshot tests changed (the LLM asset is never re-serialized into engine/session assets or API responses, so `org_id` does not leak — same as channels).
- `TestLLMs` asserts loaded LLMs report the expected `OrgID()`.
- Full test suite passes and `go vet ./core/models/...` is clean.