### PR TITLE
Publish instance level metrics without a Host dimension and remove InstanceID config setting

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -31,7 +31,7 @@ func Service(version, date string) error {
 
 	// if we have a DSN entry, try to initialize it
 	if cfg.SentryDSN != "" {
-		err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, ServerName: cfg.InstanceID, Release: version, AttachStacktrace: true})
+		err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, Release: version, AttachStacktrace: true})
 		if err != nil {
 			return err
 		}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net"
 	"net/url"
-	"os"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/nyaruka/ezconf"
@@ -77,7 +76,6 @@ type Config struct {
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
 	CloudwatchNamespace string `help:"the namespace to use for cloudwatch metrics"`
 	DeploymentID        string `help:"the deployment identifier to use for metrics"`
-	InstanceID          string `help:"the instance identifier to use for metrics"`
 
 	AndroidCredentialsFile string `help:"path to JSON file with FCM service account credentials used to sync Android relayers"`
 	IDObfuscationKey       string `help:"key used to decode obfuscated IDs, as 4 comma separated integers" validate:"omitempty,hexadecimal,len=32"`
@@ -95,8 +93,6 @@ type Config struct {
 
 // NewDefaultConfig returns a new default configuration object
 func NewDefaultConfig() *Config {
-	hostname, _ := os.Hostname()
-
 	return &Config{
 		DB:         "postgres://temba:temba@postgres/temba?sslmode=disable&Timezone=UTC",
 		ReadonlyDB: "",
@@ -143,7 +139,6 @@ func NewDefaultConfig() *Config {
 		MetricsReporting:    "off",
 		CloudwatchNamespace: "Mailroom",
 		DeploymentID:        "dev",
-		InstanceID:          hostname,
 
 		IDObfuscationKey: "000A3B1C000D2E3F0001A2B300C0FFEE",
 

--- a/service.go
+++ b/service.go
@@ -196,20 +196,21 @@ func (s *Service) reportMetrics(ctx context.Context) (int, error) {
 	s.dbWaitDuration = dbStats.WaitDuration
 	s.vkWaitDuration = vkStats.WaitDuration
 
-	hostDim := cwatch.Dimension("Host", s.rt.Config.InstanceID)
+	// instance level metrics are published without an instance dimension so that instances (which come and go with
+	// deploys) are just samples of the same metric, and can be aggregated with statistics like Max and Sum
 	metrics = append(metrics,
-		cwatch.Datum("DBConnectionsInUse", float64(dbStats.InUse), types.StandardUnitCount, hostDim),
-		cwatch.Datum("DBConnectionWaitDuration", float64(dbWaitDurationInPeriod)/float64(time.Second), types.StandardUnitSeconds, hostDim),
-		cwatch.Datum("ValkeyConnectionsInUse", float64(vkStats.ActiveCount), types.StandardUnitCount, hostDim),
-		cwatch.Datum("ValkeyConnectionsWaitDuration", float64(vkWaitDurationInPeriod)/float64(time.Second), types.StandardUnitSeconds, hostDim),
+		cwatch.Datum("DBConnectionsInUse", float64(dbStats.InUse), types.StandardUnitCount),
+		cwatch.Datum("DBConnectionWaitDuration", float64(dbWaitDurationInPeriod)/float64(time.Second), types.StandardUnitSeconds),
+		cwatch.Datum("ValkeyConnectionsInUse", float64(vkStats.ActiveCount), types.StandardUnitCount),
+		cwatch.Datum("ValkeyConnectionsWaitDuration", float64(vkWaitDurationInPeriod)/float64(time.Second), types.StandardUnitSeconds),
 		cwatch.Datum("QueuedTasks", float64(realtimeSize), types.StandardUnitCount, cwatch.Dimension("QueueName", "realtime")),
 		cwatch.Datum("QueuedTasks", float64(batchSize), types.StandardUnitCount, cwatch.Dimension("QueueName", "batch")),
 		cwatch.Datum("QueuedTasks", float64(throttledSize), types.StandardUnitCount, cwatch.Dimension("QueueName", "throttled")),
-		cwatch.Datum("DynamoSpooledItems", float64(s.rt.Dynamo.Spool.Size()), types.StandardUnitCount, hostDim),
+		cwatch.Datum("DynamoSpooledItems", float64(s.rt.Dynamo.Spool.Size()), types.StandardUnitCount),
 	)
 
 	metrics = append(metrics,
-		cwatch.Datum("ElasticSpooledItems", float64(s.rt.ES.Spool.Size()), types.StandardUnitCount, hostDim),
+		cwatch.Datum("ElasticSpooledItems", float64(s.rt.ES.Spool.Size()), types.StandardUnitCount),
 	)
 
 	if err := s.rt.CW.Send(ctx, metrics...); err != nil {


### PR DESCRIPTION
Drops the `Host` dimension from the instance-level metrics (`DBConnectionsInUse`, `DBConnectionWaitDuration`, `ValkeyConnectionsInUse`, `ValkeyConnectionsWaitDuration`, `DynamoSpooledItems`, `ElasticSpooledItems`). Same reasoning as nyaruka/courier#1052: per-instance metric streams churn in container environments, breaking alarms/dashboards bound to specific `Host` values, while un-dimensioned samples aggregate cleanly with `Max`/`Sum`/`SampleCount` statistics.

Note for operators: the un-dimensioned metrics are new streams, so alarms on the old `Host`-dimensioned metrics (e.g. on `DynamoSpooledItems`/`ElasticSpooledItems`) should be recreated against the new ones.

Since this removed `InstanceID`'s last real consumer, the config setting is also removed — its only other use was Sentry's `ServerName`, which the SDK already defaults to the hostname.