### PR TITLE
Rename public listener to internet and report listener in health endpoint

### DIFF
--- a/testsuite/web.go
+++ b/testsuite/web.go
@@ -71,7 +71,7 @@ func RunWebTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 	}
 
 	for i, tc := range tcs {
-		// route /mi/* requests to the internal listener and everything else to the public listener
+		// route /mi/* requests to the internal listener and everything else to the internet listener
 		host := "http://localhost:8190"
 		if strings.HasPrefix(tc.Path, "/mi/") {
 			host = "http://localhost:8191"

--- a/web/public/airtime.go
+++ b/web/public/airtime.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	web.PublicRoute(http.MethodPost, "/airtime/dtone/status", handleDTOneStatus)
+	web.InternetRoute(http.MethodPost, "/airtime/dtone/status", handleDTOneStatus)
 }
 
 // dtoneStatusBody is the subset of DT One's transaction callback payload we care about. See

--- a/web/public/docs.go
+++ b/web/public/docs.go
@@ -14,10 +14,10 @@ func init() {
 	docServer = http.StripPrefix("/mr/docs", http.FileServer(http.Dir("docs")))
 
 	// redirect non slashed docs to slashed version so relative URLs work
-	web.PublicRoute(http.MethodGet, "/docs", addSlashRedirect)
+	web.InternetRoute(http.MethodGet, "/docs", addSlashRedirect)
 
 	// all slashed docs are served by our static dir
-	web.PublicRoute(http.MethodGet, "/docs/*", handleDocs)
+	web.InternetRoute(http.MethodGet, "/docs/*", handleDocs)
 }
 
 func addSlashRedirect(ctx context.Context, rt *runtime.Runtime, r *http.Request, rawW http.ResponseWriter) error {

--- a/web/public/ivr.go
+++ b/web/public/ivr.go
@@ -22,9 +22,9 @@ import (
 )
 
 func init() {
-	web.PublicRoute(http.MethodPost, "/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/handle", newIVRHandler(handleCallback, models.ChannelLogTypeIVRCallback))
-	web.PublicRoute(http.MethodPost, "/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/status", newIVRHandler(handleStatus, models.ChannelLogTypeIVRStatus))
-	web.PublicRoute(http.MethodPost, "/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/incoming", newIVRHandler(handleIncoming, models.ChannelLogTypeIVRIncoming))
+	web.InternetRoute(http.MethodPost, "/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/handle", newIVRHandler(handleCallback, models.ChannelLogTypeIVRCallback))
+	web.InternetRoute(http.MethodPost, "/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/status", newIVRHandler(handleStatus, models.ChannelLogTypeIVRStatus))
+	web.InternetRoute(http.MethodPost, "/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/incoming", newIVRHandler(handleIncoming, models.ChannelLogTypeIVRIncoming))
 }
 
 type ivrHandlerFn func(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, ch *models.Channel, svc ivr.Service, r *http.Request, w http.ResponseWriter) (*models.Call, error)

--- a/web/public/metrics.go
+++ b/web/public/metrics.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	web.PublicRoute(http.MethodGet, "/org/{uuid:[0-9a-f\\-]+}/metrics", handleMetrics)
+	web.InternetRoute(http.MethodGet, "/org/{uuid:[0-9a-f\\-]+}/metrics", handleMetrics)
 }
 
 const groupCountsSQL = `

--- a/web/server.go
+++ b/web/server.go
@@ -28,12 +28,12 @@ type route struct {
 	handler Handler
 }
 
-var publicRoutes []*route
+var internetRoutes []*route
 var internalRoutes []*route
 
-// PublicRoute registers a route that handles direct requests from the internet
-func PublicRoute(method string, pattern string, handler Handler) {
-	publicRoutes = append(publicRoutes, &route{method: method, pattern: pattern, handler: handler})
+// InternetRoute registers a route that handles direct requests from the internet
+func InternetRoute(method string, pattern string, handler Handler) {
+	internetRoutes = append(internetRoutes, &route{method: method, pattern: pattern, handler: handler})
 }
 
 // InternalRoute registers a route that handles internal requests between components
@@ -47,7 +47,7 @@ type Server struct {
 
 	wg *sync.WaitGroup
 
-	publicServer   *http.Server
+	internetServer *http.Server
 	internalServer *http.Server
 }
 
@@ -55,22 +55,22 @@ type Server struct {
 func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Server {
 	s := &Server{ctx: ctx, rt: rt, wg: wg}
 
-	// public listener — exposes only /mr/* routes
-	publicRouter := chi.NewRouter()
-	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
-	publicRouter.Use(middleware.RequestID)
-	publicRouter.Use(middleware.RealIP)
-	publicRouter.Use(panicRecovery("public"))
-	publicRouter.Use(middleware.Timeout(60 * time.Second))
-	publicRouter.Use(requestLogger("public"))
-	publicRouter.NotFound(handle404)
-	publicRouter.MethodNotAllowed(handle405)
-	publicRouter.Get("/", s.WrapHandler(handleHealth))
-	for _, route := range publicRoutes {
-		publicRouter.Method(route.method, "/mr"+route.pattern, s.WrapHandler(route.handler))
+	// internet listener — exposes only /mr/* routes
+	internetRouter := chi.NewRouter()
+	internetRouter.Use(middleware.Compress(flate.DefaultCompression))
+	internetRouter.Use(middleware.RequestID)
+	internetRouter.Use(middleware.RealIP)
+	internetRouter.Use(panicRecovery("internet"))
+	internetRouter.Use(middleware.Timeout(60 * time.Second))
+	internetRouter.Use(requestLogger("internet"))
+	internetRouter.NotFound(handle404)
+	internetRouter.MethodNotAllowed(handle405)
+	internetRouter.Get("/", s.WrapHandler(handleHealth("internet")))
+	for _, route := range internetRoutes {
+		internetRouter.Method(route.method, "/mr"+route.pattern, s.WrapHandler(route.handler))
 	}
 
-	// internal listener — only /mi/* routes, no public-facing concerns
+	// internal listener — only /mi/* routes, no internet-facing concerns
 	internalRouter := chi.NewRouter()
 	internalRouter.Use(middleware.Compress(flate.DefaultCompression))
 	internalRouter.Use(middleware.RequestID)
@@ -85,14 +85,14 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 		slog.Error("internal 405", "method", r.Method, "path", r.URL.Path)
 		handle405(w, r)
 	})
-	internalRouter.Get("/", s.WrapHandler(handleHealth))
+	internalRouter.Get("/", s.WrapHandler(handleHealth("internal")))
 	for _, route := range internalRoutes {
 		internalRouter.Method(route.method, "/mi"+route.pattern, s.WrapHandler(route.handler))
 	}
 
-	s.publicServer = &http.Server{
+	s.internetServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", rt.Config.PublicAddress, rt.Config.PublicPort),
-		Handler:      publicRouter,
+		Handler:      internetRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  90 * time.Second,
@@ -135,10 +135,10 @@ func (s *Server) Start() {
 	go func() {
 		defer s.wg.Done()
 
-		log := slog.With("comp", "server", "listener", "public", "address", s.publicServer.Addr)
+		log := slog.With("comp", "server", "listener", "internet", "address", s.internetServer.Addr)
 		log.Info("server started")
 
-		err := s.publicServer.ListenAndServe()
+		err := s.internetServer.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
 			log.Error("error listening", "error", err)
 		}
@@ -159,10 +159,10 @@ func (s *Server) Start() {
 
 // Stop stops our web server
 func (s *Server) Stop() {
-	if err := s.publicServer.Shutdown(context.Background()); err != nil {
-		slog.Error("error shutting down server", "comp", "server", "listener", "public", "error", err)
+	if err := s.internetServer.Shutdown(context.Background()); err != nil {
+		slog.Error("error shutting down server", "comp", "server", "listener", "internet", "error", err)
 	} else {
-		slog.Info("server stopped", "comp", "server", "listener", "public")
+		slog.Info("server stopped", "comp", "server", "listener", "internet")
 	}
 
 	if err := s.internalServer.Shutdown(context.Background()); err != nil {
@@ -172,15 +172,18 @@ func (s *Server) Stop() {
 	}
 }
 
-// handleHealth is the liveness probe used by ALB health checks. Registered at the root of
+// handleHealth returns the liveness probe used by ALB health checks. Registered at the root of
 // both listeners and not under any /mr or /mi prefix, so no listener rule routes client
 // traffic to it — only direct ALB→target health probes reach it. Also returns the running
-// version so it doubles as a debug endpoint.
-func handleHealth(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error {
-	return WriteMarshalled(w, http.StatusOK, map[string]string{
-		"component": "mailroom",
-		"version":   rt.Config.Version,
-	})
+// version and which listener was hit so it doubles as a debug endpoint.
+func handleHealth(listener string) Handler {
+	return func(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error {
+		return WriteMarshalled(w, http.StatusOK, map[string]string{
+			"component": "mailroom",
+			"listener":  listener,
+			"version":   rt.Config.Version,
+		})
+	}
 }
 
 func handle404(w http.ResponseWriter, r *http.Request) {

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,6 +1,7 @@
 package web_test
 
 import (
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -12,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	// blank-imported so TestListeners has both a registered internal and public route to probe
+	// blank-imported so TestListeners has both a registered internal and internet route to probe
 	_ "github.com/nyaruka/mailroom/v26/web/contact"
 	_ "github.com/nyaruka/mailroom/v26/web/public"
 )
@@ -23,7 +24,7 @@ func TestServer(t *testing.T) {
 	testsuite.RunWebTests(t, rt, "testdata/server.json")
 }
 
-// TestListeners verifies that public and internal endpoints are correctly split
+// TestListeners verifies that internet and internal endpoints are correctly split
 // between the two listener ports.
 func TestListeners(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
@@ -44,7 +45,7 @@ func TestListeners(t *testing.T) {
 		}, 5*time.Second, 10*time.Millisecond, "listener at %s never came up", addr)
 	}
 
-	const publicURL = "http://localhost:8190"
+	const internetURL = "http://localhost:8190"
 	const internalURL = "http://localhost:8191"
 
 	// don't follow redirects so we can assert on the 301 from /mr/docs
@@ -57,18 +58,19 @@ func TestListeners(t *testing.T) {
 		method string
 		url    string
 		status int
+		body   string
 	}{
-		// public listener: health at /, public routes — no /mi/* routes
-		{"public: health", "GET", publicURL + "/", 200},
-		{"public: public route", "GET", publicURL + "/mr/docs", 301},
-		{"public: internal route not exposed", "GET", publicURL + "/mi/contact/parse_query", 404},
-		{"public: unknown path", "GET", publicURL + "/nope", 404},
+		// internet listener: health at /, internet routes — no /mi/* routes
+		{"internet: health", "GET", internetURL + "/", 200, `{"component": "mailroom", "listener": "internet", "version": "Dev"}`},
+		{"internet: internet route", "GET", internetURL + "/mr/docs", 301, ""},
+		{"internet: internal route not exposed", "GET", internetURL + "/mi/contact/parse_query", 404, ""},
+		{"internet: unknown path", "GET", internetURL + "/nope", 404, ""},
 
 		// internal listener: health at /, /mi/* routes — no /mr/*
-		{"internal: health", "GET", internalURL + "/", 200},
-		{"internal: internal route via GET (wrong method)", "GET", internalURL + "/mi/contact/parse_query", 405},
-		{"internal: public route not exposed", "GET", internalURL + "/mr/docs", 404},
-		{"internal: unknown path", "GET", internalURL + "/nope", 404},
+		{"internal: health", "GET", internalURL + "/", 200, `{"component": "mailroom", "listener": "internal", "version": "Dev"}`},
+		{"internal: internal route via GET (wrong method)", "GET", internalURL + "/mi/contact/parse_query", 405, ""},
+		{"internal: internet route not exposed", "GET", internalURL + "/mr/docs", 404, ""},
+		{"internal: unknown path", "GET", internalURL + "/nope", 404, ""},
 	}
 
 	for _, tc := range tcs {
@@ -77,8 +79,13 @@ func TestListeners(t *testing.T) {
 
 		resp, err := client.Do(req)
 		require.NoError(t, err, tc.label)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, tc.label)
 		resp.Body.Close()
 
 		assert.Equal(t, tc.status, resp.StatusCode, tc.label)
+		if tc.body != "" {
+			assert.JSONEq(t, tc.body, string(body), tc.label)
+		}
 	}
 }

--- a/web/testdata/server.json
+++ b/web/testdata/server.json
@@ -9,12 +9,13 @@
         }
     },
     {
-        "label": "health at root returns component and version",
+        "label": "health at root returns component, listener and version",
         "method": "GET",
         "path": "/",
         "status": 200,
         "response": {
             "component": "mailroom",
+            "listener": "internet",
             "version": "Dev"
         }
     },


### PR DESCRIPTION
Follow-up to nyaruka/courier#1047, making the same change here.

* Renames the "public" listener/router/server naming to "internet" (`internetRouter`, `internetServer`, `"listener", "internet"` log attributes, comments) to match the internet-facing vs internal terminology used by load balancers. The route registration function `web.PublicRoute` becomes `web.InternetRoute` to match.
* The health endpoint at `/` on both listeners now includes a `"listener": "internet" | "internal"` field in its response, so it's easy to tell which listener served a probe. Done with the same handler-factory pattern courier used.
* Config fields (`PublicAddress` / `PublicPort`) and their env vars are intentionally left unchanged — renaming those is a breaking config change to be handled separately. The `web/public` package name is also left as-is since it names the URL namespace rather than the listener.