### PR TITLE
Add msg/typing endpoint to send typing indicators via courier

### DIFF
--- a/core/models/channel.go
+++ b/core/models/channel.go
@@ -26,6 +26,11 @@ const (
 	ChannelTypeAndroid = ChannelType("A")
 )
 
+// channel feature constants in addition to those defined by goflow
+const (
+	ChannelFeatureTyping = assets.ChannelFeature("typing")
+)
+
 // config key constants
 const (
 	ChannelConfigCallbackDomain     = "callback_domain"
@@ -172,7 +177,9 @@ SELECT ROW_TO_JSON(r) FROM (SELECT
       c.schemes,
       c.config,
       (SELECT ARRAY(SELECT CASE r WHEN 'R' THEN 'receive' WHEN 'S' THEN 'send' WHEN 'C' THEN 'call' WHEN 'A' THEN 'answer' END FROM unnest(regexp_split_to_array(c.role,'')) AS r)) AS roles,
-      CASE WHEN channel_type IN ('FBA') THEN '{"optins"}'::text[] ELSE '{}'::text[] END AS features,
+      CASE WHEN channel_type IN ('FBA') THEN '{"optins"}'::text[]
+           WHEN channel_type IN ('TG') OR (channel_type = 'EX' AND c.config ? 'send_typing_url') THEN '{"typing"}'::text[]
+           ELSE '{}'::text[] END AS features,
       jsonb_extract_path(c.config, 'matching_prefixes') AS match_prefixes,
       jsonb_extract_path(c.config, 'allow_international') AS allow_international,
       jsonb_extract_path(c.config, 'machine_detection') AS machine_detection

--- a/core/models/channel_test.go
+++ b/core/models/channel_test.go
@@ -97,6 +97,29 @@ func TestChannels(t *testing.T) {
 	}
 }
 
+func TestChannelFeatures(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	tg := testdb.InsertChannel(t, rt, testdb.Org1, "TG", "Telegram", "mybot", []string{"telegram"}, "SR", map[string]any{})
+	exPlain := testdb.InsertChannel(t, rt, testdb.Org1, "EX", "External", "1234", []string{"tel"}, "SR", map[string]any{})
+	exTyping := testdb.InsertChannel(t, rt, testdb.Org1, "EX", "External With Typing", "2345", []string{"tel"}, "SR", map[string]any{"send_typing_url": "http://console.local/typing"})
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, 1, models.RefreshChannels)
+	require.NoError(t, err)
+
+	assertFeatures := func(ch *testdb.Channel, expected []assets.ChannelFeature) {
+		channel := oa.ChannelByUUID(ch.UUID)
+		require.NotNil(t, channel)
+		assert.Equal(t, expected, channel.Features())
+	}
+
+	assertFeatures(tg, []assets.ChannelFeature{models.ChannelFeatureTyping})
+	assertFeatures(exPlain, []assets.ChannelFeature{})
+	assertFeatures(exTyping, []assets.ChannelFeature{models.ChannelFeatureTyping})
+}
+
 func TestGetChannelByID(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -319,6 +319,43 @@ func ClearCourierQueues(vc valkey.Conn, ch *models.Channel) error {
 	return err
 }
 
+// see https://github.com/nyaruka/courier/blob/main/events.go
+type sendEventRequest struct {
+	Type        string             `json:"type"`
+	ChannelType models.ChannelType `json:"channel_type"`
+	ChannelUUID assets.ChannelUUID `json:"channel_uuid"`
+	URN         urns.URN           `json:"urn"`
+}
+
+// SendTyping calls courier to send a typing indicator to the given URN. These are transient events - there's
+// no queueing and failures are returned to the caller rather than retried.
+func SendTyping(ctx context.Context, rt *runtime.Runtime, ch *models.Channel, urn urns.URN) error {
+	payload := jsonx.MustMarshal(&sendEventRequest{
+		Type:        "typing",
+		ChannelType: ch.Type(),
+		ChannelUUID: ch.UUID(),
+		URN:         urn,
+	})
+	req, _ := http.NewRequest("POST", strings.TrimRight(rt.Config.CourierEndpoint, "/")+"/ci/event/send", bytes.NewReader(payload))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.Config.CourierAuthToken))
+
+	// like attachment fetching, this is an internal request to courier whose trace we don't persist
+	resp, err := rt.HTTP.Services.Do(req)
+	if err != nil {
+		return fmt.Errorf("error calling courier endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading courier response: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("error calling courier endpoint, got non-200 status: %s", string(body))
+	}
+	return nil
+}
+
 // see https://github.com/nyaruka/courier/blob/main/attachments.go#L23
 type fetchAttachmentRequest struct {
 	ChannelType models.ChannelType `json:"channel_type"`

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/testsuite"
@@ -25,6 +26,28 @@ func TestSend(t *testing.T) {
 	testsuite.RunWebTests(t, rt, "testdata/send.json")
 
 	testsuite.AssertCourierQueues(t, rt, map[string][]int{"msgs:74729f45-7f29-4868-9dc4-90e491e3c7d8|10/1": {1, 1, 1, 1, 1}})
+}
+
+func TestTyping(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+
+	// give Bob a telegram URN and channel so that his preferred channel supports typing indicators
+	testdb.InsertChannel(t, rt, testdb.Org1, "TG", "Telegram", "mybot", []string{"telegram"}, "SR", map[string]any{})
+	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Bob, "telegram:123456789", 2000, nil)
+
+	mocks := httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"http://localhost:8080/ci/event/send": {
+			httpx.NewMockResponse(200, nil, []byte(`{"log_uuid": "deddd249-2eab-4d4d-a1a0-1e7adda5ed4f"}`)),
+		},
+	})
+	rt.HTTP.Services.Transport = mocks
+
+	testsuite.RunWebTests(t, rt, "testdata/typing.json")
+
+	// the telegram case should have resulted in exactly one event send call to courier
+	assert.False(t, mocks.HasUnused(), "expected typing event to be sent to courier")
 }
 
 func TestDelete(t *testing.T) {

--- a/web/msg/testdata/typing.json
+++ b/web/msg/testdata/typing.json
@@ -1,0 +1,46 @@
+[
+    {
+        "label": "illegal method",
+        "method": "GET",
+        "path": "/mi/msg/typing",
+        "status": 405,
+        "response": {
+            "error": "illegal method: GET"
+        }
+    },
+    {
+        "label": "invalid org_id",
+        "method": "POST",
+        "path": "/mi/msg/typing",
+        "body": {
+            "org_id": 1234,
+            "contact_id": 10000
+        },
+        "status": 500,
+        "response": {
+            "error": "error loading org assets: error loading environment for org 1234: no org with id: 1234"
+        }
+    },
+    {
+        "label": "noop for contact whose preferred channel doesn't support typing indicators",
+        "method": "POST",
+        "path": "/mi/msg/typing",
+        "body": {
+            "org_id": 1,
+            "contact_id": 10000
+        },
+        "status": 200,
+        "response": {}
+    },
+    {
+        "label": "typing indicator sent to courier for contact whose preferred channel is telegram",
+        "method": "POST",
+        "path": "/mi/msg/typing",
+        "body": {
+            "org_id": 1,
+            "contact_id": 10001
+        },
+        "status": 200,
+        "response": {}
+    }
+]

--- a/web/msg/typing.go
+++ b/web/msg/typing.go
@@ -1,0 +1,60 @@
+package msg
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/core/msgio"
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/nyaruka/mailroom/v26/web"
+)
+
+func init() {
+	web.InternalRoute(http.MethodPost, "/msg/typing", web.JSONPayload(handleTyping))
+}
+
+// Request to send a typing indicator to a contact. This is a no-op if the contact's preferred channel doesn't
+// support typing indicators.
+//
+//	{
+//	  "org_id": 1,
+//	  "contact_id": 123456
+//	}
+type typingRequest struct {
+	OrgID     models.OrgID     `json:"org_id"     validate:"required"`
+	ContactID models.ContactID `json:"contact_id" validate:"required"`
+}
+
+// handles a request to send a typing indicator to a contact
+func handleTyping(ctx context.Context, rt *runtime.Runtime, r *typingRequest) (any, int, error) {
+	oa, err := models.GetOrgAssets(ctx, rt, r.OrgID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error loading org assets: %w", err)
+	}
+
+	c, err := models.LoadContact(ctx, rt.DB, oa, r.ContactID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error loading contact: %w", err)
+	}
+
+	contact, err := c.EngineContact(oa)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error creating flow contact: %w", err)
+	}
+
+	// resolve the same URN + channel that a send would use, and check that it supports typing indicators
+	for _, route := range contact.ResolveRoutes(false) {
+		ch := oa.ChannelByUUID(route.Channel.UUID())
+		if ch != nil && slices.Contains(ch.Features(), models.ChannelFeatureTyping) {
+			if err := msgio.SendTyping(ctx, rt, ch, route.URN); err != nil {
+				return nil, 0, fmt.Errorf("error sending typing indicator: %w", err)
+			}
+		}
+		break
+	}
+
+	return map[string]any{}, http.StatusOK, nil
+}


### PR DESCRIPTION
Adds an internal `POST /mi/msg/typing` endpoint which resolves the contact's preferred URN + channel (same routing a send would use) and, if that channel supports typing indicators, calls courier's new `/ci/event/send` endpoint. Fire and forget - nothing is queued or persisted.

Channel support is expressed as a new `typing` channel feature, derived in the channel SQL: Telegram channels, and External channels configured with a `send_typing_url` (the msg console's test channel).

Depends on nyaruka/courier#1035.
