### PR TITLE
Cache Go module and build caches in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    tags: ["**"]
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 jobs:
   test:
     name: Test
@@ -71,9 +78,15 @@ jobs:
           psql -h postgres -U postgres --no-password -c "ALTER ROLE mailroom_test WITH SUPERUSER;"
           psql -h postgres -U postgres --no-password -c "CREATE DATABASE mailroom_test;"
 
+      - name: Compile tests
+        # pre-compiles all test binaries with default parallelism since -p=1 in the real run serializes
+        # compilation as well as test execution
+        run: |
+          go test -run '^$' -cover ./...
+
       - name: Run tests
         run: |
-          go test -p=1 -coverprofile=coverage.text -covermode=atomic ./...
+          go test -p=1 -cover ./...
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Get Go cache paths
+        id: go-cache-paths
+        run: |
+          echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "gocache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.gomodcache }}
+            ${{ steps.go-cache-paths.outputs.gocache }}
+          key: go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-
+
       - name: Install Postgres Client
         run: |
           apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
           echo "gocache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "goversion=$(go env GOVERSION)" >> $GITHUB_OUTPUT
 
       - name: Cache Go modules and build cache
         uses: actions/cache@v5
@@ -57,8 +58,9 @@ jobs:
           path: |
             ${{ steps.go-cache-paths.outputs.gomodcache }}
             ${{ steps.go-cache-paths.outputs.gocache }}
-          key: go-${{ hashFiles('go.sum') }}
+          key: go-${{ steps.go-cache-paths.outputs.goversion }}-${{ hashFiles('go.sum') }}
           restore-keys: |
+            go-${{ steps.go-cache-paths.outputs.goversion }}-
             go-
 
       - name: Install Postgres Client


### PR DESCRIPTION
The Test job currently downloads all modules and compiles everything from scratch on every run — on a recent run the test step took ~12 minutes, of which only ~4 were actual test execution. This makes several changes to cut that overhead:

* **Cache Go module and build caches** via `actions/cache`, keyed on `go.sum` with a prefix restore-key fallback. Since the job runs inside a `golang` container where `GOCACHE` derives from `$HOME` (which the Actions runner overrides in container jobs), the paths are resolved at runtime via `go env` rather than hardcoded.
* **Drop the unused coverage profile.** Nothing consumes `coverage.text` anymore, and `-covermode=atomic` instrumentation slows both compilation and execution (it's only needed with `-race`). Per-package coverage is still reported in the test output via plain `-cover`.
* **Pre-compile test binaries in parallel.** `-p=1` serializes the build graph as well as test execution, so a warm-up `go test -run '^$' -cover ./...` step compiles everything with default parallelism first (safe since no package defines a `TestMain`). The real run keeps `-p=1` because tests share a database.
* **Don't run CI twice on PR branches.** Push triggers are now limited to `main` and tags (the Release job depends on Test and runs on tag refs), with a concurrency group that cancels superseded runs on non-tag refs.