### PR TITLE
Use fixed 110s threshold for reporting slow tasks

### DIFF
--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -12,6 +12,10 @@ import (
 	"github.com/nyaruka/mailroom/v26/utils/queues"
 )
 
+// tasks that take longer than this can't stop gracefully during a deployment (matches the maximum
+// stop timeout for an ECS task on Fargate) so are logged as errors
+const maxNormalDuration = 120 * time.Second
+
 var registeredTypes = map[string](func() Task){}
 
 // RegisterType registers a new type of task
@@ -52,9 +56,8 @@ func Perform(ctx context.Context, rt *runtime.Runtime, task *queues.Task) error 
 
 	err = typedTask.Perform(ctx, rt, oa)
 
-	// log if task took longer than 75% of its timeout
-	if duration := time.Since(start); duration >= (3 * typedTask.Timeout() / 4) {
-		slog.Error("task took longer than expected", "org", oa.OrgID(), "type", typedTask.Type(), "duration", duration, "limit", typedTask.Timeout())
+	if duration := time.Since(start); duration >= maxNormalDuration {
+		slog.Error("task took longer than expected", "org", oa.OrgID(), "type", typedTask.Type(), "duration", duration, "limit", maxNormalDuration)
 	}
 
 	return err

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -12,9 +12,10 @@ import (
 	"github.com/nyaruka/mailroom/v26/utils/queues"
 )
 
-// tasks that take longer than this can't stop gracefully during a deployment (matches the maximum
-// stop timeout for an ECS task on Fargate) so are logged as errors
-const maxNormalDuration = 120 * time.Second
+// tasks that take longer than this are logged as errors - set slightly below the maximum stop
+// timeout for an ECS task on Fargate (120s) so we catch tasks getting dangerously close to a
+// duration where they couldn't stop gracefully during a deployment
+const maxNormalDuration = 110 * time.Second
 
 var registeredTypes = map[string](func() Task){}
 

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -17,6 +17,13 @@ import (
 // duration where they couldn't stop gracefully during a deployment
 const maxNormalDuration = 110 * time.Second
 
+// slowThreshold is the duration after which a task is logged as an error - the lesser of
+// maxNormalDuration and 75% of the task's own timeout, so that tasks with short timeouts are
+// still reported when they get close to timing out
+func slowThreshold(timeout time.Duration) time.Duration {
+	return min(maxNormalDuration, 3*timeout/4)
+}
+
 var registeredTypes = map[string](func() Task){}
 
 // RegisterType registers a new type of task
@@ -57,8 +64,8 @@ func Perform(ctx context.Context, rt *runtime.Runtime, task *queues.Task) error 
 
 	err = typedTask.Perform(ctx, rt, oa)
 
-	if duration := time.Since(start); duration >= maxNormalDuration {
-		slog.Error("task took longer than expected", "org", oa.OrgID(), "type", typedTask.Type(), "duration", duration, "limit", maxNormalDuration)
+	if duration := time.Since(start); duration >= slowThreshold(typedTask.Timeout()) {
+		slog.Error("task took longer than expected", "org", oa.OrgID(), "type", typedTask.Type(), "duration", duration, "timeout", typedTask.Timeout())
 	}
 
 	return err


### PR DESCRIPTION
Previously a task was reported as an error if it ran longer than 75% of its task type's timeout, which varied from 45 seconds to 45 minutes depending on the type.

Since the maximum stop timeout for an ECS task on Fargate is 120 seconds ([2–120s, SIGKILL after that](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html)), any task running longer than that can't stop gracefully during a deployment. Tasks are now reported as errors when they run longer than the lesser of:

* 110 seconds — slightly below that platform limit, so we also catch tasks getting dangerously close to it
* 75% of the task type's own timeout — so types with short timeouts are still reported when they get close to timing out

Per-type `Timeout()` values are unchanged and still set the context deadline for how long a task may run, and are included in the error log attributes.