### PR TITLE
Fail IVR calls and disable email sending for suspended orgs

### DIFF
--- a/core/crons/retry_calls.go
+++ b/core/crons/retry_calls.go
@@ -55,6 +55,14 @@ func (c *RetryCallsCron) Run(ctx context.Context, rt *runtime.Runtime) (map[stri
 			continue
 		}
 
+		// org may have been suspended after the call was created
+		if oa.Org().Suspended() {
+			if err := call.SetFailed(ctx, rt.DB); err != nil {
+				log.Error("error marking call as failed due to suspended org", "error", err, "org_id", call.OrgID())
+			}
+			continue
+		}
+
 		// and the associated channel
 		channel := oa.ChannelByID(call.ChannelID())
 		if channel == nil {

--- a/core/crons/retry_calls_test.go
+++ b/core/crons/retry_calls_test.go
@@ -55,7 +55,20 @@ func TestRetryCalls(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT COUNT(*) FROM ivr_call WHERE contact_id = $1 AND status = $2 AND external_id = $3`,
 		testdb.Ann.ID, models.CallStatusWired, "call1").Returns(1)
 
-	// back to retry and make the channel inactive
+	// back to retry and suspend the org
+	rt.DB.MustExec(`UPDATE ivr_call SET status = 'E', next_attempt = NOW() WHERE external_id = 'call1';`)
+	rt.DB.MustExec(`UPDATE orgs_org SET is_suspended = TRUE WHERE id = $1`, testdb.Org1.ID)
+
+	models.FlushCache()
+	_, err = cron.Run(ctx, rt)
+	assert.NoError(t, err)
+
+	// should be failed without being requested from the provider
+	assertdb.Query(t, rt.DB, `SELECT COUNT(*) FROM ivr_call WHERE contact_id = $1 AND status = $2 AND external_id = $3`,
+		testdb.Ann.ID, models.CallStatusFailed, "call1").Returns(1)
+
+	// unsuspend the org, back to retry and make the channel inactive
+	rt.DB.MustExec(`UPDATE orgs_org SET is_suspended = FALSE WHERE id = $1`, testdb.Org1.ID)
 	rt.DB.MustExec(`UPDATE ivr_call SET status = 'E', next_attempt = NOW() WHERE external_id = 'call1';`)
 	rt.DB.MustExec(`UPDATE channels_channel SET is_active = FALSE WHERE id = $1`, testdb.TwilioChannel.ID)
 

--- a/core/ivr/ivr.go
+++ b/core/ivr/ivr.go
@@ -140,6 +140,14 @@ func RequestCall(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 		return nil, fmt.Errorf("error creating outgoing call: %w", err)
 	}
 
+	// suspended orgs can't make calls, so fail the call without requesting it from the provider
+	if oa.Org().Suspended() {
+		if err := call.SetFailed(ctx, rt.DB); err != nil {
+			return nil, fmt.Errorf("error marking call as failed: %w", err)
+		}
+		return call, nil
+	}
+
 	clog, err := RequestCallStart(ctx, rt, channel, telURN.Identity, call)
 
 	// log any error inserting our channel log, but continue

--- a/core/ivr/ivr_test.go
+++ b/core/ivr/ivr_test.go
@@ -1,0 +1,50 @@
+package ivr_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/goflow/flows/triggers"
+	"github.com/nyaruka/mailroom/v26/core/ivr"
+	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestCall(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetAll)
+
+	// register our mock client
+	ivr.RegisterService(models.ChannelType("ZZ"), testsuite.NewIVRServiceFactory)
+
+	// update our twilio channel to be of type 'ZZ'
+	rt.DB.MustExec(`UPDATE channels_channel SET channel_type = 'ZZ' WHERE id = $1`, testdb.TwilioChannel.ID)
+
+	testsuite.IVRService.CallError = nil
+	testsuite.IVRService.CallID = ivr.CallID("call1")
+
+	oa := testdb.Org1.Load(t, rt)
+	contact, _, _ := testdb.Ann.Load(t, rt, oa)
+	flow := testdb.IVRFlow.Load(t, rt, oa)
+	trigger := triggers.NewBuilder(flow.Reference()).Manual().Build()
+
+	call, err := ivr.RequestCall(ctx, rt, oa, contact, trigger)
+	require.NoError(t, err)
+	assert.Equal(t, models.CallStatusWired, call.Status())
+	assert.Equal(t, "call1", call.ExternalID())
+
+	// suspend the org and request another call
+	rt.DB.MustExec(`UPDATE orgs_org SET is_suspended = TRUE WHERE id = $1`, testdb.Org1.ID)
+	models.FlushCache()
+	oa = testdb.Org1.Load(t, rt)
+
+	call, err = ivr.RequestCall(ctx, rt, oa, contact, trigger)
+	require.NoError(t, err)
+
+	// call should be failed without ever being requested from the provider
+	assert.Equal(t, models.CallStatusFailed, call.Status())
+	assert.Equal(t, "", call.ExternalID())
+}

--- a/core/models/org.go
+++ b/core/models/org.go
@@ -169,6 +169,11 @@ func (o *Org) ConfigValue(key string, def string) string {
 
 // EmailService returns the email service for this org
 func (o *Org) EmailService(ctx context.Context, rt *runtime.Runtime, retries *smtpx.RetryConfig) (flows.EmailService, error) {
+	// suspended orgs can't send emails
+	if o.Suspended() {
+		return nil, errors.New("workspace is suspended")
+	}
+
 	// first look for custom SMTP on this org
 	smtpURL := o.FlowSMTP()
 

--- a/core/models/org_test.go
+++ b/core/models/org_test.go
@@ -121,6 +121,16 @@ func TestEmailService(t *testing.T) {
 	svc, err = org2.EmailService(ctx, rt, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, svc)
+
+	// suspend org 1.. no email service even tho it has SMTP configured
+	rt.DB.MustExec(`UPDATE orgs_org SET is_suspended = TRUE WHERE id = $1`, testdb.Org1.ID)
+	models.FlushCache()
+
+	org1, err = models.LoadOrg(ctx, rt.Config, rt.DB.DB, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	_, err = org1.EmailService(ctx, rt, nil)
+	assert.EqualError(t, err, "workspace is suspended")
 }
 
 func TestStoreAttachment(t *testing.T) {

--- a/web/public/ivr.go
+++ b/web/public/ivr.go
@@ -120,6 +120,11 @@ func handleIncoming(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 		return nil, svc.WriteErrorResponse(w, fmt.Errorf("error inserting incoming call: %w", err))
 	}
 
+	// for suspended orgs we record the call but reject it without handling any triggers
+	if oa.Org().Suspended() {
+		return call, svc.WriteRejectResponse(w)
+	}
+
 	// create an incoming call "task" and handle it to see if we have a trigger
 	task := &ctasks.EventReceived{
 		EventType: models.EventTypeIncomingCall,

--- a/web/public/ivr_test.go
+++ b/web/public/ivr_test.go
@@ -128,6 +128,26 @@ func TestTwilioIVR(t *testing.T) {
 	}
 }
 
+func TestTwilioIVRSuspendedOrg(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetAll)
+
+	// start mocked API server
+	mockTwilio := test.NewHTTPServer(50001, http.HandlerFunc(mockTwilioHandler))
+	defer mockTwilio.Close()
+
+	twiml.BaseURL = mockTwilio.URL
+	twiml.IgnoreSignatures = true
+
+	// create a trigger which would match an incoming call from Ann if the org wasn't suspended
+	testdb.InsertIncomingCallTrigger(t, rt, testdb.Org1, testdb.IVRFlow, []*testdb.Group{testdb.DoctorsGroup}, nil, nil)
+
+	rt.DB.MustExec(`UPDATE orgs_org SET is_suspended = TRUE WHERE id = $1`, testdb.Org1.ID)
+
+	testsuite.RunWebTests(t, rt, "./testdata/ivr_twilio_suspended.json")
+}
+
 func mockVonageHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("recording") != "" {
 		w.WriteHeader(http.StatusOK)

--- a/web/public/testdata/ivr_twilio_suspended.json
+++ b/web/public/testdata/ivr_twilio_suspended.json
@@ -1,0 +1,20 @@
+[
+    {
+        "label": "incoming call from Ann is recorded but rejected without matching against triggers because org is suspended",
+        "method": "POST",
+        "path": "/mr/ivr/c/74729f45-7f29-4868-9dc4-90e491e3c7d8/incoming",
+        "body": "CallSid=Call1&CallStatus=ringing&Caller=%2B16055741111",
+        "status": 200,
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response><Reject></Reject></Response>",
+        "db_assertions": [
+            {
+                "query": "SELECT count(*) FROM ivr_call WHERE external_id = 'Call1' AND direction = 'I' AND status = 'I'",
+                "returns": 1
+            },
+            {
+                "query": "SELECT count(*) FROM flows_flowsession",
+                "returns": 0
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Outgoing messages for suspended orgs are already created as failed (reason `S`) and never sent, but IVR calls and flow emails had no such checks.

Outgoing IVR:
- `ivr.RequestCall` now marks the call as failed without contacting the provider when the org is suspended. The call record is still created for visibility, mirroring how suspended-org messages appear as failed.
- The `retry_calls` cron now fails queued/errored calls whose org has been suspended since the call was created, instead of retrying them against the provider.

Incoming IVR:
- The `/ivr/.../incoming` handler now records the call but writes a reject response for suspended orgs, instead of matching triggers and answering the call to run a voice flow. This mirrors incoming messages, which are still recorded but can't produce any outgoing traffic while the org is suspended.

Email:
- `Org.EmailService` now errors for suspended orgs, so `send_email` flow actions fail with an error event instead of sending via SMTP.

Note for reviewers: failed calls currently get no `error_reason` since the existing reasons (provider/busy/no-answer/machine) don't cover suspension — adding a distinct reason would need a coordinated RapidPro change and can follow separately.