### PR TITLE
Remove allInstances option from crons

### DIFF
--- a/core/crons/base.go
+++ b/core/crons/base.go
@@ -36,10 +36,6 @@ type Cron interface {
 
 	// Run performs the task
 	Run(context.Context, *runtime.Runtime) (map[string]any, error)
-
-	// AllInstances returns whether cron runs on all instances - i.e. locking is instance specific. This is for crons
-	// like metrics which report instance specific stats. Other crons are synchronized across all instances.
-	AllInstances() bool
 }
 
 var registeredCrons = map[string]Cron{}
@@ -52,7 +48,7 @@ func Register(name string, c Cron) {
 // StartAll starts all registered cron jobs
 func StartAll(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) {
 	for name, c := range registeredCrons {
-		crons.Start(rt, wg, name, c.AllInstances(), recordExecution(name, c.Run), c.Next, time.Minute*5, quit)
+		crons.Start(rt, wg, name, recordExecution(name, c.Run), c.Next, time.Minute*5, quit)
 	}
 }
 

--- a/core/crons/base_test.go
+++ b/core/crons/base_test.go
@@ -40,10 +40,6 @@ func (c *TestCron) Next(last time.Time) time.Time {
 	return crons.Next(last, time.Minute*5)
 }
 
-func (c *TestCron) AllInstances() bool {
-	return false
-}
-
 func (c *TestCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	c.ran = true
 	return map[string]any{"foo": 123}, nil

--- a/core/crons/deindex_deleted_orgs.go
+++ b/core/crons/deindex_deleted_orgs.go
@@ -26,10 +26,6 @@ func (c *DeindexDeletedOrgsCron) Next(last time.Time) time.Time {
 	return Next(last, time.Minute*5)
 }
 
-func (c *DeindexDeletedOrgsCron) AllInstances() bool {
-	return false
-}
-
 func (c *DeindexDeletedOrgsCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	vc := rt.VK.Get()
 	defer vc.Close()

--- a/core/crons/end_incidents.go
+++ b/core/crons/end_incidents.go
@@ -22,10 +22,6 @@ func (c *EndIncidentsCron) Next(last time.Time) time.Time {
 	return Next(last, time.Minute*3)
 }
 
-func (c *EndIncidentsCron) AllInstances() bool {
-	return false
-}
-
 // EndIncidents checks open incidents and end any that no longer apply
 func (c *EndIncidentsCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	incidents, err := models.GetOpenIncidents(ctx, rt.DB, []models.IncidentType{models.IncidentTypeWebhooksUnhealthy})

--- a/core/crons/fire_contacts.go
+++ b/core/crons/fire_contacts.go
@@ -31,10 +31,6 @@ func (c *FireContactsCron) Next(last time.Time) time.Time {
 	return Next(last, 30*time.Second)
 }
 
-func (c *FireContactsCron) AllInstances() bool {
-	return false
-}
-
 func (c *FireContactsCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	start := time.Now()
 	numWaitTimeouts, numWaitExpires, numSessionExpires, numCampaignPoints := 0, 0, 0, 0

--- a/core/crons/fire_schedules.go
+++ b/core/crons/fire_schedules.go
@@ -21,10 +21,6 @@ func (c *FireSchedulesCron) Next(last time.Time) time.Time {
 	return Next(last, time.Minute)
 }
 
-func (c *FireSchedulesCron) AllInstances() bool {
-	return false
-}
-
 // checkSchedules looks up any expired schedules and fires them, setting the next fire as needed
 func (c *FireSchedulesCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	// we sleep 1 second since we fire right on the minute and want to make sure to fire

--- a/core/crons/retry_calls.go
+++ b/core/crons/retry_calls.go
@@ -21,10 +21,6 @@ func (c *RetryCallsCron) Next(last time.Time) time.Time {
 	return Next(last, time.Minute)
 }
 
-func (c *RetryCallsCron) AllInstances() bool {
-	return false
-}
-
 // RetryCalls looks for calls that need to be retried and retries them
 func (c *RetryCallsCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	log := slog.With("comp", "ivr_cron_retryer")

--- a/core/crons/retry_sending.go
+++ b/core/crons/retry_sending.go
@@ -20,10 +20,6 @@ func (c *RetrySendingCron) Next(last time.Time) time.Time {
 	return Next(last, time.Minute)
 }
 
-func (c *RetrySendingCron) AllInstances() bool {
-	return false
-}
-
 func (c *RetrySendingCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	vc := rt.VK.Get()
 	defer vc.Close()

--- a/core/crons/sync_android_channels.go
+++ b/core/crons/sync_android_channels.go
@@ -17,10 +17,6 @@ func init() {
 
 type SyncAndroidChannelsCron struct{}
 
-func (s *SyncAndroidChannelsCron) AllInstances() bool {
-	return true
-}
-
 func (s *SyncAndroidChannelsCron) Next(last time.Time) time.Time {
 	return Next(last, time.Minute*10)
 

--- a/core/crons/throttle_queue.go
+++ b/core/crons/throttle_queue.go
@@ -26,10 +26,6 @@ func (c *ThrottleQueueCron) Next(last time.Time) time.Time {
 	return Next(last, time.Second*10)
 }
 
-func (c *ThrottleQueueCron) AllInstances() bool {
-	return false
-}
-
 // Run throttles processing of starts based on that org's current outbox size
 func (c *ThrottleQueueCron) Run(ctx context.Context, rt *runtime.Runtime) (map[string]any, error) {
 	vc := rt.VK.Get()

--- a/utils/crons/cron.go
+++ b/utils/crons/cron.go
@@ -20,17 +20,12 @@ type Function func(context.Context, *runtime.Runtime) error
 // lock so that only one process is running at once. Note that across processes
 // crons may be called more often than duration as there is no inter-process
 // coordination of cron fires. (this might be a worthy addition)
-func Start(rt *runtime.Runtime, wg *sync.WaitGroup, name string, allInstances bool, cronFunc Function, next func(time.Time) time.Time, timeout time.Duration, quit chan bool) {
+func Start(rt *runtime.Runtime, wg *sync.WaitGroup, name string, cronFunc Function, next func(time.Time) time.Time, timeout time.Duration, quit chan bool) {
 	ctx := context.TODO()
 
 	wg.Add(1) // add ourselves to the wait group
 
 	lockName := fmt.Sprintf("lock:%s_lock", name) // for historical reasons...
-
-	// for jobs that run on all instances, the lock key is specific to this instance
-	if allInstances {
-		lockName = fmt.Sprintf("%s:%s", lockName, rt.Config.InstanceID)
-	}
 
 	locker := locks.NewLocker(lockName, timeout+time.Second*30)
 

--- a/utils/crons/cron_test.go
+++ b/utils/crons/cron_test.go
@@ -53,7 +53,7 @@ func TestCron(t *testing.T) {
 	}
 
 	// start a job that takes ~100 ms and runs every 250ms
-	crons.Start(rt, wg, "test1", false, createCronFunc(&running, &fired, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
+	crons.Start(rt, wg, "test1", createCronFunc(&running, &fired, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
 
 	// wait a bit, should only have fired three times (initial time + three repeats)
 	time.Sleep(time.Millisecond * 875) // time for 3 delays between tasks plus half of another delay
@@ -72,7 +72,7 @@ func TestCron(t *testing.T) {
 	align()
 
 	// simulate the job taking 400ms to run on the second fire, thus skipping the third fire
-	crons.Start(rt, wg, "test2", false, createCronFunc(&running, &fired, map[int]time.Duration{1: time.Millisecond * 400}, time.Millisecond*100), next, time.Minute, quit)
+	crons.Start(rt, wg, "test2", createCronFunc(&running, &fired, map[int]time.Duration{1: time.Millisecond * 400}, time.Millisecond*100), next, time.Minute, quit)
 
 	time.Sleep(time.Millisecond * 875)
 	assert.Equal(t, 3, fired)
@@ -80,14 +80,8 @@ func TestCron(t *testing.T) {
 	close(quit)
 
 	// simulate two different instances running the same cron
-	cfg1 := *rt.Config
-	cfg2 := *rt.Config
-	cfg1.InstanceID = "instance1"
-	cfg2.InstanceID = "instance2"
 	rt1 := *rt
-	rt1.Config = &cfg1
 	rt2 := *rt
-	rt2.Config = &cfg2
 
 	fired1 := 0
 	fired2 := 0
@@ -96,31 +90,12 @@ func TestCron(t *testing.T) {
 
 	align()
 
-	crons.Start(&rt1, wg, "test3", false, createCronFunc(&running, &fired1, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
-	crons.Start(&rt2, wg, "test3", false, createCronFunc(&running, &fired2, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
+	crons.Start(&rt1, wg, "test3", createCronFunc(&running, &fired1, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
+	crons.Start(&rt2, wg, "test3", createCronFunc(&running, &fired2, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
 
 	// same number of fires as if only a single instance was running it...
 	time.Sleep(time.Millisecond * 875)
 	assert.Equal(t, 4, fired1+fired2) // can't say which instances will run the 4 fires
-
-	close(quit)
-
-	fired1 = 0
-	fired2 = 0
-	quit = make(chan bool)
-	running1 := false
-	running2 := false
-
-	align()
-
-	// unless we start the cron with allInstances = true
-	crons.Start(&rt1, wg, "test4", true, createCronFunc(&running1, &fired1, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
-	crons.Start(&rt2, wg, "test4", true, createCronFunc(&running2, &fired2, map[int]time.Duration{}, time.Millisecond*100), next, time.Minute, quit)
-
-	// now both instances fire 4 times
-	time.Sleep(time.Millisecond * 875)
-	assert.Equal(t, 4, fired1)
-	assert.Equal(t, 4, fired2)
 
 	close(quit)
 }


### PR DESCRIPTION
The `allInstances` cron option ran a cron on every instance by making its lock name instance-specific. Its only user was `sync_android_channels`, which has no instance-specific state — every instance ran the same DB query and FCM-nudged the same devices, so all-instances execution just produced duplicate sync messages per cycle (FCM's `sync` collapse key means duplicates don't even improve delivery). It's now a regular singleton cron.

This also removes the cron system's dependence on `InstanceID`, and gives one authoritative synced/errored result per cycle instead of N overlapping ones.