### PR TITLE
Route per-ticket history events to ticket-scoped realtime channels

### DIFF
--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -7,17 +7,25 @@ import (
 
 	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
-// SocketHistoryNamespace is the realtime pub/sub channel namespace for a contact's message history, addressed
-// as "history:<contact-uuid>". Mailroom publishes engine events to this channel for any live subscribers.
-// ("Channel" here is a realtime pub/sub channel - unrelated to a messaging Channel.)
+// SocketHistoryNamespace is the realtime pub/sub channel namespace for a contact's message history. It's addressed
+// as "history:<contact-uuid>" for a contact's whole history (the contact read page) or
+// "history:<contact-uuid>:<ticket-uuid>" for the subset scoped to a single ticket (the ticket read page). Mailroom
+// publishes engine events to these channels for any live subscribers. ("Channel" here is a realtime pub/sub channel
+// - unrelated to a messaging Channel.)
 const SocketHistoryNamespace = "history"
 
 // HistoryChannel returns the realtime pub/sub channel for a contact's message history.
 func HistoryChannel(contactUUID flows.ContactUUID) string {
 	return fmt.Sprintf("%s:%s", SocketHistoryNamespace, contactUUID)
+}
+
+// TicketHistoryChannel returns the realtime pub/sub channel for a contact's history scoped to a single ticket.
+func TicketHistoryChannel(contactUUID flows.ContactUUID, ticketUUID flows.TicketUUID) string {
+	return fmt.Sprintf("%s:%s:%s", SocketHistoryNamespace, contactUUID, ticketUUID)
 }
 
 // subscriptionKey is the valkey key marking that a realtime channel has at least one active subscriber, e.g.
@@ -40,16 +48,69 @@ func IsSubscribed(ctx context.Context, rt *runtime.Runtime, channel string) (boo
 	return subscribed, nil
 }
 
-// PublishToHistory publishes engine events to a contact's history channel for any live subscribers. Each event
-// is sent as its full JSON, including its uuid - matching the shape clients fetch from the history table, save
-// for the hydration the fetch layer adds on read (e.g. resolving user avatars). It's best-effort and a no-op
-// when the channel currently has no subscribers; we only pay the centrifugo publish when someone is watching.
+// PublishToHistory publishes engine events to a contact's history channels for any live subscribers. Each event is
+// sent as its full JSON, including its uuid - matching the shape clients fetch from the history table, save for the
+// hydration the fetch layer adds on read (e.g. resolving user avatars).
+//
+// Events are routed to mirror how the read API filters the same events: the per-ticket detail events (assignee, note
+// and topic changes) are filtered off the contact read page and so go only to that ticket's channel, while everything
+// else - non-ticket events plus the basic ticket lifecycle events (opened/closed/reopened) - goes to the contact's
+// channel. The ticket read page subscribes to both its ticket channel and the contact channel, so the union it sees
+// matches what the read API returns for that ticket.
+//
+// It's best-effort and a no-op for any channel that currently has no subscribers; we only pay the centrifugo publish
+// when someone is watching.
 func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flows.ContactUUID, events []flows.Event) error {
 	if len(events) == 0 {
 		return nil
 	}
 
-	channel := HistoryChannel(contactUUID)
+	contactEvents := make([]flows.Event, 0, len(events))
+	ticketEvents := make(map[flows.TicketUUID][]flows.Event)
+
+	for _, e := range events {
+		if ticketUUID, ok := ticketDetailEvent(e); ok {
+			ticketEvents[ticketUUID] = append(ticketEvents[ticketUUID], e)
+		} else {
+			contactEvents = append(contactEvents, e)
+		}
+	}
+
+	if err := publishToChannel(ctx, rt, HistoryChannel(contactUUID), contactEvents); err != nil {
+		return err
+	}
+	for ticketUUID, evts := range ticketEvents {
+		if err := publishToChannel(ctx, rt, TicketHistoryChannel(contactUUID, ticketUUID), evts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ticketDetailEvent returns the ticket UUID and true if the event is a per-ticket detail event - one the read API
+// includes on the ticket page but filters off the contact page (assignee/note/topic changes). Everything else,
+// including the basic ticket lifecycle events (opened/closed/reopened), belongs on the contact channel.
+func ticketDetailEvent(e flows.Event) (flows.TicketUUID, bool) {
+	switch typed := e.(type) {
+	case *events.TicketAssigneeChanged:
+		return typed.TicketUUID, true
+	case *events.TicketNoteAdded:
+		return typed.TicketUUID, true
+	case *events.TicketTopicChanged:
+		return typed.TicketUUID, true
+	default:
+		return "", false
+	}
+}
+
+// publishToChannel publishes events to a single realtime channel if it currently has subscribers. All the events are
+// batched into one pipelined request so a subscribed channel costs one round-trip per commit regardless of how many
+// events it produced, and the whole batch lands or fails together.
+func publishToChannel(ctx context.Context, rt *runtime.Runtime, channel string, events []flows.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
 
 	subscribed, err := IsSubscribed(ctx, rt, channel)
 	if err != nil {
@@ -59,8 +120,6 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flow
 		return nil
 	}
 
-	// batch all events into a single pipelined request so a subscribed contact costs one round-trip per commit
-	// regardless of how many events it produced, and the whole batch lands or fails together
 	pipe := rt.Centrifugo.Pipe()
 	for _, e := range events {
 		data, err := json.Marshal(e)

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -11,54 +11,54 @@ import (
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
-// SocketHistoryNamespace is the realtime pub/sub channel namespace for a contact's message history. It's addressed
-// as "history:<contact-uuid>" for a contact's whole history (the contact read page) or
+// SocketHistoryNamespace is the realtime pub/sub namespace for a contact's message history. A history socket is
+// addressed as "history:<contact-uuid>" for a contact's whole history (the contact read page) or
 // "history:<contact-uuid>:<ticket-uuid>" for the subset scoped to a single ticket (the ticket read page). Mailroom
-// publishes engine events to these channels for any live subscribers. ("Channel" here is a realtime pub/sub channel
-// - unrelated to a messaging Channel.)
+// publishes engine events to these sockets for any live subscribers. ("Socket" is our name for a realtime pub/sub
+// address - so as not to overload Channel, which already means a messaging channel.)
 const SocketHistoryNamespace = "history"
 
-// HistoryChannel returns the realtime pub/sub channel for a contact's message history.
-func HistoryChannel(contactUUID flows.ContactUUID) string {
+// HistorySocket returns the realtime pub/sub socket for a contact's message history, optionally scoped to a single
+// ticket. Given a ticket it returns that ticket's socket ("history:<contact-uuid>:<ticket-uuid>"), otherwise the
+// contact's socket ("history:<contact-uuid>"). At most one ticket is used; any extra is ignored.
+func HistorySocket(contactUUID flows.ContactUUID, ticketUUID ...flows.TicketUUID) string {
+	if len(ticketUUID) > 0 {
+		return fmt.Sprintf("%s:%s:%s", SocketHistoryNamespace, contactUUID, ticketUUID[0])
+	}
 	return fmt.Sprintf("%s:%s", SocketHistoryNamespace, contactUUID)
 }
 
-// TicketHistoryChannel returns the realtime pub/sub channel for a contact's history scoped to a single ticket.
-func TicketHistoryChannel(contactUUID flows.ContactUUID, ticketUUID flows.TicketUUID) string {
-	return fmt.Sprintf("%s:%s:%s", SocketHistoryNamespace, contactUUID, ticketUUID)
-}
-
-// subscriptionKey is the valkey key marking that a realtime channel has at least one active subscriber, e.g.
-// "socket-subs:history:<contact-uuid>". The key is a per-channel presence marker written by the service that
+// subscriptionKey is the valkey key marking that a realtime socket has at least one active subscriber, e.g.
+// "socket-subs:history:<contact-uuid>". The key is a per-socket presence marker written by the service that
 // authorizes subscriptions (it sets/re-arms the key with a TTL on every subscribe and refresh); mailroom only
 // reads it.
-func subscriptionKey(channel string) string {
-	return fmt.Sprintf("socket-subs:%s", channel)
+func subscriptionKey(socket string) string {
+	return fmt.Sprintf("socket-subs:%s", socket)
 }
 
-// IsSubscribed reports whether a realtime channel currently has at least one active subscriber.
-func IsSubscribed(ctx context.Context, rt *runtime.Runtime, channel string) (bool, error) {
+// IsSubscribed reports whether a realtime socket currently has at least one active subscriber.
+func IsSubscribed(ctx context.Context, rt *runtime.Runtime, socket string) (bool, error) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	subscribed, err := valkey.Bool(valkey.DoContext(vc, ctx, "EXISTS", subscriptionKey(channel)))
+	subscribed, err := valkey.Bool(valkey.DoContext(vc, ctx, "EXISTS", subscriptionKey(socket)))
 	if err != nil {
-		return false, fmt.Errorf("error checking subscription for %s: %w", channel, err)
+		return false, fmt.Errorf("error checking subscription for %s: %w", socket, err)
 	}
 	return subscribed, nil
 }
 
-// PublishToHistory publishes engine events to a contact's history channels for any live subscribers. Each event is
+// PublishToHistory publishes engine events to a contact's history sockets for any live subscribers. Each event is
 // sent as its full JSON, including its uuid - matching the shape clients fetch from the history table, save for the
 // hydration the fetch layer adds on read (e.g. resolving user avatars).
 //
 // Events are routed to mirror how the read API filters the same events: the per-ticket detail events (assignee, note
-// and topic changes) are filtered off the contact read page and so go only to that ticket's channel, while everything
+// and topic changes) are filtered off the contact read page and so go only to that ticket's socket, while everything
 // else - non-ticket events plus the basic ticket lifecycle events (opened/closed/reopened) - goes to the contact's
-// channel. The ticket read page subscribes to both its ticket channel and the contact channel, so the union it sees
+// socket. The ticket read page subscribes to both its ticket socket and the contact socket, so the union it sees
 // matches what the read API returns for that ticket.
 //
-// It's best-effort and a no-op for any channel that currently has no subscribers; we only pay the centrifugo publish
+// It's best-effort and a no-op for any socket that currently has no subscribers; we only pay the centrifugo publish
 // when someone is watching.
 func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flows.ContactUUID, events []flows.Event) error {
 	if len(events) == 0 {
@@ -76,11 +76,11 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flow
 		}
 	}
 
-	if err := publishToChannel(ctx, rt, HistoryChannel(contactUUID), contactEvents); err != nil {
+	if err := publishToSocket(ctx, rt, HistorySocket(contactUUID), contactEvents); err != nil {
 		return err
 	}
 	for ticketUUID, evts := range ticketEvents {
-		if err := publishToChannel(ctx, rt, TicketHistoryChannel(contactUUID, ticketUUID), evts); err != nil {
+		if err := publishToSocket(ctx, rt, HistorySocket(contactUUID, ticketUUID), evts); err != nil {
 			return err
 		}
 	}
@@ -90,7 +90,7 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flow
 
 // ticketDetailEvent returns the ticket UUID and true if the event is a per-ticket detail event - one the read API
 // includes on the ticket page but filters off the contact page (assignee/note/topic changes). Everything else,
-// including the basic ticket lifecycle events (opened/closed/reopened), belongs on the contact channel.
+// including the basic ticket lifecycle events (opened/closed/reopened), belongs on the contact socket.
 func ticketDetailEvent(e flows.Event) (flows.TicketUUID, bool) {
 	switch typed := e.(type) {
 	case *events.TicketAssigneeChanged:
@@ -104,15 +104,15 @@ func ticketDetailEvent(e flows.Event) (flows.TicketUUID, bool) {
 	}
 }
 
-// publishToChannel publishes events to a single realtime channel if it currently has subscribers. All the events are
-// batched into one pipelined request so a subscribed channel costs one round-trip per commit regardless of how many
+// publishToSocket publishes events to a single realtime socket if it currently has subscribers. All the events are
+// batched into one pipelined request so a subscribed socket costs one round-trip per commit regardless of how many
 // events it produced, and the whole batch lands or fails together.
-func publishToChannel(ctx context.Context, rt *runtime.Runtime, channel string, events []flows.Event) error {
+func publishToSocket(ctx context.Context, rt *runtime.Runtime, socket string, events []flows.Event) error {
 	if len(events) == 0 {
 		return nil
 	}
 
-	subscribed, err := IsSubscribed(ctx, rt, channel)
+	subscribed, err := IsSubscribed(ctx, rt, socket)
 	if err != nil {
 		return err
 	}
@@ -124,20 +124,20 @@ func publishToChannel(ctx context.Context, rt *runtime.Runtime, channel string, 
 	for _, e := range events {
 		data, err := json.Marshal(e)
 		if err != nil {
-			return fmt.Errorf("error marshaling event for %s: %w", channel, err)
+			return fmt.Errorf("error marshaling event for %s: %w", socket, err)
 		}
-		if err := pipe.AddPublish(channel, data); err != nil {
-			return fmt.Errorf("error adding event to publish pipe for %s: %w", channel, err)
+		if err := pipe.AddPublish(socket, data); err != nil {
+			return fmt.Errorf("error adding event to publish pipe for %s: %w", socket, err)
 		}
 	}
 
 	replies, err := rt.Centrifugo.SendPipe(ctx, pipe)
 	if err != nil {
-		return fmt.Errorf("error publishing events to %s: %w", channel, err)
+		return fmt.Errorf("error publishing events to %s: %w", socket, err)
 	}
 	for _, reply := range replies {
 		if reply.Error != nil {
-			return fmt.Errorf("error publishing event to %s: %w", channel, reply.Error)
+			return fmt.Errorf("error publishing event to %s: %w", socket, reply.Error)
 		}
 	}
 

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -36,14 +36,33 @@ func subscriptionKey(socket string) string {
 	return fmt.Sprintf("socket-subs:%s", socket)
 }
 
-// IsSubscribed reports whether a realtime socket currently has at least one active subscriber.
-func IsSubscribed(ctx context.Context, rt *runtime.Runtime, socket string) (bool, error) {
+// SubscribedSockets returns the subset of the given sockets that currently have at least one active subscriber. It
+// resolves them all in a single round-trip by MGETting their presence keys, so checking many sockets at once (e.g. a
+// contact plus all of its tickets) costs one lookup rather than one per socket. A socket is subscribed when its key
+// is present; missing keys come back nil. The returned map only contains the subscribed sockets.
+func SubscribedSockets(ctx context.Context, rt *runtime.Runtime, sockets ...string) (map[string]bool, error) {
+	if len(sockets) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]any, len(sockets))
+	for i, s := range sockets {
+		keys[i] = subscriptionKey(s)
+	}
+
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	subscribed, err := valkey.Bool(valkey.DoContext(vc, ctx, "EXISTS", subscriptionKey(socket)))
+	values, err := valkey.Values(valkey.DoContext(vc, ctx, "MGET", keys...))
 	if err != nil {
-		return false, fmt.Errorf("error checking subscription for %s: %w", socket, err)
+		return nil, fmt.Errorf("error checking socket subscriptions: %w", err)
+	}
+
+	subscribed := make(map[string]bool, len(sockets))
+	for i, v := range values {
+		if v != nil {
+			subscribed[sockets[i]] = true
+		}
 	}
 	return subscribed, nil
 }
@@ -77,44 +96,53 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flow
 		}
 	}
 
-	pipe := rt.Centrifugo.Pipe()
-	var sockets []string // the socket each pipelined publish targets, parallel to the replies for error reporting
-
-	// addEvents adds a socket's events to the shared pipe, but only if the socket currently has subscribers
-	addEvents := func(socket string, evts []flows.Event) error {
-		if len(evts) == 0 {
-			return nil
-		}
-		subscribed, err := IsSubscribed(ctx, rt, socket)
-		if err != nil {
-			return err
-		}
-		if !subscribed {
-			return nil
-		}
-		for _, e := range evts {
-			data, err := json.Marshal(e)
-			if err != nil {
-				return fmt.Errorf("error marshaling event for %s: %w", socket, err)
-			}
-			if err := pipe.AddPublish(socket, data); err != nil {
-				return fmt.Errorf("error adding event to publish pipe for %s: %w", socket, err)
-			}
-			sockets = append(sockets, socket)
-		}
+	// gather the sockets this commit touches - the contact socket plus one per ticket with detail events - so their
+	// subscription state can be resolved in a single round-trip rather than one presence lookup per socket (which
+	// matters once a commit can span many tickets, e.g. a bulk ticket operation)
+	type batch struct {
+		socket string
+		events []flows.Event
+	}
+	batches := make([]batch, 0, len(ticketEvents)+1)
+	if len(contactEvents) > 0 {
+		batches = append(batches, batch{HistorySocket(contactUUID), contactEvents})
+	}
+	for ticketUUID, evts := range ticketEvents {
+		batches = append(batches, batch{HistorySocket(contactUUID, ticketUUID), evts})
+	}
+	if len(batches) == 0 {
 		return nil
 	}
 
-	if err := addEvents(HistorySocket(contactUUID), contactEvents); err != nil {
+	candidates := make([]string, len(batches))
+	for i, b := range batches {
+		candidates[i] = b.socket
+	}
+	subscribed, err := SubscribedSockets(ctx, rt, candidates...)
+	if err != nil {
 		return err
 	}
-	for ticketUUID, evts := range ticketEvents {
-		if err := addEvents(HistorySocket(contactUUID, ticketUUID), evts); err != nil {
-			return err
+
+	// batch every subscribed socket's events into a single pipelined request, so the whole commit is one centrifugo
+	// round-trip no matter how many sockets it spans, and the batch lands or fails together
+	pipe := rt.Centrifugo.Pipe()
+	var targets []string // the socket each pipelined publish targets, parallel to the replies for error reporting
+	for _, b := range batches {
+		if !subscribed[b.socket] {
+			continue
+		}
+		for _, e := range b.events {
+			data, err := json.Marshal(e)
+			if err != nil {
+				return fmt.Errorf("error marshaling event for %s: %w", b.socket, err)
+			}
+			if err := pipe.AddPublish(b.socket, data); err != nil {
+				return fmt.Errorf("error adding event to publish pipe for %s: %w", b.socket, err)
+			}
+			targets = append(targets, b.socket)
 		}
 	}
-
-	if len(sockets) == 0 {
+	if len(targets) == 0 {
 		return nil
 	}
 
@@ -124,7 +152,7 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flow
 	}
 	for i, reply := range replies {
 		if reply.Error != nil {
-			return fmt.Errorf("error publishing event to %s: %w", sockets[i], reply.Error)
+			return fmt.Errorf("error publishing event to %s: %w", targets[i], reply.Error)
 		}
 	}
 

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -58,8 +58,9 @@ func IsSubscribed(ctx context.Context, rt *runtime.Runtime, socket string) (bool
 // socket. The ticket read page subscribes to both its ticket socket and the contact socket, so the union it sees
 // matches what the read API returns for that ticket.
 //
-// It's best-effort and a no-op for any socket that currently has no subscribers; we only pay the centrifugo publish
-// when someone is watching.
+// Every subscribed socket's events are batched into a single pipelined request, so one commit costs one centrifugo
+// round-trip no matter how many sockets it spans, and the whole batch lands or fails together. It's best-effort and
+// a no-op for any socket that currently has no subscribers; we only publish to a socket when someone is watching.
 func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flows.ContactUUID, events []flows.Event) error {
 	if len(events) == 0 {
 		return nil
@@ -76,12 +77,54 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID flow
 		}
 	}
 
-	if err := publishToSocket(ctx, rt, HistorySocket(contactUUID), contactEvents); err != nil {
+	pipe := rt.Centrifugo.Pipe()
+	var sockets []string // the socket each pipelined publish targets, parallel to the replies for error reporting
+
+	// addEvents adds a socket's events to the shared pipe, but only if the socket currently has subscribers
+	addEvents := func(socket string, evts []flows.Event) error {
+		if len(evts) == 0 {
+			return nil
+		}
+		subscribed, err := IsSubscribed(ctx, rt, socket)
+		if err != nil {
+			return err
+		}
+		if !subscribed {
+			return nil
+		}
+		for _, e := range evts {
+			data, err := json.Marshal(e)
+			if err != nil {
+				return fmt.Errorf("error marshaling event for %s: %w", socket, err)
+			}
+			if err := pipe.AddPublish(socket, data); err != nil {
+				return fmt.Errorf("error adding event to publish pipe for %s: %w", socket, err)
+			}
+			sockets = append(sockets, socket)
+		}
+		return nil
+	}
+
+	if err := addEvents(HistorySocket(contactUUID), contactEvents); err != nil {
 		return err
 	}
 	for ticketUUID, evts := range ticketEvents {
-		if err := publishToSocket(ctx, rt, HistorySocket(contactUUID, ticketUUID), evts); err != nil {
+		if err := addEvents(HistorySocket(contactUUID, ticketUUID), evts); err != nil {
 			return err
+		}
+	}
+
+	if len(sockets) == 0 {
+		return nil
+	}
+
+	replies, err := rt.Centrifugo.SendPipe(ctx, pipe)
+	if err != nil {
+		return fmt.Errorf("error publishing history events: %w", err)
+	}
+	for i, reply := range replies {
+		if reply.Error != nil {
+			return fmt.Errorf("error publishing event to %s: %w", sockets[i], reply.Error)
 		}
 	}
 
@@ -102,44 +145,4 @@ func ticketDetailEvent(e flows.Event) (flows.TicketUUID, bool) {
 	default:
 		return "", false
 	}
-}
-
-// publishToSocket publishes events to a single realtime socket if it currently has subscribers. All the events are
-// batched into one pipelined request so a subscribed socket costs one round-trip per commit regardless of how many
-// events it produced, and the whole batch lands or fails together.
-func publishToSocket(ctx context.Context, rt *runtime.Runtime, socket string, events []flows.Event) error {
-	if len(events) == 0 {
-		return nil
-	}
-
-	subscribed, err := IsSubscribed(ctx, rt, socket)
-	if err != nil {
-		return err
-	}
-	if !subscribed {
-		return nil
-	}
-
-	pipe := rt.Centrifugo.Pipe()
-	for _, e := range events {
-		data, err := json.Marshal(e)
-		if err != nil {
-			return fmt.Errorf("error marshaling event for %s: %w", socket, err)
-		}
-		if err := pipe.AddPublish(socket, data); err != nil {
-			return fmt.Errorf("error adding event to publish pipe for %s: %w", socket, err)
-		}
-	}
-
-	replies, err := rt.Centrifugo.SendPipe(ctx, pipe)
-	if err != nil {
-		return fmt.Errorf("error publishing events to %s: %w", socket, err)
-	}
-	for _, reply := range replies {
-		if reply.Error != nil {
-			return fmt.Errorf("error publishing event to %s: %w", socket, reply.Error)
-		}
-	}
-
-	return nil
 }

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -79,8 +79,13 @@ func TestPublishToHistory(t *testing.T) {
 	}
 	var mu sync.Mutex
 	var published []publish
+	var requests int
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+
 		// the gocent client sends newline-delimited publish commands and expects one reply per command
 		dec := json.NewDecoder(r.Body)
 		replies := 0
@@ -121,6 +126,11 @@ func TestPublishToHistory(t *testing.T) {
 			}
 		}
 		return out
+	}
+	reqCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return requests
 	}
 
 	rt.Centrifugo = gocent.New(gocent.Config{Addr: srv.URL, Key: "sesame"})
@@ -178,7 +188,11 @@ func TestPublishToHistory(t *testing.T) {
 	assignB := events.NewTicketAssigneeChanged(ticketB, assets.NewUserReference("0c78ef47-7d56-44d8-8f57-96e0f30e8f44", "Bob"), nil) // detail -> ticket B socket (unsubscribed)
 	lang := events.NewContactLanguageChanged("fra")                                                                                  // non-ticket -> contact socket
 
+	reqsBefore := reqCount()
 	require.NoError(t, models.PublishToHistory(ctx, rt, contact, []flows.Event{closed, noteA, assignB, lang}))
+
+	// even though this commit spans two sockets (contact + ticket A), it's a single pipelined centrifugo round-trip
+	assert.Equal(t, 1, reqCount()-reqsBefore)
 
 	// the contact socket got the basic ticket event and the non-ticket event in order, plus the two from before
 	contactSent := sentTo(socket)

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -29,7 +29,7 @@ func TestHistorySocket(t *testing.T) {
 	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf:019905d4-5f7b-71b8-bcb8-6a68de2d91d2", models.HistorySocket(contact, ticket))
 }
 
-func TestIsSubscribed(t *testing.T) {
+func TestSubscribedSockets(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
 	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
@@ -42,26 +42,31 @@ func TestIsSubscribed(t *testing.T) {
 	hist1 := models.HistorySocket(contact1)
 	hist2 := models.HistorySocket(contact2)
 
-	assertSubscribed := func(socket string, expected bool) {
-		t.Helper()
-		actual, err := models.IsSubscribed(ctx, rt, socket)
-		require.NoError(t, err)
-		assert.Equal(t, expected, actual, "subscribed mismatch for %s", socket)
-	}
+	// no sockets to check is a no-op
+	subs, err := models.SubscribedSockets(ctx, rt)
+	require.NoError(t, err)
+	assert.Empty(t, subs)
 
 	// nothing subscribed yet
-	assertSubscribed(hist1, false)
+	subs, err = models.SubscribedSockets(ctx, rt, hist1, hist2)
+	require.NoError(t, err)
+	assert.Empty(t, subs)
 
 	// the authorizing service records a subscription by setting the per-socket presence key; mailroom only reads it
-	_, err := vc.Do("SET", "socket-subs:"+hist1, "1")
+	_, err = vc.Do("SET", "socket-subs:"+hist1, "1")
 	require.NoError(t, err)
-	assertSubscribed(hist1, true)
 
-	// each socket is its own key, checked independently
-	assertSubscribed(hist2, false)
+	// a single lookup reports which of the requested sockets are subscribed
+	subs, err = models.SubscribedSockets(ctx, rt, hist1, hist2)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{hist1: true}, subs)
+
+	// once both are subscribed they both come back from the one lookup
 	_, err = vc.Do("SET", "socket-subs:"+hist2, "1")
 	require.NoError(t, err)
-	assertSubscribed(hist2, true)
+	subs, err = models.SubscribedSockets(ctx, rt, hist1, hist2)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{hist1: true, hist2: true}, subs)
 }
 
 func TestPublishToHistory(t *testing.T) {
@@ -211,4 +216,33 @@ func TestPublishToHistory(t *testing.T) {
 
 	// ticket B's socket wasn't subscribed, so nothing was published to it
 	assert.Empty(t, sentTo(ticketBSocket))
+
+	// a commit can span several ticket sockets at once (e.g. a future bulk ticket operation) - subscribing ticket B
+	// too, a publish touching both tickets and the contact resolves every socket's subscription in one lookup and is
+	// still a single centrifugo round-trip
+	_, err = vc.Do("SET", "socket-subs:"+ticketBSocket, "1")
+	require.NoError(t, err)
+
+	noteA2 := events.NewTicketNoteAdded(ticketA, "more on A") // detail -> ticket A socket
+	noteB := events.NewTicketNoteAdded(ticketB, "now on B")   // detail -> ticket B socket
+	renamed := events.NewContactNameChanged("Bobby")          // non-ticket -> contact socket
+
+	reqsBefore = reqCount()
+	require.NoError(t, models.PublishToHistory(ctx, rt, contact, []flows.Event{noteA2, noteB, renamed}))
+	assert.Equal(t, 1, reqCount()-reqsBefore)
+
+	// each socket received exactly its own events, across all three sockets in the one round-trip
+	require.Len(t, sentTo(socket), 5) // evt1, evt2, closed, lang, renamed
+	require.NoError(t, json.Unmarshal(sentTo(socket)[4].Data, &decoded))
+	assert.Equal(t, "contact_name_changed", decoded["type"])
+
+	ticketASent = sentTo(ticketASocket)
+	require.Len(t, ticketASent, 2) // noteA, noteA2
+	require.NoError(t, json.Unmarshal(ticketASent[1].Data, &decoded))
+	assert.Equal(t, string(noteA2.UUID()), decoded["uuid"])
+
+	ticketBSent := sentTo(ticketBSocket)
+	require.Len(t, ticketBSent, 1) // noteB
+	require.NoError(t, json.Unmarshal(ticketBSent[0].Data, &decoded))
+	assert.Equal(t, string(noteB.UUID()), decoded["uuid"])
 }

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -18,15 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHistoryChannel(t *testing.T) {
-	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.HistoryChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf"))
-}
+func TestHistorySocket(t *testing.T) {
+	contact := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
+	ticket := flows.TicketUUID("019905d4-5f7b-71b8-bcb8-6a68de2d91d2")
 
-func TestTicketHistoryChannel(t *testing.T) {
-	assert.Equal(t,
-		"history:a393abc0-283d-4c9b-a1b3-641a035c34bf:019905d4-5f7b-71b8-bcb8-6a68de2d91d2",
-		models.TicketHistoryChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf", "019905d4-5f7b-71b8-bcb8-6a68de2d91d2"),
-	)
+	// with no ticket it's the contact's socket
+	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.HistorySocket(contact))
+
+	// with a ticket it's that ticket's socket
+	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf:019905d4-5f7b-71b8-bcb8-6a68de2d91d2", models.HistorySocket(contact, ticket))
 }
 
 func TestIsSubscribed(t *testing.T) {
@@ -39,25 +39,25 @@ func TestIsSubscribed(t *testing.T) {
 
 	contact1 := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
 	contact2 := flows.ContactUUID("b699a406-7e44-49be-9f01-1a82893e8a10")
-	hist1 := models.HistoryChannel(contact1)
-	hist2 := models.HistoryChannel(contact2)
+	hist1 := models.HistorySocket(contact1)
+	hist2 := models.HistorySocket(contact2)
 
-	assertSubscribed := func(channel string, expected bool) {
+	assertSubscribed := func(socket string, expected bool) {
 		t.Helper()
-		actual, err := models.IsSubscribed(ctx, rt, channel)
+		actual, err := models.IsSubscribed(ctx, rt, socket)
 		require.NoError(t, err)
-		assert.Equal(t, expected, actual, "subscribed mismatch for %s", channel)
+		assert.Equal(t, expected, actual, "subscribed mismatch for %s", socket)
 	}
 
 	// nothing subscribed yet
 	assertSubscribed(hist1, false)
 
-	// the authorizing service records a subscription by setting the per-channel presence key; mailroom only reads it
+	// the authorizing service records a subscription by setting the per-socket presence key; mailroom only reads it
 	_, err := vc.Do("SET", "socket-subs:"+hist1, "1")
 	require.NoError(t, err)
 	assertSubscribed(hist1, true)
 
-	// each channel is its own key, checked independently
+	// each socket is its own key, checked independently
 	assertSubscribed(hist2, false)
 	_, err = vc.Do("SET", "socket-subs:"+hist2, "1")
 	require.NoError(t, err)
@@ -113,32 +113,41 @@ func TestPublishToHistory(t *testing.T) {
 		defer mu.Unlock()
 		return append([]publish(nil), published...)
 	}
+	sentTo := func(socket string) []publish {
+		var out []publish
+		for _, p := range snapshot() {
+			if p.Channel == socket {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
 
 	rt.Centrifugo = gocent.New(gocent.Config{Addr: srv.URL, Key: "sesame"})
 
 	contact := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
-	channel := models.HistoryChannel(contact)
+	socket := models.HistorySocket(contact)
 	evt1 := events.NewContactNameChanged("Bob")
 	evt1.SetUser(assets.NewUserReference("eb9536d7-7b22-4ca6-9a1e-8e1f1effe7f3", "Ann Admin"), "ui")
 	evt2 := events.NewContactLanguageChanged("spa")
 
-	// channel isn't subscribed yet, so nothing is published
+	// socket isn't subscribed yet, so nothing is published
 	require.NoError(t, models.PublishToHistory(ctx, rt, contact, []flows.Event{evt1}))
 	assert.Empty(t, snapshot())
 
-	// mark the channel subscribed (as the authorizing service would) - empty event slice is still a no-op
-	_, err := vc.Do("SET", "socket-subs:"+channel, "1")
+	// mark the socket subscribed (as the authorizing service would) - empty event slice is still a no-op
+	_, err := vc.Do("SET", "socket-subs:"+socket, "1")
 	require.NoError(t, err)
 	require.NoError(t, models.PublishToHistory(ctx, rt, contact, nil))
 	assert.Empty(t, snapshot())
 
-	// now that it's subscribed, each event is published to the contact's history channel as its full JSON
+	// now that it's subscribed, each event is published to the contact's history socket as its full JSON
 	require.NoError(t, models.PublishToHistory(ctx, rt, contact, []flows.Event{evt1, evt2}))
 
 	sent := snapshot()
 	require.Len(t, sent, 2)
-	assert.Equal(t, channel, sent[0].Channel)
-	assert.Equal(t, channel, sent[1].Channel)
+	assert.Equal(t, socket, sent[0].Channel)
+	assert.Equal(t, socket, sent[1].Channel)
 
 	// the published payload is the full event including its uuid (the history table strips uuid into the key)
 	// and the raw _user reference (uuid+name) that the read path later hydrates with avatar etc.
@@ -152,55 +161,40 @@ func TestPublishToHistory(t *testing.T) {
 	assert.Equal(t, "contact_language_changed", decoded["type"])
 	assert.Equal(t, "spa", decoded["language"])
 
-	// per-ticket detail events (assignee/note/topic changes) route to that ticket's channel rather than the contact
-	// channel, mirroring how the read API filters them off the contact page; the basic ticket lifecycle events
-	// (opened/closed/reopened) and non-ticket events stay on the contact channel
+	// per-ticket detail events (assignee/note/topic changes) route to that ticket's socket rather than the contact
+	// socket, mirroring how the read API filters them off the contact page; the basic ticket lifecycle events
+	// (opened/closed/reopened) and non-ticket events stay on the contact socket
 	ticketA := flows.TicketUUID("019905d4-5f7b-71b8-bcb8-6a68de2d91d2")
 	ticketB := flows.TicketUUID("28e94070-7c69-4f8e-9b7e-2c5a3a3e6f9a")
-	ticketAChannel := models.TicketHistoryChannel(contact, ticketA)
-	ticketBChannel := models.TicketHistoryChannel(contact, ticketB)
+	ticketASocket := models.HistorySocket(contact, ticketA)
+	ticketBSocket := models.HistorySocket(contact, ticketB)
 
-	// ticket A's channel is subscribed (e.g. someone has its ticket page open), ticket B's is not
-	_, err = vc.Do("SET", "socket-subs:"+ticketAChannel, "1")
+	// ticket A's socket is subscribed (e.g. someone has its ticket page open), ticket B's is not
+	_, err = vc.Do("SET", "socket-subs:"+ticketASocket, "1")
 	require.NoError(t, err)
 
-	sentTo := func(ch string) []publish {
-		var out []publish
-		for _, p := range snapshot() {
-			if p.Channel == ch {
-				out = append(out, p)
-			}
-		}
-		return out
-	}
-	typeOf := func(data json.RawMessage) string {
-		var e struct {
-			Type string `json:"type"`
-		}
-		require.NoError(t, json.Unmarshal(data, &e))
-		return e.Type
-	}
-
-	closed := events.NewTicketClosed(ticketA)                                                                                        // basic lifecycle -> contact channel
-	noteA := events.NewTicketNoteAdded(ticketA, "look at this")                                                                      // detail -> ticket A channel
-	assignB := events.NewTicketAssigneeChanged(ticketB, assets.NewUserReference("0c78ef47-7d56-44d8-8f57-96e0f30e8f44", "Bob"), nil) // detail -> ticket B channel (unsubscribed)
-	lang := events.NewContactLanguageChanged("fra")                                                                                  // non-ticket -> contact channel
+	closed := events.NewTicketClosed(ticketA)                                                                                        // basic lifecycle -> contact socket
+	noteA := events.NewTicketNoteAdded(ticketA, "look at this")                                                                      // detail -> ticket A socket
+	assignB := events.NewTicketAssigneeChanged(ticketB, assets.NewUserReference("0c78ef47-7d56-44d8-8f57-96e0f30e8f44", "Bob"), nil) // detail -> ticket B socket (unsubscribed)
+	lang := events.NewContactLanguageChanged("fra")                                                                                  // non-ticket -> contact socket
 
 	require.NoError(t, models.PublishToHistory(ctx, rt, contact, []flows.Event{closed, noteA, assignB, lang}))
 
-	// the contact channel got the basic ticket event and the non-ticket event in order, plus the two from before
-	contactSent := sentTo(channel)
+	// the contact socket got the basic ticket event and the non-ticket event in order, plus the two from before
+	contactSent := sentTo(socket)
 	require.Len(t, contactSent, 4)
-	assert.Equal(t, "ticket_closed", typeOf(contactSent[2].Data))
-	assert.Equal(t, "contact_language_changed", typeOf(contactSent[3].Data))
+	require.NoError(t, json.Unmarshal(contactSent[2].Data, &decoded))
+	assert.Equal(t, "ticket_closed", decoded["type"])
+	require.NoError(t, json.Unmarshal(contactSent[3].Data, &decoded))
+	assert.Equal(t, "contact_language_changed", decoded["type"])
 
-	// ticket A's subscribed channel got only its own detail event, again as full JSON including its uuid
-	ticketASent := sentTo(ticketAChannel)
+	// ticket A's subscribed socket got only its own detail event, again as full JSON including its uuid
+	ticketASent := sentTo(ticketASocket)
 	require.Len(t, ticketASent, 1)
 	require.NoError(t, json.Unmarshal(ticketASent[0].Data, &decoded))
 	assert.Equal(t, "ticket_note_added", decoded["type"])
 	assert.Equal(t, string(noteA.UUID()), decoded["uuid"])
 
-	// ticket B's channel wasn't subscribed, so nothing was published to it
-	assert.Empty(t, sentTo(ticketBChannel))
+	// ticket B's socket wasn't subscribed, so nothing was published to it
+	assert.Empty(t, sentTo(ticketBSocket))
 }

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -22,6 +22,13 @@ func TestHistoryChannel(t *testing.T) {
 	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.HistoryChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf"))
 }
 
+func TestTicketHistoryChannel(t *testing.T) {
+	assert.Equal(t,
+		"history:a393abc0-283d-4c9b-a1b3-641a035c34bf:019905d4-5f7b-71b8-bcb8-6a68de2d91d2",
+		models.TicketHistoryChannel("a393abc0-283d-4c9b-a1b3-641a035c34bf", "019905d4-5f7b-71b8-bcb8-6a68de2d91d2"),
+	)
+}
+
 func TestIsSubscribed(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
@@ -144,4 +151,56 @@ func TestPublishToHistory(t *testing.T) {
 	require.NoError(t, json.Unmarshal(sent[1].Data, &decoded))
 	assert.Equal(t, "contact_language_changed", decoded["type"])
 	assert.Equal(t, "spa", decoded["language"])
+
+	// per-ticket detail events (assignee/note/topic changes) route to that ticket's channel rather than the contact
+	// channel, mirroring how the read API filters them off the contact page; the basic ticket lifecycle events
+	// (opened/closed/reopened) and non-ticket events stay on the contact channel
+	ticketA := flows.TicketUUID("019905d4-5f7b-71b8-bcb8-6a68de2d91d2")
+	ticketB := flows.TicketUUID("28e94070-7c69-4f8e-9b7e-2c5a3a3e6f9a")
+	ticketAChannel := models.TicketHistoryChannel(contact, ticketA)
+	ticketBChannel := models.TicketHistoryChannel(contact, ticketB)
+
+	// ticket A's channel is subscribed (e.g. someone has its ticket page open), ticket B's is not
+	_, err = vc.Do("SET", "socket-subs:"+ticketAChannel, "1")
+	require.NoError(t, err)
+
+	sentTo := func(ch string) []publish {
+		var out []publish
+		for _, p := range snapshot() {
+			if p.Channel == ch {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	typeOf := func(data json.RawMessage) string {
+		var e struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(data, &e))
+		return e.Type
+	}
+
+	closed := events.NewTicketClosed(ticketA)                                                                                        // basic lifecycle -> contact channel
+	noteA := events.NewTicketNoteAdded(ticketA, "look at this")                                                                      // detail -> ticket A channel
+	assignB := events.NewTicketAssigneeChanged(ticketB, assets.NewUserReference("0c78ef47-7d56-44d8-8f57-96e0f30e8f44", "Bob"), nil) // detail -> ticket B channel (unsubscribed)
+	lang := events.NewContactLanguageChanged("fra")                                                                                  // non-ticket -> contact channel
+
+	require.NoError(t, models.PublishToHistory(ctx, rt, contact, []flows.Event{closed, noteA, assignB, lang}))
+
+	// the contact channel got the basic ticket event and the non-ticket event in order, plus the two from before
+	contactSent := sentTo(channel)
+	require.Len(t, contactSent, 4)
+	assert.Equal(t, "ticket_closed", typeOf(contactSent[2].Data))
+	assert.Equal(t, "contact_language_changed", typeOf(contactSent[3].Data))
+
+	// ticket A's subscribed channel got only its own detail event, again as full JSON including its uuid
+	ticketASent := sentTo(ticketAChannel)
+	require.Len(t, ticketASent, 1)
+	require.NoError(t, json.Unmarshal(ticketASent[0].Data, &decoded))
+	assert.Equal(t, "ticket_note_added", decoded["type"])
+	assert.Equal(t, string(noteA.UUID()), decoded["uuid"])
+
+	// ticket B's channel wasn't subscribed, so nothing was published to it
+	assert.Empty(t, sentTo(ticketBChannel))
 }


### PR DESCRIPTION
Realtime history publishing now supports two channel forms, matching how the read API filters the same events when fetching from the history table:

- `history:<contact-uuid>` — a contact's whole history (contact read page)
- `history:<contact-uuid>:<ticket-uuid>` — the subset scoped to a single ticket (ticket read page)

`PublishToHistory` routes each event to the channel where it belongs so each lands on exactly one channel (no duplicates):

- The per-ticket detail events — `ticket_assignee_changed`, `ticket_note_added`, `ticket_topic_changed` — are the ones the read API filters off the contact page, so they go only to that ticket's channel (keyed by their `ticket_uuid`).
- Everything else — non-ticket events plus the basic ticket lifecycle events (`ticket_opened`/`closed`/`reopened`) — goes to the contact's channel.

The ticket read page subscribes to both its ticket channel and the contact channel, so the union it sees matches what the read API returns for that ticket.

Each channel keeps the existing behavior: publishing is best-effort and a no-op unless the channel has a live subscriber, batched into one pipelined request per channel. A commit with no per-ticket detail events makes no extra presence checks.