### PR TITLE
Replace patrickmn/go-cache with gocommon's cache.Local for org assets

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -40,6 +40,8 @@ func Index() error {
 	}
 	defer rt.Stop()
 
+	models.InitCache(rt)
+
 	// parse mode from args
 	flags := flag.NewFlagSet("mrindex", flag.ExitOnError)
 	startUUID := flags.String("start-uuid", "", "UUID to start from (messages mode only, works backwards from here)")

--- a/core/models/assets.go
+++ b/core/models/assets.go
@@ -10,13 +10,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nyaruka/gocommon/cache"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/mailroom/v26/core/goflow"
 	"github.com/nyaruka/mailroom/v26/runtime"
-	cache "github.com/patrickmn/go-cache"
 )
 
 // Refresh is our type for the pieces of org assets we want fresh (not cached)
@@ -109,39 +109,24 @@ type OrgAssets struct {
 
 var ErrNotFound = errors.New("not found")
 
-// we cache org objects for 5 seconds, cleanup every minute (gets never return expired items)
-var orgCache = cache.New(time.Second*5, time.Minute)
+// we cache org objects for 5 seconds (gets never return expired items)
+var orgCache *cache.Local[OrgID, *OrgAssets]
 
-// map of org id -> assetLoader used to make sure we only load an individual org once when expired
-var assetLoaders = sync.Map{}
-
-// represents a goroutine loading assets for an org, stores the loaded assets (and possible error) and
-// a channel to notify any listeners that the loading is complete
-type assetLoader struct {
-	done   chan struct{}
-	assets *OrgAssets
-	err    error
-}
-
-// loadOrgAssetsOnce is a thread safe method to create new org assets from the DB in a thread safe manner
-// that ensures only one goroutine is fetching the org at once. (others will block on the first completing)
-func loadOrgAssetsOnce(ctx context.Context, rt *runtime.Runtime, orgID OrgID) (*OrgAssets, error) {
-	loader := assetLoader{done: make(chan struct{})}
-	actual, inFlight := assetLoaders.LoadOrStore(orgID, &loader)
-	actualLoader := actual.(*assetLoader)
-	if inFlight {
-		<-actualLoader.done
-	} else {
-		actualLoader.assets, actualLoader.err = NewOrgAssets(ctx, rt, orgID, nil, RefreshAll)
-		close(actualLoader.done)
-		assetLoaders.Delete(orgID)
+// InitCache initializes the org assets cache which needs the runtime to load assets on cache misses
+func InitCache(rt *runtime.Runtime) {
+	if orgCache != nil {
+		orgCache.Stop()
 	}
-	return actualLoader.assets, actualLoader.err
+
+	orgCache = cache.NewLocal(func(ctx context.Context, orgID OrgID) (*OrgAssets, error) {
+		return NewOrgAssets(ctx, rt, orgID, nil, RefreshAll)
+	}, time.Second*5)
+	orgCache.Start()
 }
 
 // FlushCache clears our entire org cache
 func FlushCache() {
-	orgCache.Flush()
+	orgCache.Clear()
 }
 
 // NewOrgAssets creates and returns a new org assets objects, potentially using the previous
@@ -426,29 +411,15 @@ func GetOrgAssets(ctx context.Context, rt *runtime.Runtime, orgID OrgID) (*OrgAs
 
 // GetOrgAssetsWithRefresh creates or gets org assets for the passed in org refreshing the passed in assets
 func GetOrgAssetsWithRefresh(ctx context.Context, rt *runtime.Runtime, orgID OrgID, refresh Refresh) (*OrgAssets, error) {
-	// do we have a recent cache?
-	key := fmt.Sprintf("%d", orgID)
-	var cached *OrgAssets
-	c, found := orgCache.Get(key)
-	if found {
-		cached = c.(*OrgAssets)
+	// if nothing to refresh, return what we have cached, loading if necessary
+	if refresh == RefreshNone {
+		return orgCache.GetOrFetch(ctx, orgID)
 	}
 
-	// if found and nothing to refresh, return it
-	if found && refresh == RefreshNone {
-		return cached, nil
-	}
-
-	// if it wasn't found at all, reload it
-	if !found {
-		o, err := loadOrgAssetsOnce(ctx, rt, orgID)
-		if err != nil {
-			return nil, err
-		}
-
-		// cache it for the future
-		orgCache.SetDefault(key, o)
-		return o, nil
+	// if we don't have a cached version to refresh, do a complete load
+	cached := orgCache.Get(orgID)
+	if cached == nil {
+		return orgCache.GetOrFetch(ctx, orgID)
 	}
 
 	// otherwise we need to refresh only some parts, go do that
@@ -457,9 +428,8 @@ func GetOrgAssetsWithRefresh(ctx context.Context, rt *runtime.Runtime, orgID Org
 		return nil, err
 	}
 
-	orgCache.SetDefault(key, o)
+	orgCache.Set(orgID, o)
 
-	// return our assets
 	return o, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/nyaruka/null/v3 v3.0.0
 	github.com/nyaruka/vkutil v0.21.0
 	github.com/openai/openai-go v1.12.0
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.69.0
 	github.com/samber/slog-multi v1.8.0
@@ -104,6 +103,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
+	github.com/jellydator/ttlcache/v3 v3.4.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/muir/list v1.2.1 // indirect
 	github.com/muir/sqltoken v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
+github.com/jellydator/ttlcache/v3 v3.4.1 h1:bOdXmXiycyK6E6Qjyuj5vl+/vU3SCOoDs8a86NbHjAQ=
+github.com/jellydator/ttlcache/v3 v3.4.1/go.mod h1:j7LO12PNghFg5+0v9budMAT4rDK4JY969jb9vOdOBBk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -229,8 +231,6 @@ github.com/nyaruka/vkutil v0.21.0 h1:Vy1auqZ2slCQ1H6t/texGLv8v5DObwtwTFW7OLid9Ok
 github.com/nyaruka/vkutil v0.21.0/go.mod h1:5dIAvwkeidExJWAJ5AAYlYN8PJ4MQrzJeFuO8wRdlAo=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=

--- a/service.go
+++ b/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/gocommon/aws/cwatch"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/mailroom/v26/core/crons"
+	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/web"
 )
@@ -127,6 +128,8 @@ func (s *Service) Start() error {
 	} else {
 		log.Info("runtime started")
 	}
+
+	models.InitCache(s.rt)
 
 	// init our foremen and start it
 	s.realtimeForeman.Start(s.workersWG)

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -121,6 +121,8 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	err = rt.Start()
 	require.NoError(t, err, "error starting runtime")
 
+	models.InitCache(rt)
+
 	t.Cleanup(func() {
 		rt.Stop()
 


### PR DESCRIPTION
The org assets cache in `core/models` was the last use of `patrickmn/go-cache` (unmaintained, pre-generics). This replaces it with `gocommon/cache.Local` — a generic TTL cache with built-in singleflight loading.

- `orgCache` is now a `*cache.Local[OrgID, *OrgAssets]` (5s TTL as before), constructed by a new `models.InitCache(rt)` called wherever a runtime is started (service, mrindex, testsuite). The cache fetcher needs the runtime, which isn't available at package init.
- The hand-rolled singleflight (`assetLoaders` / `assetLoader` / `loadOrgAssetsOnce`) is replaced by `GetOrFetch`, which has the same semantics: one goroutine loads a given org, waiters share the result/error.
- Drops the `fmt.Sprintf` string keys and `.(*OrgAssets)` type assertions.

Semantics preserved: 5s TTL on set, gets never return expired entries, `FlushCache()` still clears everything.

`jellydator/ttlcache/v3` comes in as an indirect dependency via gocommon.