### PR TITLE
Run a real Centrifugo in tests instead of mocking it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,21 @@ jobs:
           SERVICES: s3,dynamodb,cloudwatch
         ports:
           - 4566:4566
+      centrifugo:
+        image: centrifugo/centrifugo:v6.8.3
+        env:
+          # API served on the internal port at /ws/api, matching the dev compose so the test config is identical
+          CENTRIFUGO_HTTP_SERVER_INTERNAL_PORT: 9000
+          CENTRIFUGO_HTTP_API_HANDLER_PREFIX: /ws/api
+          CENTRIFUGO_HTTP_API_KEY: dev-api-key
+          CENTRIFUGO_HEALTH_ENABLED: true
+          # redis engine on valkey DB 6 so the test suite can clear channel history by flushing that DB
+          CENTRIFUGO_ENGINE_TYPE: redis
+          CENTRIFUGO_ENGINE_REDIS_ADDRESS: redis://valkey:6379/6
+          # history on the namespaces the suite reads back from (production keeps its own no-history config)
+          CENTRIFUGO_CHANNEL_NAMESPACES: '[{"name":"notifications","history_size":100,"history_ttl":"300s"},{"name":"history","history_size":100,"history_ttl":"300s"}]'
+        ports:
+          - 9000:9000
 
     steps:
       - name: Checkout code
@@ -46,6 +61,14 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | tee /etc/apt/trusted.gpg.d/postgresql.asc > /dev/null
           apt-get update
           apt-get install -y --no-install-recommends postgresql-client-15
+
+      - name: Wait for Centrifugo
+        run: |
+          for i in $(seq 1 30); do
+            if wget -q -O /dev/null http://centrifugo:9000/health; then echo "centrifugo ready"; exit 0; fi
+            sleep 1
+          done
+          echo "centrifugo did not become ready" >&2; exit 1
 
       - name: Initialize database
         # we create our test database with a different user so that we can drop everything owned by this user between tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           CENTRIFUGO_HTTP_SERVER_INTERNAL_PORT: 9000
           CENTRIFUGO_HTTP_API_HANDLER_PREFIX: /ws/api
           CENTRIFUGO_HTTP_API_KEY: dev-api-key
-          CENTRIFUGO_HEALTH_ENABLED: true
           # redis engine on valkey DB 6 so the test suite can clear channel history by flushing that DB
           CENTRIFUGO_ENGINE_TYPE: redis
           CENTRIFUGO_ENGINE_REDIS_ADDRESS: redis://valkey:6379/6
@@ -61,14 +60,6 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | tee /etc/apt/trusted.gpg.d/postgresql.asc > /dev/null
           apt-get update
           apt-get install -y --no-install-recommends postgresql-client-15
-
-      - name: Wait for Centrifugo
-        run: |
-          for i in $(seq 1 30); do
-            if wget -q -O /dev/null http://centrifugo:9000/health; then echo "centrifugo ready"; exit 0; fi
-            sleep 1
-          done
-          echo "centrifugo did not become ready" >&2; exit 1
 
       - name: Initialize database
         # we create our test database with a different user so that we can drop everything owned by this user between tests

--- a/core/models/notification_test.go
+++ b/core/models/notification_test.go
@@ -18,17 +18,17 @@ import (
 func TestImportNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetCentrifugo)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
-	snapshot := recordCentrifugo(t, rt)
+	editorSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID)
 
 	// mark the creator's notifications socket subscribed so the finished notification is published to it
 	vc := rt.VK.Get()
 	defer vc.Close()
-	_, err = vc.Do("SET", fmt.Sprintf("socket-subs:notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID), "1")
+	_, err = vc.Do("SET", "socket-subs:"+editorSocket, "1")
 	require.NoError(t, err)
 
 	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Editor)
@@ -48,12 +48,11 @@ func TestImportNotifications(t *testing.T) {
 	})
 
 	// the notification was also published to the creator's realtime socket as the same JSON the API would serve
-	sent := snapshot()
+	sent := testsuite.CentrifugoHistory(t, rt, editorSocket)
 	require.Len(t, sent, 1)
-	assert.Equal(t, fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID), sent[0].Channel)
 
 	var decoded map[string]any
-	require.NoError(t, json.Unmarshal(sent[0].Data, &decoded))
+	require.NoError(t, json.Unmarshal(sent[0], &decoded))
 	assert.Equal(t, "import:finished", decoded["type"])
 	assert.Equal(t, false, decoded["is_seen"])
 	assert.Equal(t, map[string]any{"type": "contact", "num_records": float64(30)}, decoded["import"])

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -48,8 +48,7 @@ func NotificationSocket(orgUUID OrgUUID, userUUID assets.UserUUID) string {
 // then every subscribed socket's notifications are batched into one pipelined request so it costs one centrifugo
 // round-trip.
 func PublishNotifications(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, notifications []*Notification) error {
-	// the service always configures a Centrifugo client; this only guards contexts that don't start it (e.g. tests)
-	if len(notifications) == 0 || rt.Centrifugo == nil {
+	if len(notifications) == 0 {
 		return nil
 	}
 

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -14,61 +14,11 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/v26/core/models"
-	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// capturedPublish is one publish recorded by the fake centrifugo server.
-type capturedPublish struct {
-	Channel string          `json:"channel"`
-	Data    json.RawMessage `json:"data"`
-}
-
-// recordCentrifugo points rt.Centrifugo at a fake centrifugo API server that records what gets published to it,
-// returning a function that snapshots the publishes so far.
-func recordCentrifugo(t *testing.T, rt *runtime.Runtime) func() []capturedPublish {
-	var mu sync.Mutex
-	var published []capturedPublish
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// the gocent client sends newline-delimited publish commands and expects one reply per command
-		dec := json.NewDecoder(r.Body)
-		replies := 0
-		for {
-			var cmd struct {
-				Method string          `json:"method"`
-				Params capturedPublish `json:"params"`
-			}
-			if err := dec.Decode(&cmd); err == io.EOF {
-				break
-			} else if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			if cmd.Method == "publish" {
-				mu.Lock()
-				published = append(published, cmd.Params)
-				mu.Unlock()
-			}
-			replies++
-		}
-		for range replies {
-			io.WriteString(w, `{"result":{}}`+"\n")
-		}
-	}))
-	t.Cleanup(srv.Close)
-
-	rt.Centrifugo = gocent.New(gocent.Config{Addr: srv.URL, Key: "sesame"})
-
-	return func() []capturedPublish {
-		mu.Lock()
-		defer mu.Unlock()
-		return append([]capturedPublish(nil), published...)
-	}
-}
 
 func TestHistorySocket(t *testing.T) {
 	contact := flows.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
@@ -91,12 +41,10 @@ func TestNotificationSocket(t *testing.T) {
 func TestPublishNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetCentrifugo)
 
 	vc := rt.VK.Get()
 	defer vc.Close()
-
-	snapshot := recordCentrifugo(t, rt)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -105,7 +53,7 @@ func TestPublishNotifications(t *testing.T) {
 
 	// no notifications is a no-op
 	require.NoError(t, models.PublishNotifications(ctx, rt, oa, nil))
-	assert.Empty(t, snapshot())
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
 
 	n := models.NewTicketsOpenedNotification(testdb.Org1.ID, testdb.Admin.ID)
 	inserted, err := models.InsertNotifications(ctx, rt.DB, []*models.Notification{n})
@@ -114,7 +62,7 @@ func TestPublishNotifications(t *testing.T) {
 
 	// the admin's socket isn't subscribed yet, so nothing is published
 	require.NoError(t, models.PublishNotifications(ctx, rt, oa, inserted))
-	assert.Empty(t, snapshot())
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
 
 	// mark the socket subscribed (as the authorizing service would) - now it publishes as the same JSON the API serves
 	_, err = vc.Do("SET", "socket-subs:"+adminSocket, "1")
@@ -122,12 +70,11 @@ func TestPublishNotifications(t *testing.T) {
 
 	require.NoError(t, models.PublishNotifications(ctx, rt, oa, inserted))
 
-	sent := snapshot()
+	sent := testsuite.CentrifugoHistory(t, rt, adminSocket)
 	require.Len(t, sent, 1)
-	assert.Equal(t, adminSocket, sent[0].Channel)
 
 	var decoded map[string]any
-	require.NoError(t, json.Unmarshal(sent[0].Data, &decoded))
+	require.NoError(t, json.Unmarshal(sent[0], &decoded))
 	assert.Equal(t, "tickets:opened", decoded["type"])
 	assert.Equal(t, false, decoded["is_seen"])
 	assert.Equal(t, fmt.Sprintf("/notification/read/%d/", inserted[0].ID), decoded["url"])
@@ -141,10 +88,9 @@ func TestPublishNotifications(t *testing.T) {
 
 	require.NoError(t, models.PublishNotifications(ctx, rt, oa, notifications))
 
-	sent = snapshot()
+	sent = testsuite.CentrifugoHistory(t, rt, adminSocket)
 	require.Len(t, sent, 2)
-	assert.Equal(t, adminSocket, sent[1].Channel)
-	require.NoError(t, json.Unmarshal(sent[1].Data, &decoded))
+	require.NoError(t, json.Unmarshal(sent[1], &decoded))
 	assert.Equal(t, "incident:started", decoded["type"])
 	incident := decoded["incident"].(map[string]any)
 	assert.Equal(t, "webhooks:unhealthy", incident["type"])

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -3,14 +3,9 @@ package runner_test
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/centrifugal/gocent/v3"
 	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
@@ -226,50 +221,16 @@ func TestSessionWithSubflows(t *testing.T) {
 func TestBulkCommitPublishesNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetCentrifugo)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
-
-	// a fake centrifugo API server that records what gets published to it
-	type publish struct {
-		Channel string          `json:"channel"`
-		Data    json.RawMessage `json:"data"`
-	}
-	var mu sync.Mutex
-	var published []publish
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		dec := json.NewDecoder(r.Body)
-		replies := 0
-		for {
-			var cmd struct {
-				Method string  `json:"method"`
-				Params publish `json:"params"`
-			}
-			if err := dec.Decode(&cmd); err == io.EOF {
-				break
-			} else if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			if cmd.Method == "publish" {
-				mu.Lock()
-				published = append(published, cmd.Params)
-				mu.Unlock()
-			}
-			replies++
-		}
-		for range replies {
-			io.WriteString(w, `{"result":{}}`+"\n")
-		}
-	}))
-	defer srv.Close()
-	rt.Centrifugo = gocent.New(gocent.Config{Addr: srv.URL, Key: "sesame"})
 
 	vc := rt.VK.Get()
 	defer vc.Close()
 
 	// only the editor is watching their notifications socket
+	adminSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Admin.UUID)
 	editorSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Editor.UUID)
 	_, err = vc.Do("SET", "socket-subs:"+editorSocket, "1")
 	require.NoError(t, err)
@@ -286,14 +247,15 @@ func TestBulkCommitPublishesNotifications(t *testing.T) {
 	// both notifications were persisted
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM notifications_notification WHERE notification_type = 'tickets:opened'`).Returns(2)
 
-	// but only the editor's subscribed socket received a realtime publish
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, published, 1)
-	assert.Equal(t, editorSocket, published[0].Channel)
+	// the admin isn't watching, so nothing was published to their socket
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
+
+	// but the editor's subscribed socket received the realtime publish, as the same JSON the API serves
+	sent := testsuite.CentrifugoHistory(t, rt, editorSocket)
+	require.Len(t, sent, 1)
 
 	var decoded map[string]any
-	require.NoError(t, json.Unmarshal(published[0].Data, &decoded))
+	require.NoError(t, json.Unmarshal(sent[0], &decoded))
 	assert.Equal(t, "tickets:opened", decoded["type"])
 	assert.Equal(t, false, decoded["is_seen"])
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -91,6 +91,8 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 		return nil, fmt.Errorf("error creating Cloudwatch service: %w", err)
 	}
 
+	rt.Centrifugo = gocent.New(gocent.Config{Addr: cfg.CentrifugoEndpoint, Key: cfg.CentrifugoKey})
+
 	rt.Queues = newQueues(cfg)
 	rt.Stats = NewStatsCollector(rt.VK, cfg.LatencyExcludedOrgs)
 	rt.HTTP = newHTTP(cfg)

--- a/service.go
+++ b/service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/appleboy/go-fcm"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
-	"github.com/centrifugal/gocent/v3"
 	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/gocommon/aws/cwatch"
 	"github.com/nyaruka/gocommon/aws/dynamo"
@@ -122,12 +121,7 @@ func (s *Service) Start() error {
 		log.Warn("fcm not configured, no android syncing")
 	}
 
-	s.rt.Centrifugo = gocent.New(gocent.Config{
-		Addr: c.CentrifugoEndpoint,
-		Key:  c.CentrifugoKey,
-	})
-
-	// test Centrifugo - its info API confirms both that the server is reachable and that our API key is accepted
+	// the Centrifugo client is built by the runtime; confirm here that the server is reachable and accepts our key
 	if _, err := s.rt.Centrifugo.Info(s.ctx); err != nil {
 		log.Error("centrifugo not reachable", "error", err)
 	} else {

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -2,6 +2,7 @@ package testsuite
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/centrifugal/gocent/v3"
+	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/mailroom/v26/core/goflow"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -28,14 +31,15 @@ type ResetFlag int
 
 // refresh bit masks
 const (
-	ResetNone    = ResetFlag(0)
-	ResetAll     = ResetFlag(^0)
-	ResetDB      = ResetFlag(1 << 1)
-	ResetData    = ResetFlag(1 << 2)
-	ResetValkey  = ResetFlag(1 << 3)
-	ResetStorage = ResetFlag(1 << 4)
-	ResetDynamo  = ResetFlag(1 << 5)
-	ResetElastic = ResetFlag(1 << 6)
+	ResetNone       = ResetFlag(0)
+	ResetAll        = ResetFlag(^0)
+	ResetDB         = ResetFlag(1 << 1)
+	ResetData       = ResetFlag(1 << 2)
+	ResetValkey     = ResetFlag(1 << 3)
+	ResetStorage    = ResetFlag(1 << 4)
+	ResetDynamo     = ResetFlag(1 << 5)
+	ResetElastic    = ResetFlag(1 << 6)
+	ResetCentrifugo = ResetFlag(1 << 7)
 )
 
 // Reset clears out both our database and redis DB
@@ -48,6 +52,9 @@ func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 	}
 	if what&ResetDynamo > 0 {
 		resetDynamo(t, rt)
+	}
+	if what&ResetCentrifugo > 0 {
+		resetCentrifugo(t, rt)
 	}
 
 	if what&ResetDB > 0 {
@@ -80,6 +87,8 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.DynamoTablePrefix = "Test"
 	cfg.ElasticContactsIndex = "contacts-test"
 	cfg.ElasticMessagesIndex = "messages-test"
+	cfg.CentrifugoEndpoint = "http://centrifugo:9000/ws/api"
+	cfg.CentrifugoKey = "dev-api-key"
 	cfg.SpoolDir = absPath("./_test_spool")
 
 	err := cfg.Parse()
@@ -191,6 +200,37 @@ func resetStorage(t *testing.T, rt *runtime.Runtime) {
 
 	err := rt.S3.EmptyBucket(t.Context(), rt.Config.S3AttachmentsBucket)
 	require.NoError(t, err)
+}
+
+// resetCentrifugo clears any channel history Centrifugo is holding between tests. The dev and CI Centrifugo use valkey
+// DB 6 for their engine (see the centrifugo service config), so flushing that DB drops all retained publications.
+func resetCentrifugo(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	vc, err := valkey.Dial("tcp", "valkey:6379")
+	require.NoError(t, err, "error connecting to centrifugo valkey db")
+	defer vc.Close()
+
+	_, err = vc.Do("SELECT", 6)
+	require.NoError(t, err)
+	_, err = vc.Do("FLUSHDB")
+	require.NoError(t, err, "error flushing centrifugo valkey db")
+}
+
+// CentrifugoHistory returns the JSON payloads published to the given Centrifugo channel, oldest first. The channel's
+// namespace must have history enabled - the dev and CI Centrifugo enable it so tests can read publishes back; the
+// production config does not.
+func CentrifugoHistory(t *testing.T, rt *runtime.Runtime, channel string) []json.RawMessage {
+	t.Helper()
+
+	res, err := rt.Centrifugo.History(t.Context(), channel, gocent.WithLimit(-1))
+	require.NoError(t, err)
+
+	msgs := make([]json.RawMessage, len(res.Publications))
+	for i, p := range res.Publications {
+		msgs[i] = p.Data
+	}
+	return msgs
 }
 
 func createBucket(t *testing.T, rt *runtime.Runtime, bucket string) {


### PR DESCRIPTION
## What

Treat Centrifugo like every other backing service in tests (Postgres, valkey, S3/DynamoDB, Elastic) instead of leaving its client unset and mocking it per-test.

## Why

The Centrifugo client was the only backing client built in the service layer rather than in `runtime.NewRuntime`, so the test runtime never had one. That forced two awkward things: a `rt.Centrifugo == nil` guard in the publish path that only ever mattered in tests, and an in-process fake HTTP server stood up by each test that wanted to assert a publish.

## How

- Build the Centrifugo client in `runtime.NewRuntime`, next to the DB/valkey/S3/Dynamo/Elastic clients; the service layer keeps only its reachability check.
- Point the test config at a Centrifugo instance and add one as a CI service. It runs the redis engine against the existing valkey service (a dedicated DB) so channel history can be cleared by flushing that DB, and enables per-channel history on the namespaces the suite reads back from.
- Drop the nil guard in `PublishNotifications`.
- Add `testsuite.CentrifugoHistory(channel)` (reads a channel's publications via the history API) and a `ResetCentrifugo` flag (flushes the engine DB). The notification publish tests now assert against the real broker instead of a fake.
- `TestPublishToHistory` keeps a small request-recording stub on purpose: it asserts the one-round-trip-per-commit pipelining, which a real broker doesn't expose.

## Notes for reviewers

- Net removes more test code than it adds (the per-test fakes go away).
- History is enabled only for the test/CI Centrifugo; the production configuration is unchanged (no per-channel history there).
- Running the suite locally needs a Centrifugo reachable at the configured endpoint with history enabled on those namespaces; the standard local dev stack provides it.

## Testing

`core/models`, `core/runner`, `core/runner/handlers`, `core/tasks` all pass against a real Centrifugo (publish + history read-back + reset verified).