### PR TITLE
Rename client-subscribable channel namespace from "chat" to "history"

### DIFF
--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -10,18 +10,18 @@ import (
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
-// SocketChatNamespace is the realtime subscription channel namespace for a contact's chat history, addressed
-// as "chat:<contact-uuid>". It's currently the only client-subscribable namespace. ("Channel" here is a
-// realtime pub/sub channel - unrelated to a messaging Channel.)
-const SocketChatNamespace = "chat"
+// SocketHistoryNamespace is the realtime subscription channel namespace for a contact's message history,
+// addressed as "history:<contact-uuid>". It's currently the only client-subscribable namespace. ("Channel"
+// here is a realtime pub/sub channel - unrelated to a messaging Channel.)
+const SocketHistoryNamespace = "history"
 
-// ChatChannel returns the realtime subscription channel for a contact's chat history.
-func ChatChannel(contactUUID flows.ContactUUID) string {
-	return fmt.Sprintf("%s:%s", SocketChatNamespace, contactUUID)
+// HistoryChannel returns the realtime subscription channel for a contact's message history.
+func HistoryChannel(contactUUID flows.ContactUUID) string {
+	return fmt.Sprintf("%s:%s", SocketHistoryNamespace, contactUUID)
 }
 
 // subscriptionKey is the valkey key marking that a realtime channel has at least one active subscriber, e.g.
-// "socket-subs:chat:<contact-uuid>".
+// "socket-subs:history:<contact-uuid>".
 func subscriptionKey(channel string) string {
 	return fmt.Sprintf("socket-subs:%s", channel)
 }

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChatChannel(t *testing.T) {
-	assert.Equal(t, "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.ChatChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf"))
+func TestHistoryChannel(t *testing.T) {
+	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.HistoryChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf"))
 }
 
 func TestSubscriptions(t *testing.T) {
@@ -28,8 +28,8 @@ func TestSubscriptions(t *testing.T) {
 	const ttl = 150 * time.Second
 	contact1 := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
 	contact2 := flows.ContactUUID("b699a406-7e44-49be-9f01-1a82893e8a10")
-	chat1 := models.ChatChannel(contact1)
-	chat2 := models.ChatChannel(contact2)
+	hist1 := models.HistoryChannel(contact1)
+	hist2 := models.HistoryChannel(contact2)
 
 	assertSubscribed := func(channel string, expected bool) {
 		t.Helper()
@@ -39,24 +39,24 @@ func TestSubscriptions(t *testing.T) {
 	}
 
 	// nothing subscribed yet
-	assertSubscribed(chat1, false)
+	assertSubscribed(hist1, false)
 
 	// recording a subscription marks the channel present with a TTL
-	require.NoError(t, models.RecordSubscription(ctx, rt, chat1, ttl))
-	assertSubscribed(chat1, true)
+	require.NoError(t, models.RecordSubscription(ctx, rt, hist1, ttl))
+	assertSubscribed(hist1, true)
 
-	secs, err := valkey.Int64(vc.Do("TTL", "socket-subs:"+chat1))
+	secs, err := valkey.Int64(vc.Do("TTL", "socket-subs:"+hist1))
 	require.NoError(t, err)
 	assert.Greater(t, secs, int64(0))
 	assert.LessOrEqual(t, secs, int64(ttl/time.Second))
 
 	// a second subscriber to the same channel keeps it a single key (we track presence, not who)
-	require.NoError(t, models.RecordSubscription(ctx, rt, chat1, ttl))
-	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + chat1})
+	require.NoError(t, models.RecordSubscription(ctx, rt, hist1, ttl))
+	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + hist1})
 
 	// a different channel is a separate key, checked independently
-	assertSubscribed(chat2, false)
-	require.NoError(t, models.RecordSubscription(ctx, rt, chat2, ttl))
-	assertSubscribed(chat2, true)
-	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + chat1, "socket-subs:" + chat2})
+	assertSubscribed(hist2, false)
+	require.NoError(t, models.RecordSubscription(ctx, rt, hist2, ttl))
+	assertSubscribed(hist2, true)
+	assertvk.Keys(t, vc, "socket-subs:*", []string{"socket-subs:" + hist1, "socket-subs:" + hist2})
 }

--- a/web/sockets/base.go
+++ b/web/sockets/base.go
@@ -102,18 +102,18 @@ const (
 )
 
 // authorize implements the default-deny allowlist for client subscriptions. The only permitted channel is a
-// contact's chat history, allowed when the contact belongs to the org identified by the connection meta and
-// isn't released (soft-deleted). Blocked/stopped/archived contacts still have viewable history, so they're
-// allowed too. The org comes from the meta, never from the channel.
+// contact's message history, allowed when the contact belongs to the org identified by the connection meta
+// and isn't released (soft-deleted). Blocked/stopped/archived contacts still have viewable history, so
+// they're allowed too. The org comes from the meta, never from the channel.
 func authorize(ctx context.Context, rt *runtime.Runtime, meta connectionMeta, channel string) (authResult, error) {
 	// a connection with no org/user in its meta was never authenticated by the connect proxy
 	if meta.OrgUUID == "" || meta.UserUUID == "" {
 		return authNoIdentity, nil
 	}
 
-	// default deny: only "chat:<contact-uuid>" is subscribable, and only with a well-formed uuid
+	// default deny: only "history:<contact-uuid>" is subscribable, and only with a well-formed uuid
 	namespace, rest, ok := strings.Cut(channel, ":")
-	if !ok || namespace != models.SocketChatNamespace || !uuids.Is(rest) {
+	if !ok || namespace != models.SocketHistoryNamespace || !uuids.Is(rest) {
 		return authDenied, nil
 	}
 	contactUUID := flows.ContactUUID(rest)

--- a/web/sockets/base_test.go
+++ b/web/sockets/base_test.go
@@ -20,7 +20,7 @@ func TestSubscribe(t *testing.T) {
 	)
 	rt.DB.MustExec(`UPDATE contacts_contact SET is_active = FALSE WHERE id = $1`, released.ID)
 
-	// a blocked contact is still authorized - blocked/stopped/archived contacts keep viewable chat history
+	// a blocked contact is still authorized - blocked/stopped/archived contacts keep viewable message history
 	testdb.InsertContact(
 		t, rt, testdb.Org1, "22222222-2222-4222-8222-222222222222", "Blocked", "eng", models.ContactStatusBlocked,
 	)
@@ -30,10 +30,10 @@ func TestSubscribe(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	annKey := "socket-subs:chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
-	blockedKey := "socket-subs:chat:22222222-2222-4222-8222-222222222222"
+	annKey := "socket-subs:history:a393abc0-283d-4c9b-a1b3-641a035c34bf"
+	blockedKey := "socket-subs:history:22222222-2222-4222-8222-222222222222"
 
-	// the allowed subscribes marked their contact's chat channel as having a subscriber...
+	// the allowed subscribes marked their contact's history channel as having a subscriber...
 	assertvk.Exists(t, vc, annKey)
 	assertvk.Exists(t, vc, blockedKey)
 
@@ -53,7 +53,7 @@ func TestSubRefresh(t *testing.T) {
 	defer vc.Close()
 
 	// the successful refresh kept the channel marked; nothing else was written
-	key := "socket-subs:chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
+	key := "socket-subs:history:a393abc0-283d-4c9b-a1b3-641a035c34bf"
 	assertvk.Exists(t, vc, key)
 	assertvk.Keys(t, vc, "socket-subs:*", []string{key})
 }

--- a/web/sockets/testdata/sub_refresh.json
+++ b/web/sockets/testdata/sub_refresh.json
@@ -6,7 +6,7 @@
         "body": {
             "client": "conn-allowed",
             "user": "56",
-            "channel": "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf",
+            "channel": "history:a393abc0-283d-4c9b-a1b3-641a035c34bf",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -26,7 +26,7 @@
         "body": {
             "client": "conn-otherorg",
             "user": "56",
-            "channel": "chat:f6d20b72-f7d8-44dc-87f2-aae046dbff95",
+            "channel": "history:f6d20b72-f7d8-44dc-87f2-aae046dbff95",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -66,7 +66,7 @@
         "body": {
             "client": "conn-noidentity",
             "user": "56",
-            "channel": "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
+            "channel": "history:a393abc0-283d-4c9b-a1b3-641a035c34bf"
         },
         "status": 200,
         "response": {

--- a/web/sockets/testdata/subscribe.json
+++ b/web/sockets/testdata/subscribe.json
@@ -6,7 +6,7 @@
         "body": {
             "client": "conn-allowed",
             "user": "56",
-            "channel": "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf",
+            "channel": "history:a393abc0-283d-4c9b-a1b3-641a035c34bf",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -20,13 +20,13 @@
         }
     },
     {
-        "label": "allowed: blocked contact still has viewable chat history",
+        "label": "allowed: blocked contact still has viewable message history",
         "method": "POST",
         "path": "/mi/sockets/subscribe",
         "body": {
             "client": "conn-blocked",
             "user": "56",
-            "channel": "chat:22222222-2222-4222-8222-222222222222",
+            "channel": "history:22222222-2222-4222-8222-222222222222",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -46,7 +46,7 @@
         "body": {
             "client": "conn-otherorg",
             "user": "56",
-            "channel": "chat:f6d20b72-f7d8-44dc-87f2-aae046dbff95",
+            "channel": "history:f6d20b72-f7d8-44dc-87f2-aae046dbff95",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -67,7 +67,7 @@
         "body": {
             "client": "conn-nonexistent",
             "user": "56",
-            "channel": "chat:12345678-1234-4123-8123-123456789abc",
+            "channel": "history:12345678-1234-4123-8123-123456789abc",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -88,7 +88,7 @@
         "body": {
             "client": "conn-malformed",
             "user": "56",
-            "channel": "chat:not-a-uuid",
+            "channel": "history:not-a-uuid",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -130,7 +130,7 @@
         "body": {
             "client": "conn-inactive",
             "user": "56",
-            "channel": "chat:11111111-1111-4111-8111-111111111111",
+            "channel": "history:11111111-1111-4111-8111-111111111111",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -151,7 +151,7 @@
         "body": {
             "client": "conn-nometa",
             "user": "56",
-            "channel": "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf"
+            "channel": "history:a393abc0-283d-4c9b-a1b3-641a035c34bf"
         },
         "status": 200,
         "response": {
@@ -168,7 +168,7 @@
         "body": {
             "client": "conn-noorg",
             "user": "56",
-            "channel": "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf",
+            "channel": "history:a393abc0-283d-4c9b-a1b3-641a035c34bf",
             "meta": {
                 "org_uuid": "",
                 "user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
@@ -189,7 +189,7 @@
         "body": {
             "client": "conn-nouser",
             "user": "56",
-            "channel": "chat:a393abc0-283d-4c9b-a1b3-641a035c34bf",
+            "channel": "history:a393abc0-283d-4c9b-a1b3-641a035c34bf",
             "meta": {
                 "org_uuid": "bf0514a5-9407-44c9-b0f9-3f36f9c18414",
                 "user_uuid": ""


### PR DESCRIPTION
Follow-up to #1101.

The only client-subscribable realtime channel is a contact's **message history**, so this names it `history:<contact-uuid>` and frees up the `chat` namespace for a future live-chat channel.

- `SocketChatNamespace` → `SocketHistoryNamespace` (`"chat"` → `"history"`)
- `ChatChannel()` → `HistoryChannel()`
- Updated `authorize()` default-deny check, doc comments, and the subscribe/sub_refresh test fixtures
- Valkey presence keys become `socket-subs:history:<contact-uuid>`

No behavior change beyond the channel name. `./core/models/` and `./web/sockets/` tests pass.

> Note: the realtime server's namespace config must declare `history` (instead of `chat`) for the subscribe/sub_refresh proxies — handled in the deployment config alongside this.