### PR TITLE
Rename Public* server config to Internet*, default internal address to all interfaces

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -26,8 +26,8 @@ type Config struct {
 	Valkey     string `validate:"url,startswith=valkey:"             help:"URL for your Valkey instance"`
 	SentryDSN  string `                                              help:"the DSN used for logging errors to Sentry"`
 
-	PublicAddress    string `help:"the address to bind our public web server to, empty means all interfaces"`
-	PublicPort       int    `help:"the port to bind our public web server to"`
+	InternetAddress  string `help:"the address to bind our internet facing web server to, empty means all interfaces"`
+	InternetPort     int    `help:"the port to bind our internet facing web server to"`
 	InternalAddress  string `help:"the address to bind our internal web server to, empty means all interfaces"`
 	InternalPort     int    `help:"the port to bind our internal web server to"`
 	AuthToken        string `help:"the token clients will need to authenticate web requests"`
@@ -103,8 +103,8 @@ func NewDefaultConfig() *Config {
 		DBPoolSize: 36,
 		Valkey:     "valkey://valkey:6379/15",
 
-		PublicAddress:   "",
-		PublicPort:      8090,
+		InternetAddress: "",
+		InternetPort:    8090,
 		InternalAddress: "",
 		InternalPort:    8091,
 		SpoolDir:        "./_spool",

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -26,9 +26,9 @@ type Config struct {
 	Valkey     string `validate:"url,startswith=valkey:"             help:"URL for your Valkey instance"`
 	SentryDSN  string `                                              help:"the DSN used for logging errors to Sentry"`
 
-	PublicAddress    string `help:"the address to bind our public web server to"`
+	PublicAddress    string `help:"the address to bind our public web server to, empty means all interfaces"`
 	PublicPort       int    `help:"the port to bind our public web server to"`
-	InternalAddress  string `help:"the address to bind our internal web server to"`
+	InternalAddress  string `help:"the address to bind our internal web server to, empty means all interfaces"`
 	InternalPort     int    `help:"the port to bind our internal web server to"`
 	AuthToken        string `help:"the token clients will need to authenticate web requests"`
 	Domain           string `help:"the domain that mailroom is listening on"`
@@ -105,7 +105,7 @@ func NewDefaultConfig() *Config {
 
 		PublicAddress:   "",
 		PublicPort:      8090,
-		InternalAddress: "localhost",
+		InternalAddress: "",
 		InternalPort:    8091,
 		SpoolDir:        "./_spool",
 

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -68,7 +68,7 @@ func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DeploymentID = "test"
-	cfg.PublicPort = 8190
+	cfg.InternetPort = 8190
 	cfg.InternalPort = 8191
 	cfg.DB = "postgres://mailroom_test:temba@postgres/mailroom_test?sslmode=disable&Timezone=UTC"
 	cfg.Valkey = "valkey://valkey:6379/10" // use a different DB from the default so a locally-running courier can't pop from queues we're asserting on

--- a/web/server.go
+++ b/web/server.go
@@ -91,7 +91,7 @@ func NewServer(ctx context.Context, rt *runtime.Runtime, wg *sync.WaitGroup) *Se
 	}
 
 	s.internetServer = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", rt.Config.PublicAddress, rt.Config.PublicPort),
+		Addr:         fmt.Sprintf("%s:%d", rt.Config.InternetAddress, rt.Config.InternetPort),
 		Handler:      internetRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,


### PR DESCRIPTION
* Renames the `PublicAddress`/`PublicPort` config fields to `InternetAddress`/`InternetPort` (env vars `MAILROOM_INTERNET_ADDRESS`/`MAILROOM_INTERNET_PORT`), matching the `internetServer`/`internalServer` naming in `web.Server`.
* Changes the `InternalAddress` default from `localhost` to `""` (all interfaces), matching the internet server. Operators who want either server bound more narrowly can still set the address explicitly.