### PR TITLE
Use consistent naming for model vs engine contacts

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -94,29 +94,29 @@ func indexAllContacts(ctx context.Context, rt *runtime.Runtime) error {
 				return fmt.Errorf("error loading org assets for org #%d: %w", orgID, err)
 			}
 
-			contacts, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
+			mcs, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
 			if err != nil {
 				return fmt.Errorf("error loading contacts for org #%d: %w", orgID, err)
 			}
 
-			flowContacts := make([]*core.Contact, 0, len(contacts))
-			currentFlows := make(map[models.ContactID]models.FlowID, len(contacts))
-			for _, c := range contacts {
-				fc, err := c.EngineContact(oa)
+			contacts := make([]*core.Contact, 0, len(mcs))
+			currentFlows := make(map[models.ContactID]models.FlowID, len(mcs))
+			for _, mc := range mcs {
+				contact, err := mc.EngineContact(oa)
 				if err != nil {
 					orgSkipped++
 					continue
 				}
-				flowContacts = append(flowContacts, fc)
-				currentFlows[c.ID()] = c.CurrentFlowID()
+				contacts = append(contacts, contact)
+				currentFlows[mc.ID()] = mc.CurrentFlowID()
 			}
 
-			if err := search.IndexContacts(ctx, rt, oa, flowContacts, currentFlows); err != nil {
+			if err := search.IndexContacts(ctx, rt, oa, contacts, currentFlows); err != nil {
 				return fmt.Errorf("error indexing contacts for org #%d: %w", orgID, err)
 			}
 
-			orgIndexed += len(flowContacts)
-			totalIndexed += len(flowContacts)
+			orgIndexed += len(contacts)
+			totalIndexed += len(contacts)
 			orgBatches++
 			afterID = contactIDs[len(contactIDs)-1]
 

--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -19,13 +19,13 @@ import (
 
 // holds work data for import of a single contact
 type importContact struct {
-	record      int
-	spec        *models.ContactSpec
-	contact     *models.Contact
-	created     bool
-	flowContact *core.Contact
-	mods        []flows.Modifier
-	errors      []string
+	record  int
+	spec    *models.ContactSpec
+	mc      *models.Contact
+	created bool
+	contact *core.Contact
+	mods    []flows.Modifier
+	errors  []string
 }
 
 func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, b *models.ContactImportBatch, userID models.UserID) error {
@@ -56,11 +56,11 @@ func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 	mods := make(map[models.ContactID][]flows.Modifier, len(imports))
 	for _, imp := range imports {
 		// ignore errored imports which couldn't get/create a contact
-		if imp.contact != nil {
-			mcs = append(mcs, imp.contact)
-			contacts = append(contacts, imp.flowContact)
-			mods[imp.contact.ID()] = imp.mods
-			importsByContact[imp.flowContact] = imp
+		if imp.mc != nil {
+			mcs = append(mcs, imp.mc)
+			contacts = append(contacts, imp.contact)
+			mods[imp.mc.ID()] = imp.mods
+			importsByContact[imp.contact] = imp
 		}
 	}
 
@@ -109,19 +109,19 @@ func getOrCreateContacts(ctx context.Context, db *sqlx.DB, oa *models.OrgAssets,
 
 		uuid := spec.UUID
 		if uuid != "" {
-			imp.contact = contactsByUUID[uuid]
-			if imp.contact == nil {
+			imp.mc = contactsByUUID[uuid]
+			if imp.mc == nil {
 				addError("Unable to find contact with UUID '%s'", uuid)
 				continue
 			}
 
-			imp.flowContact, err = imp.contact.EngineContact(oa)
+			imp.contact, err = imp.mc.EngineContact(oa)
 			if err != nil {
-				return fmt.Errorf("error creating flow contact for %d: %w", imp.contact.ID(), err)
+				return fmt.Errorf("error creating engine contact for %d: %w", imp.mc.ID(), err)
 			}
 
 		} else {
-			imp.contact, imp.flowContact, imp.created, err = models.GetOrCreateContact(ctx, db, oa, userID, spec.URNs, models.NilChannelID)
+			imp.mc, imp.contact, imp.created, err = models.GetOrCreateContact(ctx, db, oa, userID, spec.URNs, models.NilChannelID)
 			if err != nil {
 				urnStrs := make([]string, len(spec.URNs))
 				for i := range spec.URNs {
@@ -208,7 +208,7 @@ func markBatchComplete(ctx context.Context, db models.DBorTx, b *models.ContactI
 	numErrored := 0
 	importErrors := make([]models.ImportError, 0, 10)
 	for _, imp := range imports {
-		if imp.contact == nil {
+		if imp.mc == nil {
 			numErrored++
 		} else if imp.created {
 			numCreated++

--- a/core/imports/contacts_test.go
+++ b/core/imports/contacts_test.go
@@ -192,16 +192,16 @@ func loadAllContacts(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets) []
 	allIDs, err = dbutil.ScanAllSlice(rows, allIDs)
 	require.NoError(t, err)
 
-	contacts, err := models.LoadContacts(context.Background(), rt.DB, oa, allIDs)
+	mcs, err := models.LoadContacts(context.Background(), rt.DB, oa, allIDs)
 	require.NoError(t, err)
 
-	sort.Slice(contacts, func(i, j int) bool { return contacts[i].ID() < contacts[j].ID() })
+	sort.Slice(mcs, func(i, j int) bool { return mcs[i].ID() < mcs[j].ID() })
 
-	flowContacts := make([]*core.Contact, len(contacts))
-	for i := range contacts {
-		flowContacts[i], err = contacts[i].EngineContact(oa)
+	contacts := make([]*core.Contact, len(mcs))
+	for i := range mcs {
+		contacts[i], err = mcs[i].EngineContact(oa)
 		require.NoError(t, err)
 	}
 
-	return flowContacts
+	return contacts
 }

--- a/core/ivr/ivr.go
+++ b/core/ivr/ivr.go
@@ -92,10 +92,10 @@ func HangupCall(ctx context.Context, rt *runtime.Runtime, call *models.Call) (*m
 }
 
 // RequestCall creates a new outgoing call and makes a request to the service to start it
-func RequestCall(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contact *models.Contact, trigger flows.Trigger) (*models.Call, error) {
+func RequestCall(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact, trigger flows.Trigger) (*models.Call, error) {
 	// find a tel URL for the contact
 	var telURN *models.ContactURN
-	for _, u := range contact.URNs() {
+	for _, u := range mc.URNs() {
 		if u.Scheme == urns.Phone.Prefix {
 			telURN = u
 		}
@@ -135,7 +135,7 @@ func RequestCall(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 	}
 
 	channel := callChannel.Asset().(*models.Channel)
-	call := models.NewOutgoingCall(oa.OrgID(), channel, contact, telURN.ID, trigger)
+	call := models.NewOutgoingCall(oa.OrgID(), channel, mc, telURN.ID, trigger)
 	if err := models.InsertCalls(ctx, rt.DB, []*models.Call{call}); err != nil {
 		return nil, fmt.Errorf("error creating outgoing call: %w", err)
 	}
@@ -269,7 +269,7 @@ func StartCall(
 	// load contact and update on trigger to ensure we're not starting with outdated contact data
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error loading flow contact: %w", err)
+		return fmt.Errorf("error loading engine contact: %w", err)
 	}
 
 	flowCall := core.NewCall(call.UUID(), oa.SessionAssets().Channels().Get(channel.UUID()), urn.Identity())
@@ -324,7 +324,7 @@ func ResumeCall(
 
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	flow, err := oa.FlowByUUID(session.CurrentFlowUUID)

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -76,7 +76,7 @@ var ContactToModelStatus = map[core.ContactStatus]ContactStatus{
 	core.ContactStatusArchived: ContactStatusArchived,
 }
 
-var contactToFlowStatus = map[ContactStatus]core.ContactStatus{
+var contactToEngineStatus = map[ContactStatus]core.ContactStatus{
 	ContactStatusActive:   core.ContactStatusActive,
 	ContactStatusBlocked:  core.ContactStatusBlocked,
 	ContactStatusStopped:  core.ContactStatusStopped,
@@ -214,14 +214,14 @@ func (c *Contact) EngineContact(oa *OrgAssets) (*core.Contact, error) {
 		tickets[i] = t.EngineTicket(oa)
 	}
 
-	// create our flow contact
+	// create our engine contact
 	contact, err := core.NewContact(
 		oa.SessionAssets(),
 		c.uuid,
 		core.ContactID(c.id),
 		c.name,
 		c.language,
-		contactToFlowStatus[c.Status()],
+		contactToEngineStatus[c.Status()],
 		oa.Env().Timezone(),
 		c.createdOn,
 		c.lastSeenOn,
@@ -232,7 +232,7 @@ func (c *Contact) EngineContact(oa *OrgAssets) (*core.Contact, error) {
 		assets.IgnoreMissing,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating flow contact: %w", err)
+		return nil, fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	return contact, nil
@@ -562,22 +562,22 @@ func CreateContact(ctx context.Context, db DB, oa *OrgAssets, userID UserID, nam
 	}
 
 	// load a full contact so that we can calculate dynamic groups
-	contact, err := LoadContact(ctx, db, oa, contactID)
+	mc, err := LoadContact(ctx, db, oa, contactID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error loading new contact: %w", err)
 	}
 
-	flowContact, err := contact.EngineContact(oa)
+	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating flow contact: %w", err)
+		return nil, nil, fmt.Errorf("error creating engine contact: %w", err)
 	}
 
-	err = CalculateDynamicGroups(ctx, db, oa, []*core.Contact{flowContact})
+	err = CalculateDynamicGroups(ctx, db, oa, []*core.Contact{contact})
 	if err != nil {
 		return nil, nil, fmt.Errorf("error calculating dynamic groups: %w", err)
 	}
 
-	return contact, flowContact, nil
+	return mc, contact, nil
 }
 
 // GetOrCreateContact fetches or creates a new contact for the passed in org with the passed in URNs.
@@ -599,25 +599,25 @@ func GetOrCreateContact(ctx context.Context, db DB, oa *OrgAssets, userID UserID
 	}
 
 	// load a full contact so that we can calculate dynamic groups
-	contact, err := LoadContact(ctx, db, oa, contactID)
+	mc, err := LoadContact(ctx, db, oa, contactID)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("error loading new contact: %w", err)
 	}
 
-	flowContact, err := contact.EngineContact(oa)
+	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("error creating flow contact: %w", err)
+		return nil, nil, false, fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	// calculate dynamic groups if contact was created
 	if created {
-		err := CalculateDynamicGroups(ctx, db, oa, []*core.Contact{flowContact})
+		err := CalculateDynamicGroups(ctx, db, oa, []*core.Contact{contact})
 		if err != nil {
 			return nil, nil, false, fmt.Errorf("error calculating dynamic groups: %w", err)
 		}
 	}
 
-	return contact, flowContact, created, nil
+	return mc, contact, created, nil
 }
 
 // GetOrCreateContactsFromURNs will fetch or create the contacts for the passed in URNs, returning a map of the fetched

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -47,7 +47,7 @@ func TestContacts(t *testing.T) {
 	// LoadContacts doesn't guarantee returned order of contacts
 	sort.Slice(mcs, func(i, j int) bool { return mcs[i].ID() < mcs[j].ID() })
 
-	// convert to goflow contacts
+	// convert to engine contacts
 	contacts := make([]*core.Contact, len(mcs))
 	for i := range mcs {
 		contacts[i], err = mcs[i].EngineContact(org)
@@ -99,22 +99,22 @@ func TestCreateContact(t *testing.T) {
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
-	contact, flowContact, err := models.CreateContact(ctx, rt.DB, oa, models.UserID(1), "Rich", `kin`, models.ContactStatusActive, []urns.URN{urns.URN("telegram:200001"), urns.URN("telegram:200002")})
+	mc, contact, err := models.CreateContact(ctx, rt.DB, oa, models.UserID(1), "Rich", `kin`, models.ContactStatusActive, []urns.URN{urns.URN("telegram:200001"), urns.URN("telegram:200002")})
 	assert.NoError(t, err)
+
+	assert.Equal(t, "Rich", mc.Name())
+	assert.Equal(t, i18n.Language(`kin`), mc.Language())
+	assert.Equal(t, models.ContactStatusActive, mc.Status())
+	assert.Len(t, mc.URNs(), 2)
+	assert.Equal(t, urns.URN("telegram:200001"), mc.URNs()[0].Identity)
+	assert.Equal(t, urns.URN("telegram:200002"), mc.URNs()[1].Identity)
 
 	assert.Equal(t, "Rich", contact.Name())
 	assert.Equal(t, i18n.Language(`kin`), contact.Language())
-	assert.Equal(t, models.ContactStatusActive, contact.Status())
-	assert.Len(t, contact.URNs(), 2)
-	assert.Equal(t, urns.URN("telegram:200001"), contact.URNs()[0].Identity)
-	assert.Equal(t, urns.URN("telegram:200002"), contact.URNs()[1].Identity)
-
-	assert.Equal(t, "Rich", flowContact.Name())
-	assert.Equal(t, i18n.Language(`kin`), flowContact.Language())
-	assert.Equal(t, core.ContactStatusActive, flowContact.Status())
-	assert.Equal(t, []urns.URN{"telegram:200001", "telegram:200002"}, flowContact.URNs().Encode())
-	assert.Len(t, flowContact.Groups().All(), 1)
-	assert.Equal(t, assets.GroupUUID("d636c966-79c1-4417-9f1c-82ad629773a2"), flowContact.Groups().All()[0].UUID())
+	assert.Equal(t, core.ContactStatusActive, contact.Status())
+	assert.Equal(t, []urns.URN{"telegram:200001", "telegram:200002"}, contact.URNs().Encode())
+	assert.Len(t, contact.Groups().All(), 1)
+	assert.Equal(t, assets.GroupUUID("d636c966-79c1-4417-9f1c-82ad629773a2"), contact.Groups().All()[0].UUID())
 
 	_, _, err = models.CreateContact(ctx, rt.DB, oa, models.UserID(1), "Rich", `kin`, models.ContactStatusActive, []urns.URN{urns.URN("telegram:200001")})
 	assert.EqualError(t, err, "URN 0 in use by other contacts")
@@ -125,12 +125,12 @@ func TestCreateContact(t *testing.T) {
 		assert.Equal(t, 0, uerr.Index)
 	}
 
-	// new blocked contact won't be added to smart groups
-	contact, flowContact, err = models.CreateContact(ctx, rt.DB, oa, models.UserID(1), "Bob", `kin`, models.ContactStatusBlocked, []urns.URN{urns.URN("telegram:200003")})
+	// new blocked mc won't be added to smart groups
+	mc, contact, err = models.CreateContact(ctx, rt.DB, oa, models.UserID(1), "Bob", `kin`, models.ContactStatusBlocked, []urns.URN{urns.URN("telegram:200003")})
 	assert.NoError(t, err)
-	assert.Equal(t, models.ContactStatusBlocked, contact.Status())
-	assert.Equal(t, core.ContactStatusBlocked, flowContact.Status())
-	assert.Len(t, flowContact.Groups().All(), 0)
+	assert.Equal(t, models.ContactStatusBlocked, mc.Status())
+	assert.Equal(t, core.ContactStatusBlocked, contact.Status())
+	assert.Len(t, contact.Groups().All(), 0)
 }
 
 func TestCreateContactRace(t *testing.T) {
@@ -273,15 +273,15 @@ func TestGetOrCreateContact(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		contact, flowContact, created, err := models.GetOrCreateContact(ctx, rt.DB, oa, testdb.Admin.ID, tc.URNs, tc.ChannelID)
+		mc, contact, created, err := models.GetOrCreateContact(ctx, rt.DB, oa, testdb.Admin.ID, tc.URNs, tc.ChannelID)
 		assert.NoError(t, err, "%d: error creating contact", i)
 
-		assert.Equal(t, tc.ContactID, contact.ID(), "%d: contact id mismatch", i)
-		assert.Equal(t, tc.ContactURNs, flowContact.URNs().Encode(), "%d: URNs mismatch", i)
+		assert.Equal(t, tc.ContactID, mc.ID(), "%d: contact id mismatch", i)
+		assert.Equal(t, tc.ContactURNs, contact.URNs().Encode(), "%d: URNs mismatch", i)
 		assert.Equal(t, tc.Created, created, "%d: created flag mismatch", i)
 
-		groupUUIDs := make([]assets.GroupUUID, len(flowContact.Groups().All()))
-		for i, g := range flowContact.Groups().All() {
+		groupUUIDs := make([]assets.GroupUUID, len(contact.Groups().All()))
+		for i, g := range contact.Groups().All() {
 			groupUUIDs[i] = g.UUID()
 		}
 
@@ -556,12 +556,12 @@ func TestUpdateContactURNs(t *testing.T) {
 	updateURNs := func(us map[*testdb.Contact][]urns.URN) {
 		changes := make([]*models.ContactURNsChanged, 0, 4)
 		for c, urnz := range us {
-			mc, fc, _ := c.Load(t, rt, oa)
+			mc, contact, _ := c.Load(t, rt, oa)
 
 			for _, u := range urnz {
 				// simulate how the engine would claim new URNs
-				if !fc.HasURN(u) {
-					claimed, err := models.ContactClaimURN(ctx, rt, oa.Org(), fc, u)
+				if !contact.HasURN(u) {
+					claimed, err := models.ContactClaimURN(ctx, rt, oa.Org(), contact, u)
 					assert.NoError(t, err)
 					assert.True(t, claimed)
 				}

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -125,7 +125,7 @@ func TestCreateContact(t *testing.T) {
 		assert.Equal(t, 0, uerr.Index)
 	}
 
-	// new blocked mc won't be added to smart groups
+	// new blocked contact won't be added to smart groups
 	mc, contact, err = models.CreateContact(ctx, rt.DB, oa, models.UserID(1), "Bob", `kin`, models.ContactStatusBlocked, []urns.URN{urns.URN("telegram:200003")})
 	assert.NoError(t, err)
 	assert.Equal(t, models.ContactStatusBlocked, mc.Status())

--- a/core/runner/scene.go
+++ b/core/runner/scene.go
@@ -298,12 +298,12 @@ func CreateScenes(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets
 			mc.IncludeTickets(extra)
 		}
 
-		c, err := mc.EngineContact(oa)
+		contact, err := mc.EngineContact(oa)
 		if err != nil {
 			return nil, fmt.Errorf("error creating engine contact for %s: %w", mc.UUID(), err)
 		}
 
-		scenes[i] = NewScene(mc, c)
+		scenes[i] = NewScene(mc, contact)
 	}
 
 	return scenes, nil

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -56,7 +56,7 @@ type ContactDoc struct {
 	LastSeenOn     *time.Time           `json:"last_seen_on,omitempty"`
 }
 
-// NewContactDoc builds a ContactDoc from a flow contact and its org assets. We use the flow contact
+// NewContactDoc builds a ContactDoc from an engine contact and its org assets. We use the engine contact
 // rather than the DB contact because it is kept up-to-date in memory as events are applied.
 func NewContactDoc(oa *models.OrgAssets, c *core.Contact, currentFlowID models.FlowID, flowHistoryIDs []models.FlowID) *ContactDoc {
 	doc := &ContactDoc{
@@ -73,7 +73,7 @@ func NewContactDoc(oa *models.OrgAssets, c *core.Contact, currentFlowID models.F
 		FlowHistoryIDs: flowHistoryIDs,
 	}
 
-	// build field docs from the flow contact's field values
+	// build field docs from the engine contact's field values
 	for key, fv := range c.Fields() {
 		if fv == nil {
 			continue
@@ -135,13 +135,13 @@ func NewContactDoc(oa *models.OrgAssets, c *core.Contact, currentFlowID models.F
 }
 
 // IndexContacts builds contact documents and queues them for indexing in Elastic.
-func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, flowContacts []*core.Contact, currentFlows map[models.ContactID]models.FlowID) error {
-	if len(flowContacts) == 0 {
+func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contacts []*core.Contact, currentFlows map[models.ContactID]models.FlowID) error {
+	if len(contacts) == 0 {
 		return nil
 	}
 
-	contactIDs := make([]models.ContactID, len(flowContacts))
-	for i, c := range flowContacts {
+	contactIDs := make([]models.ContactID, len(contacts))
+	for i, c := range contacts {
 		contactIDs[i] = models.ContactID(c.ID())
 	}
 
@@ -150,7 +150,7 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 		return fmt.Errorf("error loading flow history IDs: %w", err)
 	}
 
-	for _, c := range flowContacts {
+	for _, c := range contacts {
 		contactID := models.ContactID(c.ID())
 		doc := NewContactDoc(oa, c, currentFlows[contactID], flowHistoryByContact[contactID])
 

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -30,19 +30,19 @@ func TestNewContactDoc(t *testing.T) {
 
 	sort.Slice(mcs, func(i, j int) bool { return mcs[i].ID() < mcs[j].ID() })
 
-	// convert to flow contacts
-	flowContacts := make(map[models.ContactID]*core.Contact)
+	// convert to engine contacts
+	contacts := make(map[models.ContactID]*core.Contact)
 	for _, mc := range mcs {
-		fc, err := mc.EngineContact(oa)
+		contact, err := mc.EngineContact(oa)
 		require.NoError(t, err)
-		flowContacts[mc.ID()] = fc
+		contacts[mc.ID()] = contact
 	}
 
 	// Ann: has name, status=active, URNs, groups, fields (gender, state, district, ward)
-	annFC := flowContacts[testdb.Ann.ID]
-	require.NotNil(t, annFC)
+	ann := contacts[testdb.Ann.ID]
+	require.NotNil(t, ann)
 
-	doc := search.NewContactDoc(oa, annFC, testdb.Favorites.ID, []models.FlowID{testdb.Favorites.ID, testdb.PickANumber.ID})
+	doc := search.NewContactDoc(oa, ann, testdb.Favorites.ID, []models.FlowID{testdb.Favorites.ID, testdb.PickANumber.ID})
 
 	assert.Equal(t, testdb.Ann.ID, doc.DBID)
 	assert.Equal(t, testdb.Org1.ID, doc.OrgID)
@@ -85,10 +85,10 @@ func TestNewContactDoc(t *testing.T) {
 	assert.NotEmpty(t, wardField.WardKeyword)
 
 	// Cat: has name, status=active, age=30, 1 URN, in Doctors group, no tickets
-	catFC := flowContacts[testdb.Cat.ID]
-	require.NotNil(t, catFC)
+	cat := contacts[testdb.Cat.ID]
+	require.NotNil(t, cat)
 
-	doc = search.NewContactDoc(oa, catFC, models.NilFlowID, nil)
+	doc = search.NewContactDoc(oa, cat, models.NilFlowID, nil)
 
 	assert.Equal(t, testdb.Cat.ID, doc.DBID)
 	assert.Equal(t, testdb.Cat.UUID, doc.UUID)

--- a/core/tasks/bulk_campaign_trigger.go
+++ b/core/tasks/bulk_campaign_trigger.go
@@ -114,30 +114,30 @@ func (t *BulkCampaignTrigger) triggerFlow(ctx context.Context, rt *runtime.Runti
 	}
 
 	if flow.FlowType() == models.FlowTypeVoice {
-		contacts, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, t.ContactIDs)
+		mcs, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, t.ContactIDs)
 		if err != nil {
 			return nil, fmt.Errorf("error loading contacts: %w", err)
 		}
 
-		// for each contacts, request a call start
-		for _, contact := range contacts {
-			if p.StartMode == models.StartModeSkip && contact.CurrentSessionUUID() != "" {
+		// for each contact, request a call start
+		for _, mc := range mcs {
+			if p.StartMode == models.StartModeSkip && mc.CurrentSessionUUID() != "" {
 				continue
 			}
 
 			ctx, cancel := context.WithTimeout(ctx, time.Minute)
-			call, err := ivr.RequestCall(ctx, rt, oa, contact, triggerBuilder())
+			call, err := ivr.RequestCall(ctx, rt, oa, mc, triggerBuilder())
 			cancel()
 			if err != nil {
-				slog.Error("error requesting call for campaign point", "contact", contact.UUID(), "point", t.PointID, "error", err)
+				slog.Error("error requesting call for campaign point", "contact", mc.UUID(), "point", t.PointID, "error", err)
 				continue
 			}
 			if call == nil {
-				slog.Debug("call start skipped, no suitable channel", "contact", contact.UUID(), "point", t.PointID)
+				slog.Debug("call start skipped, no suitable channel", "contact", mc.UUID(), "point", t.PointID)
 				continue
 			}
 
-			started = append(started, contact.ID())
+			started = append(started, mc.ID())
 		}
 	} else {
 		scenes, skipped, err := runner.StartWithLock(ctx, rt, oa, contactIDs, triggerBuilder, p.StartMode, models.NilStartID)

--- a/core/tasks/ctasks/base.go
+++ b/core/tasks/ctasks/base.go
@@ -22,7 +22,7 @@ import (
 // Task is the interface for all contact tasks - tasks which operate on a single contact in real time
 type Task interface {
 	Type() string
-	Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contact *models.Contact) error
+	Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact) error
 }
 
 var registeredTypes = map[string]func() Task{}

--- a/core/tasks/ctasks/contact_changed.go
+++ b/core/tasks/ctasks/contact_changed.go
@@ -27,7 +27,7 @@ func (t *ContactChanged) Type() string {
 func (t *ContactChanged) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact) error {
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	scene := runner.NewScene(mc, contact)

--- a/core/tasks/ctasks/event_received.go
+++ b/core/tasks/ctasks/event_received.go
@@ -69,10 +69,10 @@ func (t *EventReceived) handle(ctx context.Context, rt *runtime.Runtime, oa *mod
 		return nil, nil
 	}
 
-	// build our flow contact
+	// build our engine contact
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return nil, fmt.Errorf("error creating flow contact: %w", err)
+		return nil, fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	var flowOptIn *core.OptIn

--- a/core/tasks/ctasks/msg_deleted.go
+++ b/core/tasks/ctasks/msg_deleted.go
@@ -25,10 +25,10 @@ func (t *MsgDeleted) Type() string {
 }
 
 func (t *MsgDeleted) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, mc *models.Contact) error {
-	// build our flow contact
+	// build our engine contact
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	scene := runner.NewScene(mc, contact)

--- a/core/tasks/ctasks/msg_received.go
+++ b/core/tasks/ctasks/msg_received.go
@@ -90,10 +90,10 @@ func (t *MsgReceived) perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 	msgEvent := events.NewMsgReceived(msgIn, ticketUUID)
 	msgEvent.UUID_ = t.MsgUUID
 
-	// build our flow contact
+	// build our engine contact
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	scene := runner.NewScene(mc, contact)

--- a/core/tasks/ctasks/ticket_closed.go
+++ b/core/tasks/ctasks/ticket_closed.go
@@ -45,10 +45,10 @@ func (t *TicketClosed) Perform(ctx context.Context, rt *runtime.Runtime, oa *mod
 		return nil
 	}
 
-	// build our flow contact
+	// build our engine contact
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	// do we have associated trigger?

--- a/core/tasks/ctasks/wait_expired.go
+++ b/core/tasks/ctasks/wait_expired.go
@@ -51,10 +51,10 @@ func (t *WaitExpired) Perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 		return nil
 	}
 
-	// build our flow contact
+	// build our engine contact
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	evt := events.NewWaitExpired()

--- a/core/tasks/ctasks/wait_timeout.go
+++ b/core/tasks/ctasks/wait_timeout.go
@@ -52,10 +52,10 @@ func (t *WaitTimeout) Perform(ctx context.Context, rt *runtime.Runtime, oa *mode
 		return nil
 	}
 
-	// build our flow contact
+	// build our engine contact
 	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return fmt.Errorf("error creating flow contact: %w", err)
+		return fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	evt := events.NewWaitTimedOut()

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -67,11 +67,11 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 
 	if start.CreateContact {
 		// if we are meant to create a new contact, do so
-		contact, _, err := models.CreateContact(ctx, rt.DB, oa, models.NilUserID, "", i18n.NilLanguage, models.ContactStatusActive, nil)
+		mc, _, err := models.CreateContact(ctx, rt.DB, oa, models.NilUserID, "", i18n.NilLanguage, models.ContactStatusActive, nil)
 		if err != nil {
 			return fmt.Errorf("error creating new contact: %w", err)
 		}
-		contactIDs = []models.ContactID{contact.ID()}
+		contactIDs = []models.ContactID{mc.ID()}
 	} else {
 		// otherwise resolve recipients across contacts, groups, urns etc
 

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -142,22 +142,22 @@ func (t *StartFlowBatch) start(ctx context.Context, rt *runtime.Runtime, oa *mod
 	}
 
 	if flow.FlowType() == models.FlowTypeVoice {
-		contacts, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, t.ContactIDs)
+		mcs, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, t.ContactIDs)
 		if err != nil {
 			return fmt.Errorf("error loading contacts: %w", err)
 		}
 
-		// for each contacts, request a call start
-		for _, contact := range contacts {
+		// for each contact, request a call start
+		for _, mc := range mcs {
 			ctx, cancel := context.WithTimeout(ctx, time.Minute)
-			call, err := ivr.RequestCall(ctx, rt, oa, contact, triggerBuilder())
+			call, err := ivr.RequestCall(ctx, rt, oa, mc, triggerBuilder())
 			cancel()
 			if err != nil {
-				slog.Error("error requesting call for flow start", "contact", contact.UUID(), "start_id", start.ID, "error", err)
+				slog.Error("error requesting call for flow start", "contact", mc.UUID(), "start_id", start.ID, "error", err)
 				continue
 			}
 			if call == nil {
-				slog.Debug("call start skipped, no suitable channel", "contact", contact.UUID(), "start_id", start.ID)
+				slog.Debug("call start skipped, no suitable channel", "contact", mc.UUID(), "start_id", start.ID)
 				continue
 			}
 		}

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -271,17 +271,17 @@ func indexOrgContacts(t *testing.T, rt *runtime.Runtime, org *testdb.Org) {
 			break
 		}
 
-		contacts, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
+		mcs, err := models.LoadContacts(ctx, rt.DB, oa, contactIDs)
 		require.NoError(t, err)
 
-		fcs := make([]*core.Contact, 0, len(contacts))
-		for _, mc := range contacts {
-			fc, err := mc.EngineContact(oa)
+		contacts := make([]*core.Contact, 0, len(mcs))
+		for _, mc := range mcs {
+			contact, err := mc.EngineContact(oa)
 			require.NoError(t, err)
-			fcs = append(fcs, fc)
+			contacts = append(contacts, contact)
 		}
 
-		err = search.IndexContacts(ctx, rt, oa, fcs, map[models.ContactID]models.FlowID{})
+		err = search.IndexContacts(ctx, rt, oa, contacts, map[models.ContactID]models.FlowID{})
 		require.NoError(t, err)
 
 		afterID = contactIDs[len(contactIDs)-1]

--- a/testsuite/sessions.go
+++ b/testsuite/sessions.go
@@ -31,9 +31,9 @@ func StartSessions(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets, cont
 	}
 
 	scenes := make([]*runner.Scene, len(contacts))
-	for i, contact := range contacts {
-		mc, fc, _ := contact.Load(t, rt, oa)
-		scenes[i] = runner.NewScene(mc, fc)
+	for i, c := range contacts {
+		mc, contact, _ := c.Load(t, rt, oa)
+		scenes[i] = runner.NewScene(mc, contact)
 
 		err := scenes[i].StartSession(ctx, rt, oa, triggers[i], true)
 		require.NoError(t, err)
@@ -44,24 +44,24 @@ func StartSessions(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets, cont
 	return scenes
 }
 
-func ResumeSession(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets, contact *testdb.Contact, resume any) *runner.Scene {
+func ResumeSession(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets, c *testdb.Contact, resume any) *runner.Scene {
 	ctx := context.Background()
 
-	mc, fc, _ := contact.Load(t, rt, oa)
+	mc, contact, _ := c.Load(t, rt, oa)
 
 	require.NotEqual(t, core.SessionUUID(""), mc.CurrentSessionUUID(), "contact must have a waiting session")
 
 	modelSession, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
 	require.NoError(t, err)
 
-	scene := runner.NewScene(mc, fc)
+	scene := runner.NewScene(mc, contact)
 
 	var r flows.Resume
 	switch typed := resume.(type) {
 	case flows.Resume:
 		r = typed
 	case string:
-		msg := core.NewMsgIn(contact.URN, nil, typed, nil, "")
+		msg := core.NewMsgIn(c.URN, nil, typed, nil, "")
 		r = resumes.NewMsg(events.NewMsgReceived(msg, ""))
 	default:
 		panic("invalid resume type")

--- a/testsuite/testdb/contacts.go
+++ b/testsuite/testdb/contacts.go
@@ -30,10 +30,10 @@ func (c *Contact) Reference() *core.ContactReference {
 func (c *Contact) Load(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets) (*models.Contact, *core.Contact, []*models.ContactURN) {
 	ctx := context.Background()
 
-	contact, err := models.LoadContact(ctx, rt.DB, oa, c.ID)
+	mc, err := models.LoadContact(ctx, rt.DB, oa, c.ID)
 	require.NoError(t, err)
 
-	flowContact, err := contact.EngineContact(oa)
+	contact, err := mc.EngineContact(oa)
 	require.NoError(t, err)
 
 	var urnIDs []models.URNID
@@ -43,7 +43,7 @@ func (c *Contact) Load(t *testing.T, rt *runtime.Runtime, oa *models.OrgAssets) 
 	cus, err := models.LoadContactURNs(ctx, rt.DB, urnIDs)
 	require.NoError(t, err)
 
-	return contact, flowContact, cus
+	return mc, contact, cus
 }
 
 type Group struct {

--- a/web/android/base.go
+++ b/web/android/base.go
@@ -31,16 +31,16 @@ func resolveContact(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 		return nil, fmt.Errorf("error getting system user id: %w", err)
 	}
 
-	contact, _, created, err := models.GetOrCreateContact(ctx, rt.DB, oa, userID, []urns.URN{urn}, channelID)
+	mc, _, created, err := models.GetOrCreateContact(ctx, rt.DB, oa, userID, []urns.URN{urn}, channelID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting or creating contact: %w", err)
 	}
 
 	// find the URN on the contact
 	var urnID models.URNID
-	if cu := contact.FindURN(urn); cu != nil {
+	if cu := mc.FindURN(urn); cu != nil {
 		urnID = cu.ID
 	}
 
-	return &contactAndURN{contactID: contact.ID(), urnID: urnID, urn: urn, newContact: created}, nil
+	return &contactAndURN{contactID: mc.ID(), urnID: urnID, urn: urn, newContact: created}, nil
 }

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -40,12 +40,12 @@ func TestDeindex(t *testing.T) {
 	oa := testdb.Org1.Load(t, rt)
 	mcs, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
 	require.NoError(t, err)
-	fcs := make([]*core.Contact, len(mcs))
+	contacts := make([]*core.Contact, len(mcs))
 	for i, mc := range mcs {
-		fcs[i], err = mc.EngineContact(oa)
+		contacts[i], err = mc.EngineContact(oa)
 		require.NoError(t, err)
 	}
-	err = search.IndexContacts(ctx, rt, oa, fcs, map[models.ContactID]models.FlowID{})
+	err = search.IndexContacts(ctx, rt, oa, contacts, map[models.ContactID]models.FlowID{})
 	require.NoError(t, err)
 	rt.ES.Writer.Flush()
 	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)

--- a/web/contact/inspect.go
+++ b/web/contact/inspect.go
@@ -79,16 +79,16 @@ func handleInspect(ctx context.Context, rt *runtime.Runtime, r *inspectRequest) 
 
 	response := make(map[core.ContactID]*contactInfo, len(contacts))
 
-	for _, c := range contacts {
-		flowContact, err := c.EngineContact(oa)
+	for _, mc := range contacts {
+		contact, err := mc.EngineContact(oa)
 		if err != nil {
-			return nil, 0, fmt.Errorf("error creating flow contact: %w", err)
+			return nil, 0, fmt.Errorf("error creating engine contact: %w", err)
 		}
 
 		// first add the URNs which have a corresponding channel (engine considers these sendable)
-		routes := flowContact.ResolveRoutes(true)
+		routes := contact.ResolveRoutes(true)
 		urnsSeen := make(map[string]bool, len(routes))
-		urnInfos := make([]urnInfo, 0, len(flowContact.URNs()))
+		urnInfos := make([]urnInfo, 0, len(contact.URNs()))
 
 		for _, r := range routes {
 			scheme, path, _, display := r.URN.ToParts()
@@ -97,14 +97,14 @@ func handleInspect(ctx context.Context, rt *runtime.Runtime, r *inspectRequest) 
 		}
 
 		// then the rest of the unsendable URNs
-		for _, u := range flowContact.URNs() {
+		for _, u := range contact.URNs() {
 			scheme, path, display := u.Scheme, u.Path, u.Display
 			if !urnsSeen[scheme+":"+path] {
 				urnInfos = append(urnInfos, urnInfo{Channel: nil, Scheme: scheme, Path: path, Display: display})
 			}
 		}
 
-		response[flowContact.ID()] = &contactInfo{URNs: urnInfos}
+		response[contact.ID()] = &contactInfo{URNs: urnInfos}
 	}
 
 	return response, http.StatusOK, nil

--- a/web/contact/modify.go
+++ b/web/contact/modify.go
@@ -98,8 +98,8 @@ func handleModify(ctx context.Context, rt *runtime.Runtime, r *modifyRequest) (a
 	}
 
 	events := make(map[core.ContactUUID][]events.Event, len(eventsByContact))
-	for flowContact, contactEvents := range eventsByContact {
-		events[flowContact.UUID()] = contactEvents
+	for contact, contactEvents := range eventsByContact {
+		events[contact.UUID()] = contactEvents
 	}
 
 	resp := &modifyResponse{Events: events, Skipped: skipped}

--- a/web/contact/reindex.go
+++ b/web/contact/reindex.go
@@ -33,25 +33,25 @@ func handleReindex(ctx context.Context, rt *runtime.Runtime, r *reindexRequest) 
 		return nil, 0, fmt.Errorf("error loading org assets: %w", err)
 	}
 
-	contacts, err := models.LoadContactsByUUID(ctx, rt.DB, oa, r.ContactUUIDs)
+	mcs, err := models.LoadContactsByUUID(ctx, rt.DB, oa, r.ContactUUIDs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error loading contacts: %w", err)
 	}
 
-	flowContacts := make([]*core.Contact, 0, len(contacts))
-	currentFlows := make(map[models.ContactID]models.FlowID, len(contacts))
-	for _, c := range contacts {
-		fc, err := c.EngineContact(oa)
+	contacts := make([]*core.Contact, 0, len(mcs))
+	currentFlows := make(map[models.ContactID]models.FlowID, len(mcs))
+	for _, mc := range mcs {
+		contact, err := mc.EngineContact(oa)
 		if err != nil {
-			return nil, 0, fmt.Errorf("error creating flow contact: %w", err)
+			return nil, 0, fmt.Errorf("error creating engine contact: %w", err)
 		}
-		flowContacts = append(flowContacts, fc)
-		currentFlows[c.ID()] = c.CurrentFlowID()
+		contacts = append(contacts, contact)
+		currentFlows[mc.ID()] = mc.CurrentFlowID()
 	}
 
-	if err := search.IndexContacts(ctx, rt, oa, flowContacts, currentFlows); err != nil {
+	if err := search.IndexContacts(ctx, rt, oa, contacts, currentFlows); err != nil {
 		return nil, 0, fmt.Errorf("error indexing contacts: %w", err)
 	}
 
-	return map[string]any{"indexed": len(contacts)}, http.StatusOK, nil
+	return map[string]any{"indexed": len(mcs)}, http.StatusOK, nil
 }

--- a/web/msg/send.go
+++ b/web/msg/send.go
@@ -46,14 +46,14 @@ func handleSend(ctx context.Context, rt *runtime.Runtime, r *sendRequest) (any, 
 	}
 
 	// load the contact and convert to engine contact
-	c, err := models.LoadContact(ctx, rt.DB, oa, r.ContactID)
+	mc, err := models.LoadContact(ctx, rt.DB, oa, r.ContactID)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error loading contact: %w", err)
 	}
 
-	contact, err := c.EngineContact(oa)
+	contact, err := mc.EngineContact(oa)
 	if err != nil {
-		return nil, 0, fmt.Errorf("error creating flow contact: %w", err)
+		return nil, 0, fmt.Errorf("error creating engine contact: %w", err)
 	}
 
 	content := &core.MsgContent{Text: r.Text, Attachments: r.Attachments, QuickReplies: r.QuickReplies}
@@ -64,7 +64,7 @@ func handleSend(ctx context.Context, rt *runtime.Runtime, r *sendRequest) (any, 
 
 	event := events.NewMsgCreated(out, "", r.TicketUUID)
 
-	scene := runner.NewScene(c, contact)
+	scene := runner.NewScene(mc, contact)
 
 	if err := scene.AddEvent(ctx, rt, oa, event, r.UserID, ""); err != nil {
 		return nil, 0, fmt.Errorf("error adding message event to scene: %w", err)

--- a/web/public/ivr.go
+++ b/web/public/ivr.go
@@ -104,18 +104,18 @@ func handleIncoming(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 	}
 
 	// get the contact for this URN
-	contact, _, _, err := models.GetOrCreateContact(ctx, rt.DB, oa, userID, []urns.URN{urn}, ch.ID())
+	mc, _, _, err := models.GetOrCreateContact(ctx, rt.DB, oa, userID, []urns.URN{urn}, ch.ID())
 	if err != nil {
 		return nil, svc.WriteErrorResponse(w, fmt.Errorf("unable to get contact by urn: %w", err))
 	}
-	cu := contact.FindURN(urn)
+	cu := mc.FindURN(urn)
 
 	externalID, err := svc.CallIDForRequest(r)
 	if err != nil {
 		return nil, svc.WriteErrorResponse(w, fmt.Errorf("unable to get external id from request: %w", err))
 	}
 
-	call := models.NewIncomingCall(oa.OrgID(), ch, contact, cu.ID, externalID)
+	call := models.NewIncomingCall(oa.OrgID(), ch, mc, cu.ID, externalID)
 	if err := models.InsertCalls(ctx, rt.DB, []*models.Call{call}); err != nil {
 		return nil, svc.WriteErrorResponse(w, fmt.Errorf("error inserting incoming call: %w", err))
 	}
@@ -127,7 +127,7 @@ func handleIncoming(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 		URNID:     cu.ID,
 		Extra:     nil,
 	}
-	scene, err := task.Handle(ctx, rt, oa, contact, call)
+	scene, err := task.Handle(ctx, rt, oa, mc, call)
 	if err != nil {
 		slog.Error("error handling incoming call", "error", err, "http_request", r)
 		return call, svc.WriteErrorResponse(w, fmt.Errorf("error handling incoming call: %w", err))
@@ -185,11 +185,11 @@ func handleCallback(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 	}
 
 	// load our contact
-	contact, err := models.LoadContact(ctx, rt.ReadonlyDB, oa, call.ContactID())
+	mc, err := models.LoadContact(ctx, rt.ReadonlyDB, oa, call.ContactID())
 	if err != nil {
 		return call, svc.WriteErrorResponse(w, fmt.Errorf("no such contact: %w", err))
 	}
-	if contact.Status() != models.ContactStatusActive {
+	if mc.Status() != models.ContactStatusActive {
 		return call, svc.WriteErrorResponse(w, fmt.Errorf("no contact with id: %d", call.ContactID()))
 	}
 
@@ -203,7 +203,7 @@ func handleCallback(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 
 	// make sure our URN is indeed present on our contact, no funny business
 	found := false
-	for _, u := range contact.URNs() {
+	for _, u := range mc.URNs() {
 		if u.ID == cu.ID {
 			found = true
 		}
@@ -217,9 +217,9 @@ func handleCallback(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsse
 	// if this a start, start our contact
 	switch request.Action {
 	case ivr.ActionStart:
-		err = ivr.StartCall(ctx, rt, svc, resumeURL, oa, ch, call, contact, urn, r, w)
+		err = ivr.StartCall(ctx, rt, svc, resumeURL, oa, ch, call, mc, urn, r, w)
 	case ivr.ActionResume:
-		err = ivr.ResumeCall(ctx, rt, resumeURL, svc, oa, ch, call, contact, urn, r, w)
+		err = ivr.ResumeCall(ctx, rt, resumeURL, svc, oa, ch, call, mc, urn, r, w)
 	case ivr.ActionStatus:
 		err = ivr.HandleStatus(ctx, rt, oa, svc, call, r, w)
 


### PR DESCRIPTION
Follow-up cleanup to the goflow v0.280.0 re-org. We had three vocabularies for the engine contact (`contact`, `flowContact`, `fc`) and three for the model contact (`mc`, `contact`, `c`), paired differently file by file.

This standardizes on the dominant convention, which also matches the `Contact.EngineContact()` method name:

* `*models.Contact` → `mc` / `mcs` (outside the `models` package, or when both types are in scope)
* `*core.Contact` → `contact` / `contacts`

Also updates comments and error messages that said "flow contact" to say "engine contact", and renames `contactToFlowStatus` → `contactToEngineStatus`. `Scene.DBContact` is left as-is.

Pure rename — no behavior changes (+168/−168).