### PR TITLE
Publish notifications to realtime sockets

### DIFF
--- a/core/crons/end_incidents_test.go
+++ b/core/crons/end_incidents_test.go
@@ -44,14 +44,14 @@ func TestEndIncidents(t *testing.T) {
 	node1.Record(ctx, rt, createWebhookEvents(10, time.Second*30))
 
 	// create incident for org 1 based on node which is still unhealthy
-	id1, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa1, []flows.NodeUUID{"3c703019-8c92-4d28-9be0-a926a934486b"})
+	id1, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa1, []flows.NodeUUID{"3c703019-8c92-4d28-9be0-a926a934486b"})
 	require.NoError(t, err)
 
 	node2 := &models.WebhookNode{UUID: "07d69080-475b-4395-aa96-ea6c28ea6cb6"}
 	node2.Record(ctx, rt, createWebhookEvents(10, time.Second*1))
 
 	// create incident for org 2 based on node which is now healthy
-	id2, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa2, []flows.NodeUUID{"07d69080-475b-4395-aa96-ea6c28ea6cb6"})
+	id2, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa2, []flows.NodeUUID{"07d69080-475b-4395-aa96-ea6c28ea6cb6"})
 	require.NoError(t, err)
 
 	cron := &crons.EndIncidentsCron{}

--- a/core/models/import.go
+++ b/core/models/import.go
@@ -49,6 +49,7 @@ type ContactImport struct {
 	OrgID       OrgID           `json:"org_id"`
 	Status      ImportStatus    `json:"status"`
 	CreatedByID UserID          `json:"created_by_id"`
+	NumRecords  int             `json:"num_records"`
 	FinishedOn  *time.Time      `json:"finished_on"`
 
 	BatchIDs      []ContactImportBatchID `json:"batch_ids"`      // ordered
@@ -57,7 +58,7 @@ type ContactImport struct {
 
 var sqlLoadContactImport = `
 SELECT row_to_json(r) FROM (
-         SELECT i.id, i.org_id, i.status, i.created_by_id, i.finished_on, array_agg(b.id ORDER BY b.id) AS "batch_ids", array_agg(DISTINCT b.status) AS "batch_statuses"
+         SELECT i.id, i.org_id, i.status, i.created_by_id, i.num_records, i.finished_on, array_agg(b.id ORDER BY b.id) AS "batch_ids", array_agg(DISTINCT b.status) AS "batch_statuses"
            FROM contacts_contactimport i
 LEFT OUTER JOIN contacts_contactimportbatch b ON b.contact_import_id = i.id
           WHERE i.id = $1

--- a/core/models/incident.go
+++ b/core/models/incident.go
@@ -56,16 +56,17 @@ func (i *Incident) End(ctx context.Context, db DBorTx) error {
 	return nil
 }
 
-// IncidentWebhooksUnhealthy ensures there is an open unhealthy webhooks incident for the given org
-func IncidentWebhooksUnhealthy(ctx context.Context, db DBorTx, rp *valkey.Pool, oa *OrgAssets, nodes []flows.NodeUUID) (IncidentID, error) {
-	id, err := getOrCreateIncident(ctx, db, oa, &Incident{
+// IncidentWebhooksUnhealthy ensures there is an open unhealthy webhooks incident for the given org. It returns any
+// notifications created for a newly started incident so the caller can publish them once its transaction has committed.
+func IncidentWebhooksUnhealthy(ctx context.Context, db DBorTx, rp *valkey.Pool, oa *OrgAssets, nodes []flows.NodeUUID) (IncidentID, []*Notification, error) {
+	id, notifications, err := getOrCreateIncident(ctx, db, oa, &Incident{
 		OrgID:     oa.OrgID(),
 		Type:      IncidentTypeWebhooksUnhealthy,
 		StartedOn: dates.Now(),
 		Scope:     "",
 	})
 	if err != nil {
-		return NilIncidentID, err
+		return NilIncidentID, nil, err
 	}
 
 	if len(nodes) > 0 {
@@ -78,11 +79,11 @@ func IncidentWebhooksUnhealthy(ctx context.Context, db DBorTx, rp *valkey.Pool, 
 		vc.Send("EXPIRE", nodesKey, 60*30) // 30 minutes
 		_, err = vc.Do("EXEC")
 		if err != nil {
-			return NilIncidentID, fmt.Errorf("error adding node uuids to incident: %w", err)
+			return NilIncidentID, nil, fmt.Errorf("error adding node uuids to incident: %w", err)
 		}
 	}
 
-	return id, nil
+	return id, notifications, nil
 }
 
 const sqlInsertIncident = `
@@ -91,28 +92,30 @@ INSERT INTO notifications_incident(org_id, incident_type, scope, started_on, cha
 ON CONFLICT DO NOTHING 
   RETURNING id`
 
-func getOrCreateIncident(ctx context.Context, db DBorTx, oa *OrgAssets, incident *Incident) (IncidentID, error) {
+func getOrCreateIncident(ctx context.Context, db DBorTx, oa *OrgAssets, incident *Incident) (IncidentID, []*Notification, error) {
 	var incidentID IncidentID
 	err := db.GetContext(ctx, &incidentID, sqlInsertIncident, incident.OrgID, incident.Type, incident.Scope, incident.StartedOn, incident.ChannelID)
 	if err != nil && err != sql.ErrNoRows {
-		return NilIncidentID, fmt.Errorf("error inserting incident: %w", err)
+		return NilIncidentID, nil, fmt.Errorf("error inserting incident: %w", err)
 	}
 
 	// if we got back an id, a new incident was actually created
 	if incidentID != NilIncidentID {
 		incident.ID = incidentID
 
-		if err := NotifyIncidentStarted(ctx, db, oa, incident); err != nil {
-			return NilIncidentID, fmt.Errorf("error creating notifications for new incident: %w", err)
-		}
-	} else {
-		err := db.GetContext(ctx, &incidentID, `SELECT id FROM notifications_incident WHERE org_id = $1 AND incident_type = $2 AND scope = $3 AND ended_on IS NULL`, incident.OrgID, incident.Type, incident.Scope)
+		notifications, err := NotifyIncidentStarted(ctx, db, oa, incident)
 		if err != nil {
-			return NilIncidentID, fmt.Errorf("error looking up existing incident: %w", err)
+			return NilIncidentID, nil, fmt.Errorf("error creating notifications for new incident: %w", err)
 		}
+		return incidentID, notifications, nil
 	}
 
-	return incidentID, nil
+	err = db.GetContext(ctx, &incidentID, `SELECT id FROM notifications_incident WHERE org_id = $1 AND incident_type = $2 AND scope = $3 AND ended_on IS NULL`, incident.OrgID, incident.Type, incident.Scope)
+	if err != nil {
+		return NilIncidentID, nil, fmt.Errorf("error looking up existing incident: %w", err)
+	}
+
+	return incidentID, nil, nil
 }
 
 const sqlSelectOpenIncidents = `

--- a/core/models/incident_test.go
+++ b/core/models/incident_test.go
@@ -29,7 +29,7 @@ func TestIncidentWebhooksUnhealthy(t *testing.T) {
 
 	oa := testdb.Org1.Load(t, rt)
 
-	id1, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, []flows.NodeUUID{"5a2e83f1-efa8-40ba-bc0c-8873c525de7d", "aba89043-6f0a-4ccf-ba7f-0e1674b90759"})
+	id1, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, []flows.NodeUUID{"5a2e83f1-efa8-40ba-bc0c-8873c525de7d", "aba89043-6f0a-4ccf-ba7f-0e1674b90759"})
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, id1)
 
@@ -37,7 +37,7 @@ func TestIncidentWebhooksUnhealthy(t *testing.T) {
 	assertvk.SMembers(t, vc, fmt.Sprintf("incident:%d:nodes", id1), []string{"5a2e83f1-efa8-40ba-bc0c-8873c525de7d", "aba89043-6f0a-4ccf-ba7f-0e1674b90759"})
 
 	// raising same incident doesn't create a new one...
-	id2, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, []flows.NodeUUID{"3b1743cd-bd8b-449e-8e8a-11a3bc479766"})
+	id2, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, []flows.NodeUUID{"3b1743cd-bd8b-449e-8e8a-11a3bc479766"})
 	require.NoError(t, err)
 	assert.Equal(t, id1, id2)
 
@@ -48,7 +48,7 @@ func TestIncidentWebhooksUnhealthy(t *testing.T) {
 	// when the incident has ended, a new one can be created
 	rt.DB.MustExec(`UPDATE notifications_incident SET ended_on = NOW()`)
 
-	id3, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, nil)
+	id3, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, id1, id3)
 
@@ -65,7 +65,7 @@ func TestGetOpenIncidents(t *testing.T) {
 	oa2 := testdb.Org2.Load(t, rt)
 
 	// create incident for org 1
-	id1, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa1, nil)
+	id1, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa1, nil)
 	require.NoError(t, err)
 
 	incidents, err := models.GetOpenIncidents(ctx, rt.DB, []models.IncidentType{models.IncidentTypeWebhooksUnhealthy})
@@ -79,11 +79,11 @@ func TestGetOpenIncidents(t *testing.T) {
 	require.NoError(t, err)
 
 	// and create another one...
-	id2, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa1, nil)
+	id2, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa1, nil)
 	require.NoError(t, err)
 
 	// create an incident for org 2
-	id3, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa2, nil)
+	id3, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa2, nil)
 	require.NoError(t, err)
 
 	incidents, err = models.GetOpenIncidents(ctx, rt.DB, []models.IncidentType{models.IncidentTypeWebhooksUnhealthy})

--- a/core/models/notification.go
+++ b/core/models/notification.go
@@ -146,7 +146,7 @@ const sqlInsertNotification = `
 INSERT INTO notifications_notification(org_id,  notification_type,  scope,  user_id,  medium, is_seen,  email_status,  created_on,  contact_import_id,  incident_id)
                                VALUES(:org_id, :notification_type, :scope, :user_id, :medium,   FALSE, :email_status, :created_on, :contact_import_id, :incident_id)
                           ON CONFLICT DO NOTHING
-                            RETURNING id, user_id, notification_type, scope`
+                            RETURNING id, org_id, user_id, notification_type, scope`
 
 // InsertNotifications inserts the given notifications and returns those that were actually created. A notification
 // that would duplicate an existing unseen one (same org, type, scope and user) is dropped by the ON CONFLICT and not
@@ -178,13 +178,14 @@ func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notifi
 
 	byKey := make(map[string]*Notification, len(notifications))
 	for _, n := range notifications {
-		byKey[notificationKey(n.UserID, n.Type, n.Scope)] = n
+		byKey[notificationKey(n.OrgID, n.UserID, n.Type, n.Scope)] = n
 	}
 
 	inserted := make([]*Notification, 0, len(notifications))
 	for rows.Next() {
 		r := struct {
 			ID    NotificationID   `db:"id"`
+			Org   OrgID            `db:"org_id"`
 			User  UserID           `db:"user_id"`
 			Type  NotificationType `db:"notification_type"`
 			Scope string           `db:"scope"`
@@ -192,7 +193,7 @@ func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notifi
 		if err := rows.StructScan(&r); err != nil {
 			return nil, fmt.Errorf("error scanning inserted notification: %w", err)
 		}
-		if n := byKey[notificationKey(r.User, r.Type, r.Scope)]; n != nil {
+		if n := byKey[notificationKey(r.Org, r.User, r.Type, r.Scope)]; n != nil {
 			n.ID = r.ID
 			inserted = append(inserted, n)
 		}
@@ -204,10 +205,11 @@ func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notifi
 	return inserted, nil
 }
 
-// notificationKey identifies a notification within an insert batch by what the unseen-notification uniqueness is
-// scoped to, so a returned row can be matched back to the notification it was inserted from.
-func notificationKey(userID UserID, t NotificationType, scope string) string {
-	return fmt.Sprintf("%d|%s|%s", userID, t, scope)
+// notificationKey identifies a notification within an insert batch by what an unseen notification is unique on (the DB
+// index is on org, type, scope and user), so a returned row can be matched back to the notification it was inserted
+// from even if a batch ever spans more than one org.
+func notificationKey(orgID OrgID, userID UserID, t NotificationType, scope string) string {
+	return fmt.Sprintf("%d|%d|%s|%s", orgID, userID, t, scope)
 }
 
 // notificationPayload is the JSON shape published to a user's realtime notifications socket. It mirrors the

--- a/core/models/notification.go
+++ b/core/models/notification.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/dbutil"
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
@@ -143,24 +142,17 @@ func NewTicketActivityNotification(orgID OrgID, userID UserID) *Notification {
 }
 
 const sqlInsertNotification = `
-INSERT INTO notifications_notification(org_id,  notification_type,  scope,  user_id,  medium, is_seen,  email_status,  created_on,  contact_import_id,  incident_id)
-                               VALUES(:org_id, :notification_type, :scope, :user_id, :medium,   FALSE, :email_status, :created_on, :contact_import_id, :incident_id)
+INSERT INTO notifications_notification(org_id,  notification_type,  scope,  user_id,  medium, is_seen,  email_status, created_on,  contact_import_id,  incident_id)
+                               VALUES(:org_id, :notification_type, :scope, :user_id, :medium,   FALSE, :email_status,      NOW(), :contact_import_id, :incident_id)
                           ON CONFLICT DO NOTHING
-                            RETURNING id, org_id, user_id, notification_type, scope`
+                            RETURNING id, org_id, user_id, notification_type, scope, created_on`
 
 // InsertNotifications inserts the given notifications and returns those that were actually created. A notification
 // that would duplicate an existing unseen one (same org, type, scope and user) is dropped by the ON CONFLICT and not
-// returned. Each returned notification has its ID populated; all are stamped with the same CreatedOn.
+// returned. Each returned notification has its ID and CreatedOn populated from the inserted row.
 func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notification) ([]*Notification, error) {
 	if len(notifications) == 0 {
 		return nil, nil
-	}
-
-	now := dates.Now()
-	for _, n := range notifications {
-		if n.CreatedOn.IsZero() {
-			n.CreatedOn = now
-		}
 	}
 
 	// we can't use the bulk query helper here: ON CONFLICT DO NOTHING means fewer rows come back than we send, so we
@@ -184,17 +176,19 @@ func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notifi
 	inserted := make([]*Notification, 0, len(notifications))
 	for rows.Next() {
 		r := struct {
-			ID    NotificationID   `db:"id"`
-			Org   OrgID            `db:"org_id"`
-			User  UserID           `db:"user_id"`
-			Type  NotificationType `db:"notification_type"`
-			Scope string           `db:"scope"`
+			ID        NotificationID   `db:"id"`
+			Org       OrgID            `db:"org_id"`
+			User      UserID           `db:"user_id"`
+			Type      NotificationType `db:"notification_type"`
+			Scope     string           `db:"scope"`
+			CreatedOn time.Time        `db:"created_on"`
 		}{}
 		if err := rows.StructScan(&r); err != nil {
 			return nil, fmt.Errorf("error scanning inserted notification: %w", err)
 		}
 		if n := byKey[notificationKey(r.Org, r.User, r.Type, r.Scope)]; n != nil {
 			n.ID = r.ID
+			n.CreatedOn = r.CreatedOn
 			inserted = append(inserted, n)
 		}
 	}

--- a/core/models/notification.go
+++ b/core/models/notification.go
@@ -2,16 +2,23 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strconv"
 	"time"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/dbutil"
+	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
 // NotificationID is our type for notification ids
 type NotificationID int64
+
+// NilNotificationID is the zero value for notification ids
+const NilNotificationID = NotificationID(0)
 
 type NotificationType string
 
@@ -49,10 +56,16 @@ type Notification struct {
 
 	ContactImportID ContactImportID `db:"contact_import_id"`
 	IncidentID      IncidentID      `db:"incident_id"`
+
+	// transient context used to render the realtime socket payload, never persisted
+	contactImport *ContactImport
+	incident      *Incident
 }
 
-// NotifyImportFinished notifies the user who created an import that it has finished
-func NotifyImportFinished(ctx context.Context, db DBorTx, imp *ContactImport) error {
+// NotifyImportFinished notifies the user who created an import that it has finished, and publishes that notification
+// to the user's realtime socket. The import has already been committed (this runs outside any transaction) so the
+// notification is published as soon as it's created.
+func NotifyImportFinished(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, imp *ContactImport) error {
 	n := &Notification{
 		OrgID:           imp.OrgID,
 		Type:            NotificationTypeImportFinished,
@@ -61,13 +74,25 @@ func NotifyImportFinished(ctx context.Context, db DBorTx, imp *ContactImport) er
 		Medium:          MediumUI,
 		EmailStatus:     EmailStatusNone,
 		ContactImportID: imp.ID,
+		contactImport:   imp,
 	}
 
-	return InsertNotifications(ctx, db, []*Notification{n})
+	inserted, err := InsertNotifications(ctx, rt.DB, []*Notification{n})
+	if err != nil {
+		return err
+	}
+
+	// realtime delivery is best-effort - a publish failure shouldn't fail the import when the notification is persisted
+	if err := PublishNotifications(ctx, rt, oa, inserted); err != nil {
+		slog.Error("error publishing import finished notification", "error", err, "import_id", imp.ID)
+	}
+
+	return nil
 }
 
-// NotifyIncidentStarted notifies administrators that an incident has started
-func NotifyIncidentStarted(ctx context.Context, db DBorTx, oa *OrgAssets, incident *Incident) error {
+// NotifyIncidentStarted notifies administrators that an incident has started, returning the notifications that were
+// actually created so the caller can publish them once its transaction has committed.
+func NotifyIncidentStarted(ctx context.Context, db DBorTx, oa *OrgAssets, incident *Incident) ([]*Notification, error) {
 	admins := usersWithRoles(oa, []UserRole{UserRoleAdministrator})
 	notifications := make([]*Notification, len(admins))
 
@@ -80,6 +105,7 @@ func NotifyIncidentStarted(ctx context.Context, db DBorTx, oa *OrgAssets, incide
 			Medium:      MediumUI,
 			EmailStatus: EmailStatusNone,
 			IncidentID:  incident.ID,
+			incident:    incident,
 		}
 	}
 
@@ -117,15 +143,119 @@ func NewTicketActivityNotification(orgID OrgID, userID UserID) *Notification {
 }
 
 const sqlInsertNotification = `
-INSERT INTO notifications_notification(org_id,  notification_type,  scope,  user_id,  medium, is_seen,  email_status, created_on,  contact_import_id,  incident_id) 
-                               VALUES(:org_id, :notification_type, :scope, :user_id, :medium,   FALSE, :email_status,      NOW(), :contact_import_id, :incident_id) 
-							   ON CONFLICT DO NOTHING`
+INSERT INTO notifications_notification(org_id,  notification_type,  scope,  user_id,  medium, is_seen,  email_status,  created_on,  contact_import_id,  incident_id)
+                               VALUES(:org_id, :notification_type, :scope, :user_id, :medium,   FALSE, :email_status, :created_on, :contact_import_id, :incident_id)
+                          ON CONFLICT DO NOTHING
+                            RETURNING id, user_id, notification_type, scope`
 
-func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notification) error {
-	if err := dbutil.BulkQuery(ctx, db, sqlInsertNotification, notifications); err != nil {
-		return fmt.Errorf("error inserting notifications: %w", err)
+// InsertNotifications inserts the given notifications and returns those that were actually created. A notification
+// that would duplicate an existing unseen one (same org, type, scope and user) is dropped by the ON CONFLICT and not
+// returned. Each returned notification has its ID populated; all are stamped with the same CreatedOn.
+func InsertNotifications(ctx context.Context, db DBorTx, notifications []*Notification) ([]*Notification, error) {
+	if len(notifications) == 0 {
+		return nil, nil
 	}
-	return nil
+
+	now := dates.Now()
+	for _, n := range notifications {
+		if n.CreatedOn.IsZero() {
+			n.CreatedOn = now
+		}
+	}
+
+	// we can't use the bulk query helper here: ON CONFLICT DO NOTHING means fewer rows come back than we send, so we
+	// build the bulk insert ourselves and match each returned row to its notification by its unique key
+	sql, args, err := dbutil.BulkSQL(db, sqlInsertNotification, notifications)
+	if err != nil {
+		return nil, fmt.Errorf("error building notifications insert: %w", err)
+	}
+
+	rows, err := db.QueryxContext(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error inserting notifications: %w", err)
+	}
+	defer rows.Close()
+
+	byKey := make(map[string]*Notification, len(notifications))
+	for _, n := range notifications {
+		byKey[notificationKey(n.UserID, n.Type, n.Scope)] = n
+	}
+
+	inserted := make([]*Notification, 0, len(notifications))
+	for rows.Next() {
+		r := struct {
+			ID    NotificationID   `db:"id"`
+			User  UserID           `db:"user_id"`
+			Type  NotificationType `db:"notification_type"`
+			Scope string           `db:"scope"`
+		}{}
+		if err := rows.StructScan(&r); err != nil {
+			return nil, fmt.Errorf("error scanning inserted notification: %w", err)
+		}
+		if n := byKey[notificationKey(r.User, r.Type, r.Scope)]; n != nil {
+			n.ID = r.ID
+			inserted = append(inserted, n)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating inserted notifications: %w", err)
+	}
+
+	return inserted, nil
+}
+
+// notificationKey identifies a notification within an insert batch by what the unseen-notification uniqueness is
+// scoped to, so a returned row can be matched back to the notification it was inserted from.
+func notificationKey(userID UserID, t NotificationType, scope string) string {
+	return fmt.Sprintf("%d|%s|%s", userID, t, scope)
+}
+
+// notificationPayload is the JSON shape published to a user's realtime notifications socket. It mirrors the
+// representation the web API serves (see temba/notifications), so a client gets the same notification whether it
+// fetches the list or receives one live.
+type notificationPayload struct {
+	Type      NotificationType `json:"type"`
+	CreatedOn time.Time        `json:"created_on"`
+	URL       string           `json:"url"`
+	IsSeen    bool             `json:"is_seen"`
+
+	// at most one of these is set, depending on the notification type
+	Import   *importPayload   `json:"import,omitempty"`
+	Incident *incidentPayload `json:"incident,omitempty"`
+}
+
+type importPayload struct {
+	Type       string `json:"type"`
+	NumRecords int    `json:"num_records"`
+}
+
+type incidentPayload struct {
+	Type      IncidentType `json:"type"`
+	StartedOn time.Time    `json:"started_on"`
+	EndedOn   *time.Time   `json:"ended_on"`
+}
+
+// marshalForSocket renders the notification as the JSON published to its user's realtime socket.
+func (n *Notification) marshalForSocket() ([]byte, error) {
+	p := &notificationPayload{
+		Type:      n.Type,
+		CreatedOn: n.CreatedOn,
+		URL:       fmt.Sprintf("/notification/read/%d/", n.ID),
+		IsSeen:    n.IsSeen,
+	}
+
+	switch n.Type {
+	case NotificationTypeImportFinished:
+		if n.contactImport != nil {
+			p.Import = &importPayload{Type: "contact", NumRecords: n.contactImport.NumRecords}
+		}
+	case NotificationTypeIncidentStarted:
+		if n.incident != nil {
+			p.Incident = &incidentPayload{Type: n.incident.Type, StartedOn: n.incident.StartedOn, EndedOn: n.incident.EndedOn}
+		}
+	}
+
+	return json.Marshal(p)
 }
 
 func usersWithRoles(oa *OrgAssets, roles []UserRole) []*User {

--- a/core/models/notification_test.go
+++ b/core/models/notification_test.go
@@ -2,6 +2,8 @@ package models_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +18,18 @@ import (
 func TestImportNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	snapshot := recordCentrifugo(t, rt)
+
+	// mark the creator's notifications socket subscribed so the finished notification is published to it
+	vc := rt.VK.Get()
+	defer vc.Close()
+	_, err = vc.Do("SET", fmt.Sprintf("socket-subs:notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID), "1")
+	require.NoError(t, err)
 
 	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Editor)
 	imp, err := models.LoadContactImport(ctx, rt.DB, importID)
@@ -27,12 +40,23 @@ func TestImportNotifications(t *testing.T) {
 
 	t0 := time.Now()
 
-	err = models.NotifyImportFinished(ctx, rt.DB, imp)
+	err = models.NotifyImportFinished(ctx, rt, oa, imp)
 	require.NoError(t, err)
 
 	assertNotifications(t, ctx, rt.DB, t0, map[*testdb.User][]models.NotificationType{
 		testdb.Editor: {models.NotificationTypeImportFinished},
 	})
+
+	// the notification was also published to the creator's realtime socket as the same JSON the API would serve
+	sent := snapshot()
+	require.Len(t, sent, 1)
+	assert.Equal(t, fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID), sent[0].Channel)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(sent[0].Data, &decoded))
+	assert.Equal(t, "import:finished", decoded["type"])
+	assert.Equal(t, false, decoded["is_seen"])
+	assert.Equal(t, map[string]any{"type": "contact", "num_records": float64(30)}, decoded["import"])
 }
 
 func TestIncidentNotifications(t *testing.T) {
@@ -45,7 +69,7 @@ func TestIncidentNotifications(t *testing.T) {
 
 	t0 := time.Now()
 
-	_, err = models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, nil)
+	_, _, err = models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, nil)
 	require.NoError(t, err)
 
 	assertNotifications(t, ctx, rt.DB, t0, map[*testdb.User][]models.NotificationType{

--- a/core/models/org.go
+++ b/core/models/org.go
@@ -120,6 +120,9 @@ func (e *Environment) ObfuscationKey() [4]uint32 { return e.obfuscationKey }
 // ID returns the id of the org
 func (o *Org) ID() OrgID { return o.o.ID }
 
+// UUID returns the uuid of the org
+func (o *Org) UUID() OrgUUID { return o.o.UUID }
+
 // Name returns the name of the org
 func (o *Org) Name() string { return o.o.Name }
 

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/v26/runtime"
@@ -26,6 +28,91 @@ func HistorySocket(contactUUID flows.ContactUUID, ticketUUID ...flows.TicketUUID
 		return fmt.Sprintf("%s:%s:%s", SocketHistoryNamespace, contactUUID, ticketUUID[0])
 	}
 	return fmt.Sprintf("%s:%s", SocketHistoryNamespace, contactUUID)
+}
+
+// SocketNotificationsNamespace is the realtime pub/sub namespace for a user's notifications within a workspace. A
+// notification socket is addressed as "notifications:<org-uuid>:<user-uuid>". Like history sockets it's a client
+// subscription, authorized per-session by the subscribe proxy, which records the same "socket-subs:" presence key -
+// so mailroom only publishes to it when someone is watching.
+const SocketNotificationsNamespace = "notifications"
+
+// NotificationSocket returns the realtime pub/sub socket for a user's notifications within a workspace, addressed as
+// "notifications:<org-uuid>:<user-uuid>".
+func NotificationSocket(orgUUID OrgUUID, userUUID assets.UserUUID) string {
+	return fmt.Sprintf("%s:%s:%s", SocketNotificationsNamespace, orgUUID, userUUID)
+}
+
+// PublishNotifications publishes the given notifications to their users' notification sockets, each as the same JSON a
+// client would otherwise fetch from the notifications API. As with history, it's best-effort and a no-op for any
+// socket that currently has no subscribers; the sockets this commit touches are resolved in a single presence lookup,
+// then every subscribed socket's notifications are batched into one pipelined request so it costs one centrifugo
+// round-trip.
+func PublishNotifications(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, notifications []*Notification) error {
+	// the service always configures a Centrifugo client; this only guards contexts that don't start it (e.g. tests)
+	if len(notifications) == 0 || rt.Centrifugo == nil {
+		return nil
+	}
+
+	orgUUID := oa.Org().UUID()
+
+	// resolve each notification's socket up front, skipping any whose user we can't resolve
+	type pending struct {
+		socket string
+		n      *Notification
+	}
+	items := make([]pending, 0, len(notifications))
+	candidates := make([]string, 0, len(notifications))
+	for _, n := range notifications {
+		user := oa.UserByID(n.UserID)
+		if user == nil {
+			slog.Error("unable to publish notification for unknown user", "user_id", n.UserID, "org_id", n.OrgID)
+			continue
+		}
+
+		socket := NotificationSocket(orgUUID, user.UUID())
+		items = append(items, pending{socket, n})
+		candidates = append(candidates, socket)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	subscribed, err := SubscribedSockets(ctx, rt, candidates...)
+	if err != nil {
+		return err
+	}
+
+	pipe := rt.Centrifugo.Pipe()
+	var targets []string // the socket each pipelined publish targets, parallel to the replies for error reporting
+	for _, it := range items {
+		if !subscribed[it.socket] {
+			continue
+		}
+
+		data, err := it.n.marshalForSocket()
+		if err != nil {
+			return fmt.Errorf("error marshaling notification for %s: %w", it.socket, err)
+		}
+		if err := pipe.AddPublish(it.socket, data); err != nil {
+			return fmt.Errorf("error adding notification to publish pipe for %s: %w", it.socket, err)
+		}
+		targets = append(targets, it.socket)
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	replies, err := rt.Centrifugo.SendPipe(ctx, pipe)
+	if err != nil {
+		return fmt.Errorf("error publishing notifications: %w", err)
+	}
+	for i, reply := range replies {
+		if reply.Error != nil {
+			return fmt.Errorf("error publishing notification to %s: %w", targets[i], reply.Error)
+		}
+	}
+
+	return nil
 }
 
 // subscriptionKey is the valkey key marking that a realtime socket has at least one active subscriber, e.g.

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,10 +14,61 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// capturedPublish is one publish recorded by the fake centrifugo server.
+type capturedPublish struct {
+	Channel string          `json:"channel"`
+	Data    json.RawMessage `json:"data"`
+}
+
+// recordCentrifugo points rt.Centrifugo at a fake centrifugo API server that records what gets published to it,
+// returning a function that snapshots the publishes so far.
+func recordCentrifugo(t *testing.T, rt *runtime.Runtime) func() []capturedPublish {
+	var mu sync.Mutex
+	var published []capturedPublish
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// the gocent client sends newline-delimited publish commands and expects one reply per command
+		dec := json.NewDecoder(r.Body)
+		replies := 0
+		for {
+			var cmd struct {
+				Method string          `json:"method"`
+				Params capturedPublish `json:"params"`
+			}
+			if err := dec.Decode(&cmd); err == io.EOF {
+				break
+			} else if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if cmd.Method == "publish" {
+				mu.Lock()
+				published = append(published, cmd.Params)
+				mu.Unlock()
+			}
+			replies++
+		}
+		for range replies {
+			io.WriteString(w, `{"result":{}}`+"\n")
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	rt.Centrifugo = gocent.New(gocent.Config{Addr: srv.URL, Key: "sesame"})
+
+	return func() []capturedPublish {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]capturedPublish(nil), published...)
+	}
+}
 
 func TestHistorySocket(t *testing.T) {
 	contact := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
@@ -27,6 +79,77 @@ func TestHistorySocket(t *testing.T) {
 
 	// with a ticket it's that ticket's socket
 	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf:019905d4-5f7b-71b8-bcb8-6a68de2d91d2", models.HistorySocket(contact, ticket))
+}
+
+func TestNotificationSocket(t *testing.T) {
+	org := models.OrgUUID("bf0514a5-9407-44c9-b0f9-3f36f9c18414")
+	user := assets.UserUUID("ad9fdf9f-56ab-422a-b77d-e3ec26091a25")
+
+	assert.Equal(t, "notifications:bf0514a5-9407-44c9-b0f9-3f36f9c18414:ad9fdf9f-56ab-422a-b77d-e3ec26091a25", models.NotificationSocket(org, user))
+}
+
+func TestPublishNotifications(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	snapshot := recordCentrifugo(t, rt)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	adminSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Admin.UUID)
+
+	// no notifications is a no-op
+	require.NoError(t, models.PublishNotifications(ctx, rt, oa, nil))
+	assert.Empty(t, snapshot())
+
+	n := models.NewTicketsOpenedNotification(testdb.Org1.ID, testdb.Admin.ID)
+	inserted, err := models.InsertNotifications(ctx, rt.DB, []*models.Notification{n})
+	require.NoError(t, err)
+	require.Len(t, inserted, 1)
+
+	// the admin's socket isn't subscribed yet, so nothing is published
+	require.NoError(t, models.PublishNotifications(ctx, rt, oa, inserted))
+	assert.Empty(t, snapshot())
+
+	// mark the socket subscribed (as the authorizing service would) - now it publishes as the same JSON the API serves
+	_, err = vc.Do("SET", "socket-subs:"+adminSocket, "1")
+	require.NoError(t, err)
+
+	require.NoError(t, models.PublishNotifications(ctx, rt, oa, inserted))
+
+	sent := snapshot()
+	require.Len(t, sent, 1)
+	assert.Equal(t, adminSocket, sent[0].Channel)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(sent[0].Data, &decoded))
+	assert.Equal(t, "tickets:opened", decoded["type"])
+	assert.Equal(t, false, decoded["is_seen"])
+	assert.Equal(t, fmt.Sprintf("/notification/read/%d/", inserted[0].ID), decoded["url"])
+	assert.NotEmpty(t, decoded["created_on"])
+	assert.NotContains(t, decoded, "incident") // type-specific fields are omitted when not relevant
+
+	// an incident:started notification carries the incident detail
+	_, notifications, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, nil)
+	require.NoError(t, err)
+	require.Len(t, notifications, 1) // org1 has a single admin
+
+	require.NoError(t, models.PublishNotifications(ctx, rt, oa, notifications))
+
+	sent = snapshot()
+	require.Len(t, sent, 2)
+	assert.Equal(t, adminSocket, sent[1].Channel)
+	require.NoError(t, json.Unmarshal(sent[1].Data, &decoded))
+	assert.Equal(t, "incident:started", decoded["type"])
+	incident := decoded["incident"].(map[string]any)
+	assert.Equal(t, "webhooks:unhealthy", incident["type"])
+	assert.NotEmpty(t, incident["started_on"])
+	assert.Nil(t, incident["ended_on"])
 }
 
 func TestSubscribedSockets(t *testing.T) {

--- a/core/runner/hooks/insert_notifications.go
+++ b/core/runner/hooks/insert_notifications.go
@@ -3,8 +3,6 @@ package hooks
 import (
 	"context"
 	"fmt"
-	"maps"
-	"slices"
 
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
@@ -19,17 +17,38 @@ type insertNotifications struct{}
 func (h *insertNotifications) Order() int { return 10 }
 
 func (h *insertNotifications) Execute(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa *models.OrgAssets, scenes map[*runner.Scene][]any) error {
-	// de-dupe notifications by user, type and scope
-	notifications := make(map[string]*models.Notification)
-	for _, args := range scenes {
+	// de-dupe notifications by user, type and scope, remembering a scene to publish each from
+	type kept struct {
+		scene *runner.Scene
+		n     *models.Notification
+	}
+	deduped := make(map[string]kept)
+	for scene, args := range scenes {
 		for _, e := range args {
 			n := e.(*models.Notification)
-			notifications[fmt.Sprintf("%d|%s|%s", n.UserID, n.Type, n.Scope)] = n
+			deduped[fmt.Sprintf("%d|%s|%s", n.UserID, n.Type, n.Scope)] = kept{scene, n}
 		}
 	}
 
-	if err := models.InsertNotifications(ctx, tx, slices.Collect(maps.Values(notifications))); err != nil {
+	notifications := make([]*models.Notification, 0, len(deduped))
+	for _, k := range deduped {
+		notifications = append(notifications, k.n)
+	}
+
+	inserted, err := models.InsertNotifications(ctx, tx, notifications)
+	if err != nil {
 		return fmt.Errorf("error inserting notifications: %w", err)
+	}
+
+	// record each newly created notification on its scene so it gets published once the commit succeeds
+	insertedSet := make(map[*models.Notification]bool, len(inserted))
+	for _, n := range inserted {
+		insertedSet[n] = true
+	}
+	for _, k := range deduped {
+		if insertedSet[k.n] {
+			k.scene.AddNotifications(k.n)
+		}
 	}
 
 	return nil

--- a/core/runner/hooks/monitor_webhooks.go
+++ b/core/runner/hooks/monitor_webhooks.go
@@ -54,9 +54,18 @@ func (h *monitorWebhooks) Execute(ctx context.Context, rt *runtime.Runtime, tx *
 
 	// if we have unhealthy nodes, ensure we have an incident
 	if len(unhealthyNodeUUIDs) > 0 {
-		_, err := models.IncidentWebhooksUnhealthy(ctx, tx, rt.VK, oa, unhealthyNodeUUIDs)
+		_, notifications, err := models.IncidentWebhooksUnhealthy(ctx, tx, rt.VK, oa, unhealthyNodeUUIDs)
 		if err != nil {
 			return fmt.Errorf("error creating unhealthy webhooks incident: %w", err)
+		}
+
+		// record any notifications for a newly started incident on a scene so they're published after commit. The
+		// incident is workspace-level rather than tied to any one contact, so any of this commit's scenes will do.
+		if len(notifications) > 0 {
+			for scene := range scenes {
+				scene.AddNotifications(notifications...)
+				break
+			}
 		}
 	}
 

--- a/core/runner/hooks/monitor_webhooks.go
+++ b/core/runner/hooks/monitor_webhooks.go
@@ -59,13 +59,11 @@ func (h *monitorWebhooks) Execute(ctx context.Context, rt *runtime.Runtime, tx *
 			return fmt.Errorf("error creating unhealthy webhooks incident: %w", err)
 		}
 
-		// record any notifications for a newly started incident on a scene so they're published after commit. The
-		// incident is workspace-level rather than tied to any one contact, so any of this commit's scenes will do.
-		if len(notifications) > 0 {
-			for scene := range scenes {
-				scene.AddNotifications(notifications...)
-				break
-			}
+		// record any notifications for a newly started incident so they're published after commit. The incident is
+		// workspace-level rather than tied to any one contact, so we record them on every scene in this commit - the
+		// post-commit gather de-dupes, and this way they survive as long as any one scene commits.
+		for scene := range scenes {
+			scene.AddNotifications(notifications...)
 		}
 	}
 

--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -47,6 +47,7 @@ type Scene struct {
 	postCommits   map[PostCommitHook][]any
 	rawEvents     []flows.Event
 	persistEvents []*models.Event
+	notifications []*models.Notification
 
 	// can be overridden by tests
 	Engine func(*runtime.Runtime) flows.Engine
@@ -271,6 +272,13 @@ func (s *Scene) AttachPostCommitHook(hook PostCommitHook, item any) {
 	s.postCommits[hook] = append(s.postCommits[hook], item)
 }
 
+// AddNotifications records notifications created while committing this scene so they can be published to their users'
+// realtime sockets once the commit succeeds. The pre-commit insert populates each notification's id in place, so the
+// same pointer recorded here carries the persisted id by the time it's published.
+func (s *Scene) AddNotifications(notifications ...*models.Notification) {
+	s.notifications = append(s.notifications, notifications...)
+}
+
 // Commit commits this scene's events
 func (s *Scene) Commit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
 	return BulkCommit(ctx, rt, oa, []*Scene{s})
@@ -424,6 +432,32 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 	}
 
 	slog.Debug("events queued to history writer", "count", eventsWritten)
+
+	// publish any notifications created while committing to their users' realtime sockets - best-effort, like history,
+	// and done after commit so we never publish a notification that was rolled back. Gathered across all scenes into a
+	// single centrifugo round-trip and de-duped by what an unseen notification is unique on (org, user, type, scope),
+	// keeping the highest id: a retried scene re-creates its notifications, so without this a rolled-back duplicate
+	// from the failed attempt could be published alongside the committed one.
+	latest := make(map[string]*models.Notification)
+	var order []string
+	for _, scene := range scenes {
+		for _, n := range scene.notifications {
+			key := fmt.Sprintf("%d|%d|%s|%s", n.OrgID, n.UserID, n.Type, n.Scope)
+			if prev, seen := latest[key]; !seen {
+				order = append(order, key)
+				latest[key] = n
+			} else if n.ID > prev.ID {
+				latest[key] = n
+			}
+		}
+	}
+	notifications := make([]*models.Notification, len(order))
+	for i, key := range order {
+		notifications[i] = latest[key]
+	}
+	if err := models.PublishNotifications(ctx, rt, oa, notifications); err != nil {
+		slog.Error("error publishing notifications", "error", err)
+	}
 
 	if err := ExecutePostCommitHooks(ctx, rt, oa, scenes); err != nil {
 		return fmt.Errorf("error processing post commit hooks: %w", err)

--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -422,9 +422,10 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 	}
 
 	// send events to be persisted to the history table writer, and publish them to any live subscribers of the
-	// contact's history channel
+	// contact's history channel - only for scenes that actually committed, so a rolled-back scene's events never reach
+	// the history table or its live subscribers
 	eventsWritten := 0
-	for _, scene := range scenes {
+	for _, scene := range committed {
 		evts := make([]flows.Event, len(scene.persistEvents))
 		for i, evt := range scene.persistEvents {
 			if _, err := rt.Dynamo.History.Queue(evt); err != nil {
@@ -470,7 +471,9 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 		slog.Error("error publishing notifications", "error", err)
 	}
 
-	if err := ExecutePostCommitHooks(ctx, rt, oa, scenes); err != nil {
+	// likewise only run post-commit hooks (sending messages, queuing tasks, search indexing) for scenes that committed
+	// - a rolled-back scene has no persisted rows for them to act on
+	if err := ExecutePostCommitHooks(ctx, rt, oa, committed); err != nil {
 		return fmt.Errorf("error processing post commit hooks: %w", err)
 	}
 

--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -421,10 +421,15 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 		}
 	}
 
-	// send events to be persisted to the history table writer, and publish them to any live subscribers of the
-	// contact's history channel - only for scenes that actually committed, so a rolled-back scene's events never reach
-	// the history table or its live subscribers
+	// do the realtime post-commit work for the scenes that actually committed, so a rolled-back scene's events never
+	// reach the history table or its live subscribers and its notifications are never delivered: persist each scene's
+	// events to the history table writer and publish them to the contact's history socket, and gather its notifications
+	// to publish. Notifications are de-duped by what an unseen notification is unique on (org, user, type, scope) since
+	// the same one can be recorded on several scenes (e.g. a workspace incident), taking the highest id as a tiebreak.
 	eventsWritten := 0
+	latest := make(map[string]*models.Notification)
+	var order []string
+
 	for _, scene := range committed {
 		evts := make([]flows.Event, len(scene.persistEvents))
 		for i, evt := range scene.persistEvents {
@@ -441,18 +446,7 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 		}
 
 		eventsWritten += len(scene.persistEvents)
-	}
 
-	slog.Debug("events queued to history writer", "count", eventsWritten)
-
-	// publish any notifications created while committing to their users' realtime sockets - best-effort, like history,
-	// and only after commit so a rolled-back notification is never delivered. Gathered from the scenes that actually
-	// committed into a single centrifugo round-trip and de-duped by what an unseen notification is unique on (org,
-	// user, type, scope) - the same notification can be recorded on several scenes (e.g. a workspace incident) - taking
-	// the highest id as a tiebreak.
-	latest := make(map[string]*models.Notification)
-	var order []string
-	for _, scene := range committed {
 		for _, n := range scene.notifications {
 			key := fmt.Sprintf("%d|%d|%s|%s", n.OrgID, n.UserID, n.Type, n.Scope)
 			if prev, seen := latest[key]; !seen {
@@ -463,6 +457,10 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 			}
 		}
 	}
+
+	slog.Debug("events queued to history writer", "count", eventsWritten)
+
+	// publish the gathered notifications in a single centrifugo round-trip - best-effort, like history
 	notifications := make([]*models.Notification, len(order))
 	for i, key := range order {
 		notifications[i] = latest[key]

--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -382,6 +382,10 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 		return fmt.Errorf("error executing scene pre commit hooks: %w", err)
 	}
 
+	// the scenes that actually committed - all of them on the happy path, or just those whose individual retry
+	// succeeded - so post-commit work (notification publishing) doesn't act on rolled-back changes
+	committed := scenes
+
 	if err := tx.Commit(); err != nil {
 		// retry committing our scenes one at a time
 		slog.Debug("failed committing scenes in bulk, retrying one at a time", "error", err)
@@ -389,6 +393,7 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 		tx.Rollback()
 
 		// we failed committing the scenes in one go, try one at a time
+		committed = make([]*Scene, 0, len(scenes))
 		for _, scene := range scenes {
 			txCTX, cancel := context.WithTimeout(ctx, commitTimeout)
 			defer cancel()
@@ -397,6 +402,10 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 			if err != nil {
 				return fmt.Errorf("error starting transaction for retry: %w", err)
 			}
+
+			// this attempt re-runs the pre-commit hooks, which re-record this scene's notifications, so clear the
+			// rolled-back bulk attempt's first - otherwise we'd publish a notification whose row no longer exists
+			scene.notifications = nil
 
 			if err := ExecutePreCommitHooks(ctx, rt, tx, oa, []*Scene{scene}); err != nil {
 				return fmt.Errorf("error applying scene pre commit hooks: %w", err)
@@ -407,6 +416,8 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 				slog.Error("error committing scene", "error", err, "contact", scene.ContactUUID())
 				continue
 			}
+
+			committed = append(committed, scene)
 		}
 	}
 
@@ -434,13 +445,13 @@ func BulkCommit(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, 
 	slog.Debug("events queued to history writer", "count", eventsWritten)
 
 	// publish any notifications created while committing to their users' realtime sockets - best-effort, like history,
-	// and done after commit so we never publish a notification that was rolled back. Gathered across all scenes into a
-	// single centrifugo round-trip and de-duped by what an unseen notification is unique on (org, user, type, scope),
-	// keeping the highest id: a retried scene re-creates its notifications, so without this a rolled-back duplicate
-	// from the failed attempt could be published alongside the committed one.
+	// and only after commit so a rolled-back notification is never delivered. Gathered from the scenes that actually
+	// committed into a single centrifugo round-trip and de-duped by what an unseen notification is unique on (org,
+	// user, type, scope) - the same notification can be recorded on several scenes (e.g. a workspace incident) - taking
+	// the highest id as a tiebreak.
 	latest := make(map[string]*models.Notification)
 	var order []string
-	for _, scene := range scenes {
+	for _, scene := range committed {
 		for _, n := range scene.notifications {
 			key := fmt.Sprintf("%d|%d|%s|%s", n.OrgID, n.UserID, n.Type, n.Scope)
 			if prev, seen := latest[key]; !seen {

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -1,10 +1,16 @@
 package runner_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/centrifugal/gocent/v3"
 	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
@@ -18,6 +24,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/runner/hooks"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
@@ -214,6 +221,81 @@ func TestSessionWithSubflows(t *testing.T) {
 
 	// check we have no contact fires for wait expiration or timeout
 	testsuite.AssertContactFires(t, rt, testdb.Ann.ID, map[string]time.Time{})
+}
+
+func TestBulkCommitPublishesNotifications(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	// a fake centrifugo API server that records what gets published to it
+	type publish struct {
+		Channel string          `json:"channel"`
+		Data    json.RawMessage `json:"data"`
+	}
+	var mu sync.Mutex
+	var published []publish
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dec := json.NewDecoder(r.Body)
+		replies := 0
+		for {
+			var cmd struct {
+				Method string  `json:"method"`
+				Params publish `json:"params"`
+			}
+			if err := dec.Decode(&cmd); err == io.EOF {
+				break
+			} else if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if cmd.Method == "publish" {
+				mu.Lock()
+				published = append(published, cmd.Params)
+				mu.Unlock()
+			}
+			replies++
+		}
+		for range replies {
+			io.WriteString(w, `{"result":{}}`+"\n")
+		}
+	}))
+	defer srv.Close()
+	rt.Centrifugo = gocent.New(gocent.Config{Addr: srv.URL, Key: "sesame"})
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	// only the editor is watching their notifications socket
+	editorSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID)
+	_, err = vc.Do("SET", "socket-subs:"+editorSocket, "1")
+	require.NoError(t, err)
+
+	// commit a scene that creates a tickets:opened notification for each of the admin and editor, attaching them the
+	// same way the ticket-opened handler does
+	mc, contact, _ := testdb.Ann.Load(t, rt, oa)
+	scene := runner.NewScene(mc, contact)
+	scene.AttachPreCommitHook(hooks.InsertNotifications, models.NewTicketsOpenedNotification(oa.OrgID(), testdb.Admin.ID))
+	scene.AttachPreCommitHook(hooks.InsertNotifications, models.NewTicketsOpenedNotification(oa.OrgID(), testdb.Editor.ID))
+
+	require.NoError(t, runner.BulkCommit(ctx, rt, oa, []*runner.Scene{scene}))
+
+	// both notifications were persisted
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM notifications_notification WHERE notification_type = 'tickets:opened'`).Returns(2)
+
+	// but only the editor's subscribed socket received a realtime publish
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, published, 1)
+	assert.Equal(t, editorSocket, published[0].Channel)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(published[0].Data, &decoded))
+	assert.Equal(t, "tickets:opened", decoded["type"])
+	assert.Equal(t, false, decoded["is_seen"])
 }
 
 func TestSessionFailedStart(t *testing.T) {

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -69,7 +69,7 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 			return fmt.Errorf("error marking import as finished: %w", err)
 		}
 
-		if err := models.NotifyImportFinished(ctx, rt.DB, imp); err != nil {
+		if err := models.NotifyImportFinished(ctx, rt, oa, imp); err != nil {
 			return fmt.Errorf("error creating import finished notification: %w", err)
 		}
 	}


### PR DESCRIPTION
## What

Publish each notification mailroom creates to its user's realtime socket `notifications:<org-uuid>:<user-uuid>`, as the same JSON the web API serves for that notification — so a client gets the same shape whether it fetches the list or receives one live:

```json
{ "type": "...", "created_on": "...", "url": "/notification/read/<id>/", "is_seen": false }
```

plus the type-specific block (`import: {type, num_records}`, `incident: {type, started_on, ended_on}`). The four types mailroom creates are covered: `tickets:opened`, `tickets:activity`, `import:finished`, `incident:started`.

## How

- `PublishNotifications` mirrors `PublishToHistory`: best-effort, gated on the `socket-subs:` presence key the subscribe proxy records, and batched into a single centrifugo round-trip per commit. The notifications channel is a client subscription with the same presence contract as history.
- Delivery is **post-commit** for the scene-based paths (tickets, webhook incidents): notifications ride on the scene like persisted events and are published in `BulkCommit` after the transaction commits, so a rolled-back notification is never delivered. The gather draws only from scenes that actually committed, and a scene's recorded notifications are reset before each retry so a rolled-back attempt's notification isn't published; results are de-duped by `(org, user, type, scope)`. Imports publish inline since they're committed outside any transaction.
- `InsertNotifications` now returns the notifications **actually** created. `ON CONFLICT DO NOTHING` drops duplicate-unseen ones, so the bulk insert is built with `RETURNING` and rows matched back by their unique key — `(org, user, type, scope)`, matching the DB index. `created_on` is stamped app-side so the published payload matches the persisted row.
- Adds `Org.UUID()`, `ContactImport.NumRecords`, and a `NotificationSocket()` helper.

## Notes for reviewers

- Pairs with the realtime server making the notifications channel a client subscription that records the `socket-subs:` key. The publisher contract is `EXISTS socket-subs:notifications:<org-uuid>:<user-uuid>`; the `NotificationSocket` format must stay in sync with it.
- `PublishNotifications` no-ops when no Centrifugo client is configured, which only happens in contexts that don't start the service (e.g. tests); the service always configures one.

## Testing

- `TestNotificationSocket`, `TestPublishNotifications` (presence gate both ways; tickets + incident payloads), `TestImportNotifications` (asserts the published `import:finished` payload), and `TestBulkCommitPublishesNotifications` — an end-to-end test driving `tickets:opened` notifications through `BulkCommit`, asserting the presence gate and scene-path delivery.
- `go vet ./...` clean; `core/models`, `core/runner/...`, `core/tasks/...`, `core/crons` all pass.