### PR TITLE
Fix determination of final status of contact imports

### DIFF
--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"time"
 
@@ -52,7 +53,9 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 
 	// if any error occurs this batch should be marked as failed
 	if batchErr != nil {
-		batch.SetFailed(ctx, rt.DB)
+		if err := batch.SetFailed(ctx, rt.DB); err != nil {
+			slog.Error("error marking import batch as failed", "error", err, "batch_id", batch.ID)
+		}
 	}
 
 	// decrement the counter to see if the overall import is now finished

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -54,7 +54,7 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 	// if any error occurs this batch should be marked as failed
 	if batchErr != nil {
 		if err := batch.SetFailed(ctx, rt.DB); err != nil {
-			slog.Error("error marking import batch as failed", "error", err, "batch_id", batch.ID)
+			slog.Error("error marking import batch as failed", "error", err, "import_id", batch.ImportID, "batch_id", batch.ID)
 		}
 	}
 

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -62,6 +62,13 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		return fmt.Errorf("error decrementing import batch counter: %w", err)
 	}
 	if done {
+		// reload the import to get the final statuses of all batches - the statuses loaded before this batch was
+		// processed are stale by now
+		imp, err = models.LoadContactImport(ctx, rt.DB, batch.ImportID)
+		if err != nil {
+			return fmt.Errorf("error reloading contact import: %w", err)
+		}
+
 		// if any batch failed, then import is considered failed
 		success := !slices.Contains(imp.BatchStatuses, models.ImportStatusFailed)
 

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nyaruka/mailroom/v26/core/tasks"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImportContactBatch(t *testing.T) {
@@ -55,4 +57,29 @@ func TestImportContactBatch(t *testing.T) {
 			"scope":             fmt.Sprintf("contact:%d", importID),
 			"user_id":           int64(testdb.Admin.ID),
 		})
+}
+
+func TestImportContactBatchFailure(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+
+	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
+
+	// insert a batch with specs that can't be unmarshaled so that processing it fails
+	batchID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[{"urns": "should-be-an-array"}]`))
+
+	vc.Do("SETEX", fmt.Sprintf("contact_import_batches_remaining:%d", importID), 10, 1)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	task := &tasks.ImportContactBatch{ContactImportBatchID: batchID}
+	assert.Error(t, task.Perform(ctx, rt, oa))
+
+	// batch and overall import should be marked as failed
+	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimportbatch WHERE id = $1`, batchID).Columns(map[string]any{"status": "F"})
+	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "F"})
 }

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -82,4 +82,7 @@ func TestImportContactBatchFailure(t *testing.T) {
 	// batch and overall import should be marked as failed
 	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimportbatch WHERE id = $1`, batchID).Columns(map[string]any{"status": "F"})
 	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "F"})
+
+	// and the creator still notified that the import finished
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM notifications_notification WHERE contact_import_id = $1 AND notification_type = 'import:finished' AND user_id = $2`, importID, testdb.Admin.ID).Returns(1)
 }


### PR DESCRIPTION
## Problem

The batch statuses used to decide the final status of a contact import were loaded *before* the batch was processed. The task that finishes last therefore never saw its own batch's failure — nor failures written by other batches after that load. For a single-batch import that failed, this was deterministic: the import was always marked complete and the user notified of success even though nothing was imported.

Relatedly, if marking an errored batch as failed itself failed (e.g. a DB error), that error was silently discarded — the batch stayed marked as processing with no trace of what happened, which would also feed a wrong final import status.

## Changes

* Reload the contact import once the batch counter reaches zero, so the success check runs against the actual final statuses of all batches.
* Log the error from `SetFailed` via `slog` instead of ignoring it. Processing still continues to the counter decrement so the overall import isn't left hanging.
* Add `TestImportContactBatchFailure` covering a batch whose specs can't be unmarshaled — asserts the batch and the overall import both end up failed and that the creator is still notified the import finished. This test reproduces the original bug (import ended `C` instead of `F`).