### PR TITLE
Add endpoint to publish externally-created notifications to realtime sockets

### DIFF
--- a/cmd/mailroom/main.go
+++ b/cmd/mailroom/main.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/nyaruka/mailroom/v26/web/flow"
 	_ "github.com/nyaruka/mailroom/v26/web/llm"
 	_ "github.com/nyaruka/mailroom/v26/web/msg"
+	_ "github.com/nyaruka/mailroom/v26/web/notification"
 	_ "github.com/nyaruka/mailroom/v26/web/org"
 	_ "github.com/nyaruka/mailroom/v26/web/po"
 	_ "github.com/nyaruka/mailroom/v26/web/public"

--- a/core/models/notification.go
+++ b/core/models/notification.go
@@ -42,6 +42,13 @@ const (
 	MediumEmail = "E"
 )
 
+// NotificationData pairs a user with an already-rendered notification payload, for publishing notifications created
+// outside mailroom to that user's realtime socket. See PublishNotificationData.
+type NotificationData struct {
+	UserID UserID
+	Data   json.RawMessage
+}
+
 type Notification struct {
 	ID          NotificationID   `db:"id"`
 	OrgID       OrgID            `db:"org_id"`

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -54,13 +54,7 @@ func PublishNotifications(ctx context.Context, rt *runtime.Runtime, oa *OrgAsset
 
 	orgUUID := oa.Org().UUID()
 
-	// resolve each notification's socket up front, skipping any whose user we can't resolve
-	type pending struct {
-		socket string
-		n      *Notification
-	}
-	items := make([]pending, 0, len(notifications))
-	candidates := make([]string, 0, len(notifications))
+	msgs := make([]socketMessage, 0, len(notifications))
 	for _, n := range notifications {
 		user := oa.UserByID(n.UserID)
 		if user == nil {
@@ -68,12 +62,60 @@ func PublishNotifications(ctx context.Context, rt *runtime.Runtime, oa *OrgAsset
 			continue
 		}
 
-		socket := NotificationSocket(orgUUID, user.UUID())
-		items = append(items, pending{socket, n})
-		candidates = append(candidates, socket)
+		data, err := n.marshalForSocket()
+		if err != nil {
+			return fmt.Errorf("error marshaling notification for user #%d: %w", n.UserID, err)
+		}
+		msgs = append(msgs, socketMessage{NotificationSocket(orgUUID, user.UUID()), data})
 	}
+
+	return publishToSockets(ctx, rt, msgs)
+}
+
+// PublishNotificationData publishes already-rendered notification payloads to their users' notification sockets. It's
+// the counterpart to PublishNotifications for notifications created outside mailroom (e.g. the platform's Django side
+// creates finished-export and locally-detected-incident notifications): it delivers them over the same realtime path,
+// reusing the socket addressing and subscriber-presence check so there's a single implementation of those. Each item's
+// data is published verbatim - the rendering is the caller's, so mailroom needs no knowledge of those notification
+// types. Best-effort and a no-op for any socket with no current subscribers, exactly like PublishNotifications.
+func PublishNotificationData(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, items []NotificationData) error {
 	if len(items) == 0 {
 		return nil
+	}
+
+	orgUUID := oa.Org().UUID()
+
+	msgs := make([]socketMessage, 0, len(items))
+	for _, it := range items {
+		user := oa.UserByID(it.UserID)
+		if user == nil {
+			slog.Error("unable to publish notification for unknown user", "user_id", it.UserID, "org_id", oa.OrgID())
+			continue
+		}
+		msgs = append(msgs, socketMessage{NotificationSocket(orgUUID, user.UUID()), it.Data})
+	}
+
+	return publishToSockets(ctx, rt, msgs)
+}
+
+// socketMessage is an already-marshaled payload bound for a single realtime socket.
+type socketMessage struct {
+	socket string
+	data   []byte
+}
+
+// publishToSockets publishes pre-rendered messages to their sockets, best-effort, skipping any socket that currently
+// has no active subscriber. Subscriber presence for every socket is resolved in a single round-trip, then each
+// subscribed socket's payload is batched into one pipelined centrifugo request so the whole batch costs one round-trip
+// and lands or fails together. This is the shared publish core behind the notification publishers above.
+func publishToSockets(ctx context.Context, rt *runtime.Runtime, msgs []socketMessage) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	candidates := make([]string, len(msgs))
+	for i, m := range msgs {
+		candidates[i] = m.socket
 	}
 
 	subscribed, err := SubscribedSockets(ctx, rt, candidates...)
@@ -83,19 +125,14 @@ func PublishNotifications(ctx context.Context, rt *runtime.Runtime, oa *OrgAsset
 
 	pipe := rt.Centrifugo.Pipe()
 	var targets []string // the socket each pipelined publish targets, parallel to the replies for error reporting
-	for _, it := range items {
-		if !subscribed[it.socket] {
+	for _, m := range msgs {
+		if !subscribed[m.socket] {
 			continue
 		}
-
-		data, err := it.n.marshalForSocket()
-		if err != nil {
-			return fmt.Errorf("error marshaling notification for %s: %w", it.socket, err)
+		if err := pipe.AddPublish(m.socket, m.data); err != nil {
+			return fmt.Errorf("error adding notification to publish pipe for %s: %w", m.socket, err)
 		}
-		if err := pipe.AddPublish(it.socket, data); err != nil {
-			return fmt.Errorf("error adding notification to publish pipe for %s: %w", it.socket, err)
-		}
-		targets = append(targets, it.socket)
+		targets = append(targets, m.socket)
 	}
 	if len(targets) == 0 {
 		return nil

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -98,6 +98,43 @@ func TestPublishNotifications(t *testing.T) {
 	assert.Nil(t, incident["ended_on"])
 }
 
+func TestPublishNotificationData(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetCentrifugo)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	adminSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Admin.UUID)
+	payload := json.RawMessage(`{"type":"export:finished","is_seen":false,"url":"/notification/read/123/"}`)
+
+	// no items is a no-op
+	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, nil))
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
+
+	// socket isn't subscribed yet, so nothing is published
+	items := []models.NotificationData{{UserID: testdb.Admin.ID, Data: payload}}
+	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, items))
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
+
+	// an unknown user is skipped rather than failing the batch
+	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, []models.NotificationData{{UserID: 0, Data: payload}}))
+
+	// mark the socket subscribed - now the pre-rendered payload is published verbatim
+	_, err = vc.Do("SET", "socket-subs:"+adminSocket, "1")
+	require.NoError(t, err)
+
+	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, items))
+
+	sent := testsuite.CentrifugoHistory(t, rt, adminSocket)
+	require.Len(t, sent, 1)
+	assert.JSONEq(t, string(payload), string(sent[0]))
+}
+
 func TestSubscribedSockets(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/web/notification/base_test.go
+++ b/web/notification/base_test.go
@@ -1,0 +1,15 @@
+package notification_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/mailroom/v26/testsuite"
+)
+
+func TestPublish(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetCentrifugo)
+
+	testsuite.RunWebTests(t, rt, "testdata/publish.json")
+}

--- a/web/notification/publish.go
+++ b/web/notification/publish.go
@@ -1,0 +1,54 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/nyaruka/mailroom/v26/web"
+)
+
+func init() {
+	web.InternalRoute(http.MethodPost, "/notification/publish", web.JSONPayload(handlePublish))
+}
+
+// Publishes already-created notifications to their users' realtime sockets. Used by the platform's Django side to
+// deliver notifications it creates itself (e.g. finished exports, locally-detected incidents) over the same realtime
+// path used for notifications created here, so the socket addressing and subscriber-presence check have a single
+// implementation. Each notification carries the user it's for and the already-rendered JSON payload to publish; the
+// rendering is Django's, so mailroom needs no knowledge of those notification types.
+//
+//	{
+//	  "org_id": 1,
+//	  "notifications": [
+//	    {"user_id": 234, "data": {"type": "export:finished", "created_on": "...", "url": "...", "is_seen": false}}
+//	  ]
+//	}
+type publishRequest struct {
+	OrgID         models.OrgID `json:"org_id"        validate:"required"`
+	Notifications []struct {
+		UserID models.UserID   `json:"user_id" validate:"required"`
+		Data   json.RawMessage `json:"data"    validate:"required"`
+	} `json:"notifications" validate:"required"`
+}
+
+func handlePublish(ctx context.Context, rt *runtime.Runtime, r *publishRequest) (any, int, error) {
+	oa, err := models.GetOrgAssets(ctx, rt, r.OrgID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error loading org assets for org #%d: %w", r.OrgID, err)
+	}
+
+	items := make([]models.NotificationData, len(r.Notifications))
+	for i, n := range r.Notifications {
+		items[i] = models.NotificationData{UserID: n.UserID, Data: n.Data}
+	}
+
+	if err := models.PublishNotificationData(ctx, rt, oa, items); err != nil {
+		return nil, 0, fmt.Errorf("error publishing notifications for org #%d: %w", r.OrgID, err)
+	}
+
+	return map[string]any{}, http.StatusOK, nil
+}

--- a/web/notification/publish.go
+++ b/web/notification/publish.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -43,6 +44,11 @@ func handlePublish(ctx context.Context, rt *runtime.Runtime, r *publishRequest) 
 
 	items := make([]models.NotificationData, len(r.Notifications))
 	for i, n := range r.Notifications {
+		// `validate:"required"` doesn't reject `null` or a non-object payload, but the realtime protocol assumes an
+		// object, so guard here rather than forwarding e.g. literal `null` to a subscriber's socket
+		if data := bytes.TrimSpace(n.Data); len(data) == 0 || data[0] != '{' {
+			return fmt.Errorf("notification %d: data must be a JSON object", i), http.StatusBadRequest, nil
+		}
 		items[i] = models.NotificationData{UserID: n.UserID, Data: n.Data}
 	}
 

--- a/web/notification/testdata/publish.json
+++ b/web/notification/testdata/publish.json
@@ -1,0 +1,39 @@
+[
+    {
+        "label": "illegal method",
+        "method": "GET",
+        "path": "/mi/notification/publish",
+        "status": 405,
+        "response": {
+            "error": "illegal method: GET"
+        }
+    },
+    {
+        "label": "invalid org_id",
+        "method": "POST",
+        "path": "/mi/notification/publish",
+        "body": {
+            "org_id": 1234,
+            "notifications": [
+                {"user_id": 3, "data": {"type": "export:finished"}}
+            ]
+        },
+        "status": 500,
+        "response": {
+            "error": "error loading org assets for org #1234: error loading environment for org 1234: no org with id: 1234"
+        }
+    },
+    {
+        "label": "no subscribers is a no-op",
+        "method": "POST",
+        "path": "/mi/notification/publish",
+        "body": {
+            "org_id": 1,
+            "notifications": [
+                {"user_id": 3, "data": {"type": "export:finished", "is_seen": false, "url": "/notification/read/123/"}}
+            ]
+        },
+        "status": 200,
+        "response": {}
+    }
+]


### PR DESCRIPTION
## What

Adds an internal endpoint, `POST /mi/notification/publish`, that publishes already-created notifications to their users' realtime notification sockets.

## Why

Some notification types are created outside mailroom (e.g. finished exports and locally-detected incidents are created directly by the platform's Django side and persisted to the database). These are UI notifications, but they had no realtime delivery — they only showed up on the next page load rather than live over a user's `notifications:<org>:<user>` socket. This endpoint lets those notifications be delivered over the same realtime path used for the ones created here.

## How

- Extract the shared publish core (`publishToSockets`) out of `PublishNotifications`.
- Add `PublishNotificationData`, which publishes **pre-rendered** payloads: it resolves each user's socket, checks subscriber presence, and publishes the JSON verbatim. The caller owns the rendering, so mailroom needs no knowledge of those notification types — the socket addressing and presence check stay in one place.
- Add the `POST /mi/notification/publish` endpoint taking `{org_id, notifications: [{user_id, data}]}`, and register the new `web/notification` package.

## Notes for reviewers

- Best-effort and a no-op for any socket with no current subscriber, exactly like `PublishNotifications`.
- An unknown/unresolvable user is skipped rather than failing the whole batch.
- Tests: `TestPublishNotificationData` (models) and a `web/notification` endpoint test covering illegal method, unknown org, and the no-subscriber no-op.