### PR TITLE
Fail startup if postgres or valkey are unreachable

### DIFF
--- a/service.go
+++ b/service.go
@@ -58,30 +58,28 @@ func (s *Service) Start() error {
 
 	log := slog.With("comp", "mailroom")
 
-	// test Postgres
+	// we can't function at all without Postgres and Valkey so unreachable is fatal, whereas writes to services
+	// like DynamoDB and Elastic are spooled so we can start without them and recover later
 	if err := checkDBConnection(s.rt.DB.DB); err != nil {
-		log.Error("postgres not reachable", "error", err)
-	} else {
-		log.Info("postgres ok")
+		return fmt.Errorf("postgres not reachable: %w", err)
 	}
+	log.Info("postgres ok")
+
 	if s.rt.ReadonlyDB != s.rt.DB.DB {
 		if err := checkDBConnection(s.rt.ReadonlyDB); err != nil {
-			log.Error("readonly db not reachable", "error", err)
-		} else {
-			log.Info("readonly db ok")
+			return fmt.Errorf("readonly db not reachable: %w", err)
 		}
+		log.Info("readonly db ok")
 	} else {
 		log.Warn("no distinct readonly db configured")
 	}
 
-	// test Valkey
 	vc := s.rt.VK.Get()
 	defer vc.Close()
 	if _, err := vc.Do("PING"); err != nil {
-		log.Error("valkey not reachable", "error", err)
-	} else {
-		log.Info("valkey ok")
+		return fmt.Errorf("valkey not reachable: %w", err)
 	}
+	log.Info("valkey ok")
 
 	// test DynamoDB tables
 	if err := dynamo.Test(s.ctx, s.rt.Dynamo.Main.Client(), c.DynamoTablePrefix+"Main", c.DynamoTablePrefix+"History"); err != nil {

--- a/service.go
+++ b/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/appleboy/go-fcm"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/gocommon/aws/cwatch"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/mailroom/v26/core/crons"
@@ -76,7 +77,7 @@ func (s *Service) Start() error {
 
 	vc := s.rt.VK.Get()
 	defer vc.Close()
-	if _, err := vc.Do("PING"); err != nil {
+	if _, err := valkey.DoWithTimeout(vc, 5*time.Second, "PING"); err != nil {
 		return fmt.Errorf("valkey not reachable: %w", err)
 	}
 	log.Info("valkey ok")
@@ -245,7 +246,7 @@ func (s *Service) Stop() error {
 }
 
 func checkDBConnection(db *sql.DB) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	err := db.PingContext(ctx)
 	cancel()
 


### PR DESCRIPTION
Previously all startup dependency checks only logged errors, so an instance would come up (and pass health checks) even with no database. Now:

* **Postgres (incl. readonly) and Valkey unreachable → startup fails** with a non-zero exit, so an orchestrator can detect the failed launch and retry/roll back. Mailroom can't do anything useful without them.
* **DynamoDB, Elastic, S3, FCM, Centrifugo remain log-only** — writes to Dynamo and Elastic are spooled so an instance can start during a temporary outage of those services and recover once they're back.