### PR TITLE
Add models API for checking realtime subscription presence

### DIFF
--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/mailroom/v26/runtime"
+)
+
+// SocketChatNamespace is the realtime subscription channel namespace for a contact's chat history, addressed
+// as "chat:<contact-uuid>". It's currently the only client-subscribable namespace. ("Channel" here is a
+// realtime pub/sub channel - unrelated to a messaging Channel.)
+const SocketChatNamespace = "chat"
+
+// ChatChannel returns the realtime subscription channel for a contact's chat history.
+func ChatChannel(contactUUID flows.ContactUUID) string {
+	return fmt.Sprintf("%s:%s", SocketChatNamespace, contactUUID)
+}
+
+// subscriptionKey is the valkey key marking that a realtime channel has at least one active subscriber, e.g.
+// "socket-subs:chat:<contact-uuid>".
+func subscriptionKey(channel string) string {
+	return fmt.Sprintf("socket-subs:%s", channel)
+}
+
+// RecordSubscription marks a realtime channel as having at least one active subscriber by (re)setting a
+// single per-channel presence key in valkey with the given TTL. The websocket layer calls this on every
+// subscribe and refresh, so the key stays present while some subscriber keeps refreshing it and expires once
+// the last one stops (the realtime server has no unsubscribe/disconnect callback, so the TTL is the only GC).
+// We only track presence - whether a channel has any subscribers, not who or how many - so one key per
+// channel is all we keep.
+func RecordSubscription(ctx context.Context, rt *runtime.Runtime, channel string, ttl time.Duration) error {
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	if _, err := valkey.DoContext(vc, ctx, "SET", subscriptionKey(channel), "1", "EX", int(ttl/time.Second)); err != nil {
+		return fmt.Errorf("error recording subscription for %s: %w", channel, err)
+	}
+	return nil
+}
+
+// IsSubscribed reports whether a realtime channel currently has at least one active subscriber.
+func IsSubscribed(ctx context.Context, rt *runtime.Runtime, channel string) (bool, error) {
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	subscribed, err := valkey.Bool(valkey.DoContext(vc, ctx, "EXISTS", subscriptionKey(channel)))
+	if err != nil {
+		return false, fmt.Errorf("error checking subscription for %s: %w", channel, err)
+	}
+	return subscribed, nil
+}
+
+// IsChatSubscribed reports whether a contact's chat history currently has any subscribers. Backend code that
+// persists chat-visible activity (e.g. channel events) can use this to cheaply decide whether anyone is
+// watching a given contact's chat.
+func IsChatSubscribed(ctx context.Context, rt *runtime.Runtime, contactUUID flows.ContactUUID) (bool, error) {
+	return IsSubscribed(ctx, rt, ChatChannel(contactUUID))
+}

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -53,10 +53,3 @@ func IsSubscribed(ctx context.Context, rt *runtime.Runtime, channel string) (boo
 	}
 	return subscribed, nil
 }
-
-// IsChatSubscribed reports whether a contact's chat history currently has any subscribers. Backend code that
-// persists chat-visible activity (e.g. channel events) can use this to cheaply decide whether anyone is
-// watching a given contact's chat.
-func IsChatSubscribed(ctx context.Context, rt *runtime.Runtime, contactUUID flows.ContactUUID) (bool, error) {
-	return IsSubscribed(ctx, rt, ChatChannel(contactUUID))
-}

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -37,21 +37,13 @@ func TestSubscriptions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual, "subscribed mismatch for %s", channel)
 	}
-	assertChatSubscribed := func(contactUUID flows.ContactUUID, expected bool) {
-		t.Helper()
-		actual, err := models.IsChatSubscribed(ctx, rt, contactUUID)
-		require.NoError(t, err)
-		assert.Equal(t, expected, actual, "chat subscribed mismatch for %s", contactUUID)
-	}
 
 	// nothing subscribed yet
 	assertSubscribed(chat1, false)
-	assertChatSubscribed(contact1, false)
 
 	// recording a subscription marks the channel present with a TTL
 	require.NoError(t, models.RecordSubscription(ctx, rt, chat1, ttl))
 	assertSubscribed(chat1, true)
-	assertChatSubscribed(contact1, true)
 
 	secs, err := valkey.Int64(vc.Do("TTL", "socket-subs:"+chat1))
 	require.NoError(t, err)
@@ -63,8 +55,8 @@ func TestSubscriptions(t *testing.T) {
 	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + chat1})
 
 	// a different channel is a separate key, checked independently
-	assertChatSubscribed(contact2, false)
+	assertSubscribed(chat2, false)
 	require.NoError(t, models.RecordSubscription(ctx, rt, chat2, ttl))
-	assertChatSubscribed(contact2, true)
+	assertSubscribed(chat2, true)
 	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + chat1, "socket-subs:" + chat2})
 }

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -1,0 +1,70 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/vkutil/assertvk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatChannel(t *testing.T) {
+	assert.Equal(t, "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.ChatChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf"))
+}
+
+func TestSubscriptions(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	const ttl = 150 * time.Second
+	contact1 := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
+	contact2 := flows.ContactUUID("b699a406-7e44-49be-9f01-1a82893e8a10")
+	chat1 := models.ChatChannel(contact1)
+	chat2 := models.ChatChannel(contact2)
+
+	assertSubscribed := func(channel string, expected bool) {
+		t.Helper()
+		actual, err := models.IsSubscribed(ctx, rt, channel)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual, "subscribed mismatch for %s", channel)
+	}
+	assertChatSubscribed := func(contactUUID flows.ContactUUID, expected bool) {
+		t.Helper()
+		actual, err := models.IsChatSubscribed(ctx, rt, contactUUID)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual, "chat subscribed mismatch for %s", contactUUID)
+	}
+
+	// nothing subscribed yet
+	assertSubscribed(chat1, false)
+	assertChatSubscribed(contact1, false)
+
+	// recording a subscription marks the channel present with a TTL
+	require.NoError(t, models.RecordSubscription(ctx, rt, chat1, ttl))
+	assertSubscribed(chat1, true)
+	assertChatSubscribed(contact1, true)
+
+	secs, err := valkey.Int64(vc.Do("TTL", "socket-subs:"+chat1))
+	require.NoError(t, err)
+	assert.Greater(t, secs, int64(0))
+	assert.LessOrEqual(t, secs, int64(ttl/time.Second))
+
+	// a second subscriber to the same channel keeps it a single key (we track presence, not who)
+	require.NoError(t, models.RecordSubscription(ctx, rt, chat1, ttl))
+	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + chat1})
+
+	// a different channel is a separate key, checked independently
+	assertChatSubscribed(contact2, false)
+	require.NoError(t, models.RecordSubscription(ctx, rt, chat2, ttl))
+	assertChatSubscribed(contact2, true)
+	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + chat1, "socket-subs:" + chat2})
+}

--- a/web/sockets/base.go
+++ b/web/sockets/base.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -14,11 +13,6 @@ import (
 )
 
 const (
-	// chatNamespace is the only client-subscribable channel namespace: a contact's chat history,
-	// addressed as "chat:<contact-uuid>". A contact UUID uniquely implies its org, so the org isn't
-	// in the channel name - it comes from the connection meta.
-	chatNamespace = "chat"
-
 	// subscribeWindow is how far ahead we set a subscription's expire_at, scheduling the realtime
 	// server to call sub_refresh before it lapses so we can re-authorize.
 	subscribeWindow = 60 * time.Second
@@ -119,7 +113,7 @@ func authorize(ctx context.Context, rt *runtime.Runtime, meta connectionMeta, ch
 
 	// default deny: only "chat:<contact-uuid>" is subscribable, and only with a well-formed uuid
 	namespace, rest, ok := strings.Cut(channel, ":")
-	if !ok || namespace != chatNamespace || !uuids.Is(rest) {
+	if !ok || namespace != models.SocketChatNamespace || !uuids.Is(rest) {
 		return authDenied, nil
 	}
 	contactUUID := flows.ContactUUID(rest)
@@ -144,28 +138,4 @@ func authorize(ctx context.Context, rt *runtime.Runtime, meta connectionMeta, ch
 	}
 
 	return authAllowed, nil
-}
-
-// subKey is the valkey key marking that a channel has at least one active subscription, e.g.
-// "socket-subs:chat:<contact-uuid>".
-func subKey(channel string) string {
-	return fmt.Sprintf("socket-subs:%s", channel)
-}
-
-// indexSubscription marks a channel as having at least one active subscription, with a TTL. Every subscribe
-// and sub_refresh from any connection re-sets the same per-channel key, so the key stays present as long as
-// some subscriber keeps refreshing it; once the last one goes away (the realtime server has no unsubscribe
-// or disconnect callback) nobody refreshes it and it expires. The backend only needs to know whether a
-// contact's chat might have subscribers - not who or how many - so a single presence key per channel is all
-// we keep.
-func indexSubscription(ctx context.Context, rt *runtime.Runtime, channel string) error {
-	vc := rt.VK.Get()
-	defer vc.Close()
-
-	ttl := int(subscribeTTL / time.Second)
-	if _, err := valkey.DoContext(vc, ctx, "SET", subKey(channel), "1", "EX", ttl); err != nil {
-		return fmt.Errorf("error updating subscription index for %s: %w", channel, err)
-	}
-
-	return nil
 }

--- a/web/sockets/base_test.go
+++ b/web/sockets/base_test.go
@@ -2,15 +2,11 @@ package sockets
 
 import (
 	"testing"
-	"time"
 
-	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/nyaruka/vkutil/assertvk"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSubscribe(t *testing.T) {
@@ -34,8 +30,8 @@ func TestSubscribe(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	annKey := subKey("chat:a393abc0-283d-4c9b-a1b3-641a035c34bf")
-	blockedKey := subKey("chat:22222222-2222-4222-8222-222222222222")
+	annKey := "socket-subs:chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
+	blockedKey := "socket-subs:chat:22222222-2222-4222-8222-222222222222"
 
 	// the allowed subscribes marked their contact's chat channel as having a subscriber...
 	assertvk.Exists(t, vc, annKey)
@@ -57,36 +53,7 @@ func TestSubRefresh(t *testing.T) {
 	defer vc.Close()
 
 	// the successful refresh kept the channel marked; nothing else was written
-	key := subKey("chat:a393abc0-283d-4c9b-a1b3-641a035c34bf")
+	key := "socket-subs:chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
 	assertvk.Exists(t, vc, key)
 	assertvk.Keys(t, vc, "socket-subs:*", []string{key})
-}
-
-func TestSubscriptionIndex(t *testing.T) {
-	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
-
-	vc := rt.VK.Get()
-	defer vc.Close()
-
-	chat1 := "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
-	chat2 := "chat:b699a406-7e44-49be-9f01-1a82893e8a10"
-
-	// a subscription marks its channel present with a TTL
-	require.NoError(t, indexSubscription(ctx, rt, chat1))
-	assertvk.Exists(t, vc, subKey(chat1))
-
-	ttl, err := valkey.Int64(vc.Do("TTL", subKey(chat1)))
-	require.NoError(t, err)
-	assert.Greater(t, ttl, int64(0))
-	assert.LessOrEqual(t, ttl, int64(subscribeTTL/time.Second))
-
-	// a second subscriber to the same channel keeps it a single key (we track presence, not who)
-	require.NoError(t, indexSubscription(ctx, rt, chat1))
-	assertvk.Keys(t, vc, "socket-subs:*", []string{subKey(chat1)})
-
-	// a different channel is a separate key
-	require.NoError(t, indexSubscription(ctx, rt, chat2))
-	assertvk.Keys(t, vc, "socket-subs:*", []string{subKey(chat1), subKey(chat2)})
 }

--- a/web/sockets/sub_refresh.go
+++ b/web/sockets/sub_refresh.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/web"
 )
@@ -28,7 +29,7 @@ func handleSubRefresh(ctx context.Context, rt *runtime.Runtime, r *proxyRequest)
 		return expired(), http.StatusOK, nil
 	}
 
-	if err := indexSubscription(ctx, rt, r.Channel); err != nil {
+	if err := models.RecordSubscription(ctx, rt, r.Channel, subscribeTTL); err != nil {
 		return nil, 0, err
 	}
 	return allowed(now), http.StatusOK, nil

--- a/web/sockets/subscribe.go
+++ b/web/sockets/subscribe.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/web"
 )
@@ -26,7 +27,7 @@ func handleSubscribe(ctx context.Context, rt *runtime.Runtime, r *proxyRequest) 
 
 	switch auth {
 	case authAllowed:
-		if err := indexSubscription(ctx, rt, r.Channel); err != nil {
+		if err := models.RecordSubscription(ctx, rt, r.Channel, subscribeTTL); err != nil {
 			return nil, 0, err
 		}
 		return allowed(now), http.StatusOK, nil


### PR DESCRIPTION
## What

Adds a small presence API in `core/models` (`socket.go`) over the valkey subscription markers that the websocket layer already writes, so backend code can cheaply check whether a realtime channel currently has subscribers.

- `ChatChannel(contactUUID)` — builds the `chat:<contact-uuid>` channel name (single source of truth for the naming scheme)
- `RecordSubscription(ctx, rt, channel, ttl)` — (re)sets the per-channel presence key
- `IsSubscribed(ctx, rt, channel)` — presence read (`EXISTS`)

## Why

The marker-writing logic previously lived only in `web/sockets` and nothing read it. This pulls the key format and read/write mechanics into `core/models` so other code can ask, for example when persisting channel events, whether a contact's chat is being watched:

```go
watching, err := models.IsSubscribed(ctx, rt, models.ChatChannel(contact.UUID()))
```

## Refactor of web/sockets

- Removed the local `subKey`/`indexSubscription`; `subscribe.go` and `sub_refresh.go` now call `models.RecordSubscription`
- `authorize` references `models.SocketChatNamespace` instead of a local const
- The TTL/window timing policy stays in `web/sockets` (it's tied to the realtime server's refresh behavior) and is passed into `RecordSubscription` as an argument

## Notes for reviewers

- "channel" here is a realtime pub/sub channel (a plain string), not a messaging `models.Channel` — the doc comments call this out to avoid confusion.
- The new API is not yet wired into the channel-event persistence path; this PR adds the capability only.
- New tests: `TestChatChannel`, `TestSubscriptions` in `core/models`; the old `TestSubscriptionIndex` was removed from `web/sockets` as its logic moved. `./core/models/` and `./web/sockets/` tests pass.