### PR TITLE
Address notification sockets by user UUID when publishing external notifications

### DIFF
--- a/core/models/notification.go
+++ b/core/models/notification.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/dbutil"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
@@ -43,10 +44,11 @@ const (
 )
 
 // NotificationData pairs a user with an already-rendered notification payload, for publishing notifications created
-// outside mailroom to that user's realtime socket. See PublishNotificationData.
+// outside mailroom to that user's realtime socket. The user is identified by UUID because that's what socket
+// addressing uses, and because the user may not belong to the workspace (e.g. staff). See PublishNotificationData.
 type NotificationData struct {
-	UserID UserID
-	Data   json.RawMessage
+	UserUUID assets.UserUUID
+	Data     json.RawMessage
 }
 
 type Notification struct {

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -81,7 +81,9 @@ func PublishNotifications(ctx context.Context, rt *runtime.Runtime, oa *OrgAsset
 // creates finished-export and locally-detected-incident notifications): it delivers them over the same realtime path,
 // reusing the socket addressing and subscriber-presence check so there's a single implementation of those. Each item's
 // data is published verbatim - the rendering is the caller's, so mailroom needs no knowledge of those notification
-// types. Best-effort and a no-op for any socket with no current subscribers, exactly like PublishNotifications.
+// types. Each item carries its user's UUID so sockets are addressed directly without a user asset lookup - the user
+// may not belong to the workspace (e.g. staff who serviced it). Best-effort and a no-op for any socket with no
+// current subscribers, exactly like PublishNotifications.
 func PublishNotificationData(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, items []NotificationData) error {
 	if len(items) == 0 {
 		return nil
@@ -91,12 +93,7 @@ func PublishNotificationData(ctx context.Context, rt *runtime.Runtime, oa *OrgAs
 
 	pubs := make([]*centrifugo.Publication, 0, len(items))
 	for _, it := range items {
-		user := oa.UserByID(it.UserID)
-		if user == nil {
-			slog.Error("unable to publish notification for unknown user", "user_id", it.UserID, "org_id", oa.OrgID())
-			continue
-		}
-		pubs = append(pubs, &centrifugo.Publication{Channel: NotificationSocket(orgUUID, user.UUID()), Data: it.Data})
+		pubs = append(pubs, &centrifugo.Publication{Channel: NotificationSocket(orgUUID, it.UserUUID), Data: it.Data})
 	}
 
 	if err := rt.Centrifugo.Publish(ctx, pubs...); err != nil {

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -113,12 +113,9 @@ func TestPublishNotificationData(t *testing.T) {
 	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
 
 	// socket isn't subscribed yet, so nothing is published
-	items := []models.NotificationData{{UserID: testdb.Admin.ID, Data: payload}}
+	items := []models.NotificationData{{UserUUID: testdb.Admin.UUID, Data: payload}}
 	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, items))
 	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, adminSocket))
-
-	// an unknown user is skipped rather than failing the batch
-	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, []models.NotificationData{{UserID: 0, Data: payload}}))
 
 	// mark the socket subscribed - now the pre-rendered payload is published verbatim
 	_, err = vc.Do("SET", centrifugo.SubscriptionKey(adminSocket), "1")
@@ -127,6 +124,19 @@ func TestPublishNotificationData(t *testing.T) {
 	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, items))
 
 	sent := testsuite.CentrifugoHistory(t, rt, adminSocket)
+	require.Len(t, sent, 1)
+	assert.JSONEq(t, string(payload), string(sent[0]))
+
+	// users are addressed by UUID without an asset lookup, so a user who isn't a member of the workspace (e.g. staff
+	// who serviced it) still receives their notification on their subscribed socket
+	staffSocket := fmt.Sprintf("notifications:%s:%s", testdb.Org1.UUID, testdb.Org2Admin.UUID)
+	_, err = vc.Do("SET", centrifugo.SubscriptionKey(staffSocket), "1")
+	require.NoError(t, err)
+
+	staffItems := []models.NotificationData{{UserUUID: testdb.Org2Admin.UUID, Data: payload}}
+	require.NoError(t, models.PublishNotificationData(ctx, rt, oa, staffItems))
+
+	sent = testsuite.CentrifugoHistory(t, rt, staffSocket)
 	require.Len(t, sent, 1)
 	assert.JSONEq(t, string(payload), string(sent[0]))
 }

--- a/web/notification/publish.go
+++ b/web/notification/publish.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/web"
@@ -19,20 +21,23 @@ func init() {
 // Publishes already-created notifications to their users' realtime sockets. Used by the platform's Django side to
 // deliver notifications it creates itself (e.g. finished exports, locally-detected incidents) over the same realtime
 // path used for notifications created here, so the socket addressing and subscriber-presence check have a single
-// implementation. Each notification carries the user it's for and the already-rendered JSON payload to publish; the
-// rendering is Django's, so mailroom needs no knowledge of those notification types.
+// implementation. Each notification carries the UUID of the user it's for and the already-rendered JSON payload to
+// publish; the rendering is Django's, so mailroom needs no knowledge of those notification types. Users are
+// identified by UUID rather than looked up in the workspace's assets because they may not belong to the workspace
+// (e.g. staff who serviced it).
 //
 //	{
 //	  "org_id": 1,
 //	  "notifications": [
-//	    {"user_id": 234, "data": {"type": "export:finished", "created_on": "...", "url": "...", "is_seen": false}}
+//	    {"user_uuid": "4ac30bf6-b21a-4b90-a1a4-b09e73372dbd", "data": {"type": "export:finished", "created_on": "...", "url": "...", "is_seen": false}}
 //	  ]
 //	}
 type publishRequest struct {
 	OrgID         models.OrgID `json:"org_id"        validate:"required"`
 	Notifications []struct {
-		UserID models.UserID   `json:"user_id" validate:"required"`
-		Data   json.RawMessage `json:"data"    validate:"required"`
+		UserUUID assets.UserUUID `json:"user_uuid"`
+		UserID   models.UserID   `json:"user_id"` // deprecated, only read when user_uuid isn't provided
+		Data     json.RawMessage `json:"data"     validate:"required"`
 	} `json:"notifications" validate:"required"`
 }
 
@@ -42,14 +47,30 @@ func handlePublish(ctx context.Context, rt *runtime.Runtime, r *publishRequest) 
 		return nil, 0, fmt.Errorf("error loading org assets for org #%d: %w", r.OrgID, err)
 	}
 
-	items := make([]models.NotificationData, len(r.Notifications))
+	items := make([]models.NotificationData, 0, len(r.Notifications))
 	for i, n := range r.Notifications {
 		// `validate:"required"` doesn't reject `null` or a non-object payload, but the realtime protocol assumes an
 		// object, so guard here rather than forwarding e.g. literal `null` to a subscriber's socket
 		if data := bytes.TrimSpace(n.Data); len(data) == 0 || data[0] != '{' {
 			return fmt.Errorf("notification %d: data must be a JSON object", i), http.StatusBadRequest, nil
 		}
-		items[i] = models.NotificationData{UserID: n.UserID, Data: n.Data}
+
+		userUUID := n.UserUUID
+		if userUUID == "" {
+			// deprecated: resolve user_id via the workspace's assets, which loses notifications for users who aren't
+			// members of the workspace (e.g. staff who serviced it) - that's why callers should send user_uuid
+			if n.UserID == models.NilUserID {
+				return fmt.Errorf("notification %d: user_uuid or user_id required", i), http.StatusBadRequest, nil
+			}
+			user := oa.UserByID(n.UserID)
+			if user == nil {
+				slog.Error("unable to publish notification for unknown user", "user_id", n.UserID, "org_id", oa.OrgID())
+				continue
+			}
+			userUUID = user.UUID()
+		}
+
+		items = append(items, models.NotificationData{UserUUID: userUUID, Data: n.Data})
 	}
 
 	if err := models.PublishNotificationData(ctx, rt, oa, items); err != nil {

--- a/web/notification/testdata/publish.json
+++ b/web/notification/testdata/publish.json
@@ -15,7 +15,7 @@
         "body": {
             "org_id": 1234,
             "notifications": [
-                {"user_id": 3, "data": {"type": "export:finished"}}
+                {"user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25", "data": {"type": "export:finished"}}
             ]
         },
         "status": 500,
@@ -30,10 +30,51 @@
         "body": {
             "org_id": 1,
             "notifications": [
+                {"user_uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25", "data": {"type": "export:finished", "is_seen": false, "url": "/notification/read/123/"}}
+            ]
+        },
+        "status": 200,
+        "response": {}
+    },
+    {
+        "label": "deprecated user_id is resolved to a UUID via the workspace's users",
+        "method": "POST",
+        "path": "/mi/notification/publish",
+        "body": {
+            "org_id": 1,
+            "notifications": [
                 {"user_id": 3, "data": {"type": "export:finished", "is_seen": false, "url": "/notification/read/123/"}}
             ]
         },
         "status": 200,
         "response": {}
+    },
+    {
+        "label": "deprecated user_id that isn't a workspace user is skipped rather than failing the batch",
+        "method": "POST",
+        "path": "/mi/notification/publish",
+        "body": {
+            "org_id": 1,
+            "notifications": [
+                {"user_id": 12345678, "data": {"type": "export:finished", "is_seen": false, "url": "/notification/read/123/"}}
+            ]
+        },
+        "status": 200,
+        "response": {}
+    },
+    {
+        "label": "notification without user_uuid or user_id is an error",
+        "method": "POST",
+        "path": "/mi/notification/publish",
+        "body": {
+            "org_id": 1,
+            "notifications": [
+                {"data": {"type": "export:finished"}}
+            ]
+        },
+        "status": 400,
+        "response": {
+            "error": "notification 0: user_uuid or user_id required"
+        }
     }
 ]


### PR DESCRIPTION
Notification sockets are addressed by user UUID, but externally-created notifications arrived at `/mi/notification/publish` with only a user id, which was resolved against the workspace's users. That lookup fails - and the notification is silently dropped, with an error logged - for users who aren't members of the workspace, e.g. staff who serviced it and ran an export there.

The endpoint now takes `user_uuid` per notification and addresses the socket directly, with no user lookup, so those notifications are actually delivered. `user_id` is still accepted as a deprecated fallback for callers that don't send `user_uuid` yet - that path keeps the old assets lookup and its error logging (a notification that can't be resolved there really is lost and should be visible). Sending neither is a 400. The fallback and `user_id` can be removed once all callers send `user_uuid`.

`PublishNotifications` (for notifications created here: imports, tickets, incidents) is unchanged and keeps its unknown-user error logging.

Pairs with nyaruka/rapidpro#6707, which makes the caller send both fields. Either side can deploy first.

Tests updated: endpoint testdata covers the UUID path, the deprecated fallback, the unknown-user skip and the missing-both error; the model test now asserts a non-member user's subscribed socket receives its payload.