### PR TITLE
Resolve single UUID contact queries from the database instead of Elastic

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -372,6 +372,24 @@ func GetContactIDsFromUUIDs(ctx context.Context, db Queryer, orgID OrgID, uuids 
 	return ids, nil
 }
 
+const sqlSelectContactExists = `
+SELECT EXISTS(
+	SELECT 1 FROM contacts_contact
+	 WHERE org_id = $1 AND uuid = $2 AND is_active = TRUE
+	   AND ($3 = 0 OR EXISTS(SELECT 1 FROM contacts_contactgroup_contacts WHERE contactgroup_id = $3 AND contact_id = contacts_contact.id))
+	   AND ($4 = '' OR status = $4)
+)`
+
+// ContactExists returns whether a contact with the given UUID exists in the given org, optionally filtered by group
+// membership and status.
+func ContactExists(ctx context.Context, db DBorTx, orgID OrgID, uuid flows.ContactUUID, groupID GroupID, status ContactStatus) (bool, error) {
+	var exists bool
+	if err := db.GetContext(ctx, &exists, sqlSelectContactExists, orgID, uuid, groupID, status); err != nil {
+		return false, fmt.Errorf("error querying contact exists: %w", err)
+	}
+	return exists, nil
+}
+
 // utility to query contact IDs
 func queryContactIDs(ctx context.Context, db Queryer, query string, args ...any) ([]ContactID, error) {
 	rows, err := db.QueryContext(ctx, query, args...)

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -419,6 +419,32 @@ func TestGetContactIDsFromReferences(t *testing.T) {
 	assert.ElementsMatch(t, []models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, ids)
 }
 
+func TestContactExists(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	tcs := []struct {
+		orgID    models.OrgID
+		uuid     flows.ContactUUID
+		groupID  models.GroupID
+		status   models.ContactStatus
+		expected bool
+	}{
+		{testdb.Org1.ID, testdb.Ann.UUID, models.GroupID(0), models.NilContactStatus, true},
+		{testdb.Org1.ID, "e0c261e1-c95f-4a04-92c6-e6d13ea16d1a", models.GroupID(0), models.NilContactStatus, false}, // no such contact
+		{testdb.Org1.ID, testdb.Org2Contact.UUID, models.GroupID(0), models.NilContactStatus, false},                // wrong org
+		{testdb.Org1.ID, testdb.Ann.UUID, testdb.DoctorsGroup.ID, models.NilContactStatus, true},
+		{testdb.Org1.ID, testdb.Bob.UUID, testdb.DoctorsGroup.ID, models.NilContactStatus, false}, // not a doctor
+		{testdb.Org1.ID, testdb.Ann.UUID, models.GroupID(0), models.ContactStatusActive, true},
+		{testdb.Org1.ID, testdb.Ann.UUID, models.GroupID(0), models.ContactStatusBlocked, false}, // not blocked
+	}
+
+	for i, tc := range tcs {
+		exists, err := models.ContactExists(ctx, rt.DB, tc.orgID, tc.uuid, tc.groupID, tc.status)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expected, exists, "%d: exists mismatch", i)
+	}
+}
+
 func TestGetContactIDsPage(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v9/typedapi/types"
 	"github.com/nyaruka/gocommon/elastic"
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/goflow/contactql/es"
@@ -35,6 +36,34 @@ var assetMapper = &AssetMapper{}
 
 func newConverter(oa *models.OrgAssets, uuidAsDocID bool) *es.Converter {
 	return es.NewConverter(oa.Env(), assetMapper, uuidAsDocID)
+}
+
+// queryAsUUID returns the UUID value if the given query is a single equality condition on contact UUID,
+// e.g. `uuid = "0197c464-c397-72e8-8b52-9c4b0b23e096"`, or false if it's anything else.
+func queryAsUUID(query *contactql.ContactQuery) (flows.ContactUUID, bool) {
+	if query != nil {
+		if c, ok := query.Root().(*contactql.Condition); ok {
+			if c.PropertyType() == contactql.PropertyTypeAttribute && c.PropertyKey() == contactql.AttributeUUID && c.Operator() == contactql.OpEqual && uuids.Is(c.Value()) {
+				return flows.ContactUUID(c.Value()), true
+			}
+		}
+	}
+	return "", false
+}
+
+// contactExistsInDB checks in the database whether a contact matching the given UUID and group/status filters exists -
+// used to resolve queries on UUID without Elastic, so that contacts not yet indexed are still visible to such queries.
+func contactExistsInDB(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, uuid flows.ContactUUID) (bool, error) {
+	var groupID models.GroupID
+	if group != nil {
+		groupID = group.ID()
+	}
+
+	exists, err := models.ContactExists(ctx, rt.DB, oa.OrgID(), uuid, groupID, status)
+	if err != nil {
+		return false, fmt.Errorf("error looking up contact UUID in database: %w", err)
+	}
+	return exists, nil
 }
 
 func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeUUIDs []flows.ContactUUID, query *contactql.ContactQuery) elastic.Query {
@@ -90,6 +119,20 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
+	// a query that is a single condition on UUID can be resolved from the database, so that contacts not yet
+	// indexed in Elastic are still visible to such queries
+	if uuid, ok := queryAsUUID(parsed); ok {
+		exists, err := contactExistsInDB(ctx, rt, oa, group, status, uuid)
+		if err != nil {
+			return nil, 0, err
+		}
+		total := int64(0)
+		if exists {
+			total = 1
+		}
+		return parsed, total, nil
+	}
+
 	index := rt.Config.ElasticContactsIndex
 	eq := buildContactQuery(oa, group, status, nil, parsed)
 	src := map[string]any{"query": eq}
@@ -126,6 +169,25 @@ func GetContactUUIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *m
 	fieldSort, err := conv.Sort(sort, oa.SessionAssets())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
+	}
+
+	// a query that is a single condition on UUID can be resolved from the database, so that contacts not yet
+	// indexed in Elastic are still visible to such queries
+	if uuid, ok := queryAsUUID(parsed); ok {
+		exists, err := contactExistsInDB(ctx, rt, oa, group, status, uuid)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+
+		page := []flows.ContactUUID{}
+		total := int64(0)
+		if exists && !slices.Contains(excludeUUIDs, uuid) {
+			total = 1
+			if offset == 0 && pageSize > 0 {
+				page = append(page, uuid)
+			}
+		}
+		return parsed, page, total, nil
 	}
 
 	start := time.Now()
@@ -183,6 +245,21 @@ func GetContactUUIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *model
 	if group != nil && !group.Visible() {
 		status = models.ContactStatus(group.Type())
 		group = nil
+	}
+
+	// a query that is a single condition on UUID can be resolved from the database, so that contacts not yet
+	// indexed in Elastic are still visible to such queries
+	if uuid, ok := queryAsUUID(parsed); ok {
+		exists, err := contactExistsInDB(ctx, rt, oa, group, status, uuid)
+		if err != nil {
+			return nil, err
+		}
+
+		matches := []flows.ContactUUID{}
+		if exists && limit != 0 {
+			matches = append(matches, uuid)
+		}
+		return matches, nil
 	}
 
 	eq := buildContactQuery(oa, group, status, nil, parsed)

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -51,21 +51,6 @@ func queryAsUUID(query *contactql.ContactQuery) (flows.ContactUUID, bool) {
 	return "", false
 }
 
-// contactExistsInDB checks in the database whether a contact matching the given UUID and group/status filters exists -
-// used to resolve queries on UUID without Elastic, so that contacts not yet indexed are still visible to such queries.
-func contactExistsInDB(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, group *models.Group, status models.ContactStatus, uuid flows.ContactUUID) (bool, error) {
-	var groupID models.GroupID
-	if group != nil {
-		groupID = group.ID()
-	}
-
-	exists, err := models.ContactExists(ctx, rt.DB, oa.OrgID(), uuid, groupID, status)
-	if err != nil {
-		return false, fmt.Errorf("error looking up contact UUID in database: %w", err)
-	}
-	return exists, nil
-}
-
 func buildContactQuery(oa *models.OrgAssets, group *models.Group, status models.ContactStatus, excludeUUIDs []flows.ContactUUID, query *contactql.ContactQuery) elastic.Query {
 	// use filter context for all clauses since we never sort by relevance score, and filter clauses
 	// are cacheable and skip scoring
@@ -119,20 +104,6 @@ func GetContactTotal(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAss
 		group = nil
 	}
 
-	// a query that is a single condition on UUID can be resolved from the database, so that contacts not yet
-	// indexed in Elastic are still visible to such queries
-	if uuid, ok := queryAsUUID(parsed); ok {
-		exists, err := contactExistsInDB(ctx, rt, oa, group, status, uuid)
-		if err != nil {
-			return nil, 0, err
-		}
-		total := int64(0)
-		if exists {
-			total = 1
-		}
-		return parsed, total, nil
-	}
-
 	index := rt.Config.ElasticContactsIndex
 	eq := buildContactQuery(oa, group, status, nil, parsed)
 	src := map[string]any{"query": eq}
@@ -169,25 +140,6 @@ func GetContactUUIDsForQueryPage(ctx context.Context, rt *runtime.Runtime, oa *m
 	fieldSort, err := conv.Sort(sort, oa.SessionAssets())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error parsing sort: %w", err)
-	}
-
-	// a query that is a single condition on UUID can be resolved from the database, so that contacts not yet
-	// indexed in Elastic are still visible to such queries
-	if uuid, ok := queryAsUUID(parsed); ok {
-		exists, err := contactExistsInDB(ctx, rt, oa, group, status, uuid)
-		if err != nil {
-			return nil, nil, 0, err
-		}
-
-		page := []flows.ContactUUID{}
-		total := int64(0)
-		if exists && !slices.Contains(excludeUUIDs, uuid) {
-			total = 1
-			if offset == 0 && pageSize > 0 {
-				page = append(page, uuid)
-			}
-		}
-		return parsed, page, total, nil
 	}
 
 	start := time.Now()
@@ -250,9 +202,14 @@ func GetContactUUIDsForQuery(ctx context.Context, rt *runtime.Runtime, oa *model
 	// a query that is a single condition on UUID can be resolved from the database, so that contacts not yet
 	// indexed in Elastic are still visible to such queries
 	if uuid, ok := queryAsUUID(parsed); ok {
-		exists, err := contactExistsInDB(ctx, rt, oa, group, status, uuid)
+		var groupID models.GroupID
+		if group != nil {
+			groupID = group.ID()
+		}
+
+		exists, err := models.ContactExists(ctx, rt.DB, oa.OrgID(), uuid, groupID, status)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error looking up contact UUID in database: %w", err)
 		}
 
 		matches := []flows.ContactUUID{}

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -16,9 +16,12 @@ import (
 
 func TestGetContactTotal(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
+
+	// created after indexing so only visible to UUID queries which are resolved from the database
+	eve := testdb.InsertContact(t, rt, testdb.Org1, flows.NewContactUUID(), "Eve", i18n.NilLanguage, models.ContactStatusActive)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -34,6 +37,13 @@ func TestGetContactTotal(t *testing.T) {
 		{group: nil, query: "cat", expectedTotal: 1},
 		{group: testdb.ActiveGroup, query: "cat", expectedTotal: 1},
 		{group: nil, query: "age >= 30", expectedTotal: 1},
+		{group: nil, query: fmt.Sprintf(`uuid = "%s"`, eve.UUID), expectedTotal: 1}, // not yet indexed but resolved from database
+		{group: testdb.DoctorsGroup, query: fmt.Sprintf(`uuid = "%s"`, testdb.Ann.UUID), expectedTotal: 1},
+		{group: testdb.DoctorsGroup, query: fmt.Sprintf(`uuid = "%s"`, testdb.Bob.UUID), expectedTotal: 0},          // not a doctor
+		{group: testdb.BlockedGroup, query: fmt.Sprintf(`uuid = "%s"`, eve.UUID), expectedTotal: 0},                 // not blocked
+		{group: nil, query: `uuid = "xyz"`, expectedTotal: 0},                                                       // not a valid UUID so still uses Elastic
+		{group: nil, query: fmt.Sprintf(`uuid = "%s" OR uuid = "%s"`, testdb.Ann.UUID, eve.UUID), expectedTotal: 1}, // OR queries still use Elastic so eve not visible
+		{group: nil, query: fmt.Sprintf(`uuid = "%s" OR name = "Ann"`, eve.UUID), expectedTotal: 1},                 // as do mixed queries
 		{
 			group:         nil,
 			query:         "goats > 2", // no such contact field
@@ -60,9 +70,12 @@ func TestGetContactTotal(t *testing.T) {
 
 func TestGetContactUUIDsForQueryPage(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
+
+	// created after indexing so only visible to UUID queries which are resolved from the database
+	eve := testdb.InsertContact(t, rt, testdb.Org1, flows.NewContactUUID(), "Eve", i18n.NilLanguage, models.ContactStatusActive)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -104,6 +117,25 @@ func TestGetContactUUIDsForQueryPage(t *testing.T) {
 			expectedTotal:    0,
 		},
 		{ // 4
+			group:            testdb.ActiveGroup,
+			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID), // not yet indexed but resolved from database
+			expectedContacts: []flows.ContactUUID{eve.UUID},
+			expectedTotal:    1,
+		},
+		{ // 5
+			group:            testdb.ActiveGroup,
+			excludeUUIDs:     []flows.ContactUUID{eve.UUID},
+			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID),
+			expectedContacts: []flows.ContactUUID{},
+			expectedTotal:    0,
+		},
+		{ // 6
+			group:            testdb.BlockedGroup,
+			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID), // not blocked
+			expectedContacts: []flows.ContactUUID{},
+			expectedTotal:    0,
+		},
+		{ // 7
 			group:         testdb.BlockedGroup,
 			query:         "goats > 2", // no such contact field
 			expectedError: "error parsing query: goats > 2: can't resolve 'goats' to attribute, scheme or field",
@@ -145,6 +177,9 @@ func TestGetContactUUIDsForQuery(t *testing.T) {
 	testdb.InsertContact(t, rt, testdb.Org2, flows.NewContactUUID(), "Cylon 0", i18n.NilLanguage, models.ContactStatusActive)
 
 	testsuite.IndexContacts(t, rt)
+
+	// created after indexing so only visible to UUID queries which are resolved from the database
+	eve := testdb.InsertContact(t, rt, testdb.Org1, flows.NewContactUUID(), "Eve", i18n.NilLanguage, models.ContactStatusActive)
 
 	tcs := []struct {
 		group            *testdb.Group
@@ -202,6 +237,27 @@ func TestGetContactUUIDsForQuery(t *testing.T) {
 			query:            "name has cylon",
 			limit:            -1,
 			expectedContacts: cylonUUIDs,
+		},
+		{
+			group:            nil,
+			status:           models.ContactStatusActive,
+			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID), // not yet indexed but resolved from database
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{eve.UUID},
+		},
+		{
+			group:            testdb.DoctorsGroup,
+			status:           models.NilContactStatus,
+			query:            fmt.Sprintf(`uuid = "%s"`, testdb.Bob.UUID), // not a doctor
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{},
+		},
+		{
+			group:            nil,
+			status:           models.NilContactStatus,
+			query:            fmt.Sprintf(`uuid = "%s" OR uuid = "%s"`, testdb.Cat.UUID, eve.UUID), // OR queries still use Elastic so eve not visible
+			limit:            -1,
+			expectedContacts: []flows.ContactUUID{testdb.Cat.UUID},
 		},
 		{
 			group:         nil,

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -16,12 +16,9 @@ import (
 
 func TestGetContactTotal(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
-
-	// created after indexing so only visible to UUID queries which are resolved from the database
-	eve := testdb.InsertContact(t, rt, testdb.Org1, flows.NewContactUUID(), "Eve", i18n.NilLanguage, models.ContactStatusActive)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -37,13 +34,6 @@ func TestGetContactTotal(t *testing.T) {
 		{group: nil, query: "cat", expectedTotal: 1},
 		{group: testdb.ActiveGroup, query: "cat", expectedTotal: 1},
 		{group: nil, query: "age >= 30", expectedTotal: 1},
-		{group: nil, query: fmt.Sprintf(`uuid = "%s"`, eve.UUID), expectedTotal: 1}, // not yet indexed but resolved from database
-		{group: testdb.DoctorsGroup, query: fmt.Sprintf(`uuid = "%s"`, testdb.Ann.UUID), expectedTotal: 1},
-		{group: testdb.DoctorsGroup, query: fmt.Sprintf(`uuid = "%s"`, testdb.Bob.UUID), expectedTotal: 0},          // not a doctor
-		{group: testdb.BlockedGroup, query: fmt.Sprintf(`uuid = "%s"`, eve.UUID), expectedTotal: 0},                 // not blocked
-		{group: nil, query: `uuid = "xyz"`, expectedTotal: 0},                                                       // not a valid UUID so still uses Elastic
-		{group: nil, query: fmt.Sprintf(`uuid = "%s" OR uuid = "%s"`, testdb.Ann.UUID, eve.UUID), expectedTotal: 1}, // OR queries still use Elastic so eve not visible
-		{group: nil, query: fmt.Sprintf(`uuid = "%s" OR name = "Ann"`, eve.UUID), expectedTotal: 1},                 // as do mixed queries
 		{
 			group:         nil,
 			query:         "goats > 2", // no such contact field
@@ -70,12 +60,9 @@ func TestGetContactTotal(t *testing.T) {
 
 func TestGetContactUUIDsForQueryPage(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
-
-	// created after indexing so only visible to UUID queries which are resolved from the database
-	eve := testdb.InsertContact(t, rt, testdb.Org1, flows.NewContactUUID(), "Eve", i18n.NilLanguage, models.ContactStatusActive)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -117,25 +104,6 @@ func TestGetContactUUIDsForQueryPage(t *testing.T) {
 			expectedTotal:    0,
 		},
 		{ // 4
-			group:            testdb.ActiveGroup,
-			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID), // not yet indexed but resolved from database
-			expectedContacts: []flows.ContactUUID{eve.UUID},
-			expectedTotal:    1,
-		},
-		{ // 5
-			group:            testdb.ActiveGroup,
-			excludeUUIDs:     []flows.ContactUUID{eve.UUID},
-			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID),
-			expectedContacts: []flows.ContactUUID{},
-			expectedTotal:    0,
-		},
-		{ // 6
-			group:            testdb.BlockedGroup,
-			query:            fmt.Sprintf(`uuid = "%s"`, eve.UUID), // not blocked
-			expectedContacts: []flows.ContactUUID{},
-			expectedTotal:    0,
-		},
-		{ // 7
 			group:         testdb.BlockedGroup,
 			query:         "goats > 2", // no such contact field
 			expectedError: "error parsing query: goats > 2: can't resolve 'goats' to attribute, scheme or field",


### PR DESCRIPTION
Contact queries that consist of a single equality condition on UUID, e.g. `uuid = "0197c464-c397-72e8-8b52-9c4b0b23e096"`, are now resolved with a database existence check instead of an Elastic search when resolving recipients for starts and broadcasts.

## Why

Elastic indexing is asynchronous, so a newly created contact isn't immediately visible to queries. The motivating case is a flow that creates a contact via a webhook call and then uses a Start Somebody Else action with a query like `uuid = @webhook.json.uuid` — previously that could silently match nothing because the contact wasn't indexed yet. It also skips an Elastic round trip for a query the database can answer directly.

## What changed

- New `models.ContactExists` does a `SELECT EXISTS(...)` on `contacts_contact` filtered by org, and optionally by group membership (via `contacts_contactgroup_contacts`, the same source that feeds the indexed `group_ids`) and status.
- `search.GetContactUUIDsForQuery` takes this fast path when the parsed query is a single `uuid =` condition with a valid UUID value. Status groups are converted to status filters before the check, same as the Elastic path.
- Anything else — OR/AND combinations, other properties, `uuid !=`, invalid UUID values — falls through to Elastic unchanged.
- The shortcut is deliberately *not* applied to `GetContactTotal` or `GetContactUUIDsForQueryPage` (previews and paged UI searches) — those keep pure Elastic semantics.

## Notes for review

- `TestGetContactUUIDsForQuery` includes a contact created *after* indexing to prove the database path makes it visible, plus cases asserting that OR'd and mixed queries still use Elastic (so unindexed contacts remain invisible to those).
- The full suite passes in the test environment apart from the pre-existing Centrifugo-dependent tests which can't run there.