### PR TITLE
Resolve AWS credentials and region from standard AWS SDK chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ environment variables and parameters and for more details on each option.
  
 ### AWS services:
 
- * `MAILROOM_AWS_ACCESS_KEY_ID`: AWS access key id used to authenticate to AWS
- * `MAILROOM_AWS_SECRET_ACCESS_KEY`: AWS secret access key used to authenticate to AWS
- * `MAILROOM_AWS_REGION`: AWS region (e.g. `eu-west-1`)
  * `MAILROOM_S3_ATTACHMENTS_BUCKET`: name of your S3 bucket (e.g. `mailroom-attachments`)
+
+The AWS region and credentials are resolved via the standard AWS SDK default chain — the
+`AWS_REGION` (or `AWS_DEFAULT_REGION`) environment variable, the instance/task IAM role,
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables, the shared config/credentials
+files, etc. When running on AWS the task/instance role is the recommended option for credentials.
 
 ### Logging and error reporting:
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -60,10 +60,6 @@ type Config struct {
 	ElasticContactsIndex string `help:"the name of the contacts index written by mailroom"`
 	ElasticMessagesIndex string `help:"the base name for monthly message indexes (e.g. messages-v1 -> messages-v1-2026-02)"`
 
-	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
-	AWSSecretAccessKey string `help:"secret access key to use for AWS services"`
-	AWSRegion          string `help:"region to use for AWS services, e.g. us-east-1"`
-
 	DynamoEndpoint    string `help:"DynamoDB service endpoint, e.g. https://dynamodb.us-east-1.amazonaws.com"`
 	DynamoTablePrefix string `help:"prefix to use for DynamoDB tables"`
 
@@ -137,10 +133,6 @@ func NewDefaultConfig() *Config {
 		ElasticPassword:      "",
 		ElasticContactsIndex: "contacts-v1",
 		ElasticMessagesIndex: "messages-v1",
-
-		AWSAccessKeyID:     "",
-		AWSSecretAccessKey: "",
-		AWSRegion:          "us-east-1",
 
 		DynamoEndpoint:    "", // let library generate it
 		DynamoTablePrefix: "Temba",

--- a/runtime/dynamo.go
+++ b/runtime/dynamo.go
@@ -15,7 +15,7 @@ type Dynamo struct {
 }
 
 func newDynamo(cfg *Config) (*Dynamo, error) {
-	client, err := dynamo.NewClient(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.DynamoEndpoint)
+	client, err := dynamo.NewClient("", "", "", cfg.DynamoEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DynamoDB client: %w", err)
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -76,7 +76,7 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 		return nil, fmt.Errorf("error creating Valkey pool: %w", err)
 	}
 
-	rt.S3, err = s3x.NewService(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.S3Endpoint, cfg.S3PathStyle)
+	rt.S3, err = s3x.NewService("", "", "", cfg.S3Endpoint, cfg.S3PathStyle)
 	if err != nil {
 		return nil, fmt.Errorf("error creating S3 service: %w", err)
 	}
@@ -86,7 +86,7 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 		return nil, err
 	}
 
-	rt.CW, err = cwatch.NewService(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.CloudwatchNamespace, cfg.DeploymentID)
+	rt.CW, err = cwatch.NewService("", "", "", cfg.CloudwatchNamespace, cfg.DeploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Cloudwatch service: %w", err)
 	}

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -78,8 +78,11 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.DB = "postgres://mailroom_test:temba@postgres/mailroom_test?sslmode=disable&Timezone=UTC"
 	cfg.Valkey = "valkey://valkey:6379/10" // use a different DB from the default so a locally-running courier can't pop from queues we're asserting on
 
-	cfg.AWSAccessKeyID = "root"
-	cfg.AWSSecretAccessKey = "tembatemba"
+	// AWS SDK default chain reads these — used by the localstack S3/Dynamo/Cloudwatch clients
+	t.Setenv("AWS_ACCESS_KEY_ID", "root")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "tembatemba")
+	t.Setenv("AWS_REGION", "us-east-1")
+
 	cfg.S3Endpoint = "http://localstack:4566"
 	cfg.S3AttachmentsBucket = "test-attachments"
 	cfg.S3PathStyle = true


### PR DESCRIPTION
Resolve AWS credentials and region via the standard AWS SDK default credential chain instead of dedicated config settings.

## What changed

- Removed the `AWSAccessKeyID`, `AWSSecretAccessKey` and `AWSRegion` config settings (and their defaults, including the hardcoded `us-east-1`).
- `s3x.NewService`, `cwatch.NewService` and `dynamo.NewClient` now pass empty strings for access key / secret / region, letting the SDK resolve them from its default chain: the `AWS_REGION` (or `AWS_DEFAULT_REGION`) env var, the instance/task IAM role, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, shared config/credentials files, etc.
- Test setup now exports the standard `AWS_*` env vars so the SDK chain resolves against localstack.
- Updated the README to describe the SDK default chain in place of the removed env vars.

## Why

First step toward running as a container task, where the region and credentials come from the task/instance role and standard AWS environment variables rather than app-specific settings.

## Reviewer notes

- **Breaking config change:** the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` config options no longer exist. Deployments must supply these through the standard AWS environment (env vars or the task/instance role). In particular, since there is no longer a default region, `AWS_REGION` (or `AWS_DEFAULT_REGION`) must be set where it previously relied on the built-in default.
- Verified with a `go build`, `gofmt`, and a focused test that constructs the runtime with only the standard `AWS_*` env vars set and does a real authenticated S3 round-trip against localstack.