### PR TITLE
Fix import records being dropped when two records resolve to the same contact

### DIFF
--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -56,12 +56,25 @@ func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 	mods := make(map[models.ContactID][]flows.Modifier, len(imports))
 	for _, imp := range imports {
 		// ignore errored imports which couldn't get/create a contact
-		if imp.mc != nil {
-			mcs = append(mcs, imp.mc)
-			contacts = append(contacts, imp.contact)
-			mods[imp.mc.ID()] = imp.mods
-			importsByContact[imp.contact] = imp
+		if imp.mc == nil {
+			continue
 		}
+
+		// multiple records in a batch can resolve to the same contact if one references it by UUID and another by a
+		// URN it owns - parse time validation can't detect that without database lookups. We append to the contact's
+		// modifiers so the later record isn't silently dropped, matching what already happens when such records fall
+		// into different batches. Note that errors from the later record's modifiers will be misattributed to the
+		// first record. Really such duplicates should be rejected up front, but that requires resolving all records
+		// against the database before batching, i.e. moving more of the import processing into this service.
+		if _, seen := mods[imp.mc.ID()]; seen {
+			mods[imp.mc.ID()] = append(mods[imp.mc.ID()], imp.mods...)
+			continue
+		}
+
+		mcs = append(mcs, imp.mc)
+		contacts = append(contacts, imp.contact)
+		mods[imp.mc.ID()] = imp.mods
+		importsByContact[imp.contact] = imp
 	}
 
 	// and apply in bulk

--- a/core/imports/testdata/contacts.json
+++ b/core/imports/testdata/contacts.json
@@ -1205,5 +1205,134 @@
                 }
             }
         ]
+    },
+    {
+        "label": "two records resolving to same contact (by UUID and by URN) both applied",
+        "specs": [
+            {
+                "uuid": "ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "name": "Annie",
+                "_import_row": 1
+            },
+            {
+                "urns": [
+                    "tel:+16055700001"
+                ],
+                "language": "kin",
+                "_import_row": 2
+            }
+        ],
+        "num_created": 0,
+        "num_updated": 2,
+        "num_errored": 0,
+        "expected_errors": [],
+        "expected_contacts": [
+            {
+                "uuid": "ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "name": "Annie",
+                "language": "kin",
+                "status": "archived",
+                "urns": [
+                    "tel:+16055700001",
+                    "tel:+16055700005"
+                ],
+                "fields": {},
+                "groups": [],
+                "_import_row": 0
+            },
+            {
+                "uuid": "b26fcae1-abb6-49f8-95cf-9fca95f1c30a",
+                "name": "Bob",
+                "language": "kin",
+                "status": "active",
+                "urns": [
+                    "tel:+16055700002",
+                    "tel:+593979000002"
+                ],
+                "fields": {
+                    "age": "28",
+                    "joined": "2020-01-01T10:45:30.000000Z"
+                },
+                "groups": [],
+                "_import_row": 0
+            },
+            {
+                "uuid": "21ba4570-846e-4143-a7eb-cc4cc9ec3e6b",
+                "name": "Cat",
+                "language": "spa",
+                "status": "active",
+                "urns": [
+                    "tel:+16055700003",
+                    "tel:+593979000001"
+                ],
+                "fields": {
+                    "age": "39",
+                    "joined": "2020-02-01T17:15:30.000000Z"
+                },
+                "groups": [
+                    "5e9d8fab-5e7e-4f51-b533-261af5dea70d",
+                    "c153e265-f7c9-4539-9dbc-9b358714b638"
+                ],
+                "_import_row": 0
+            },
+            {
+                "uuid": "b87ff1cf-63b4-427d-a851-494c098c6807",
+                "name": "Blake",
+                "language": "",
+                "status": "blocked",
+                "urns": [
+                    "tel:+16055700007"
+                ],
+                "fields": {},
+                "groups": [],
+                "_import_row": 0
+            },
+            {
+                "uuid": "a57b9391-cd23-4136-99b2-e3c62e5695d5",
+                "name": "Ivan",
+                "language": "",
+                "status": "active",
+                "urns": [
+                    "tel:+16055700008"
+                ],
+                "fields": {},
+                "groups": [],
+                "_import_row": 0
+            }
+        ],
+        "expected_history": [
+            {
+                "PK": "con#ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "SK": "evt#01969b48-2a7b-76f8-838e-7d5caf016400",
+                "OrgID": 1,
+                "TTL": "2026-05-04T12:32:01Z",
+                "Data": {
+                    "_user": {
+                        "name": "Andy Admin",
+                        "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
+                    },
+                    "_via": "import",
+                    "created_on": "2025-05-04T12:32:01.123456789Z",
+                    "name": "Annie",
+                    "type": "contact_name_changed"
+                }
+            },
+            {
+                "PK": "con#ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "SK": "evt#01969b48-324b-76f8-b806-699460e5ca92",
+                "OrgID": 1,
+                "TTL": "2026-05-04T12:32:03Z",
+                "Data": {
+                    "_user": {
+                        "name": "Andy Admin",
+                        "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
+                    },
+                    "_via": "import",
+                    "created_on": "2025-05-04T12:32:03.123456789Z",
+                    "language": "kin",
+                    "type": "contact_language_changed"
+                }
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## Problem

An import file can contain one record referencing a contact by UUID and another record whose URN belongs to that same contact (upload validation only rejects *exact* duplicate UUIDs/URNs, so it can't catch this). Modifiers were gathered into a map keyed by contact ID, so the later record's modifiers replaced the earlier record's — silently discarding its changes — and were then applied once per duplicate scene.

## Changes

* When multiple records resolve to the same contact, append the later record's modifiers to the contact's existing scene instead of creating a second scene and overwriting the map entry. Later records still win where they conflict (same as if the records were in different batches).
* Add a snapshot test case where one record updates a contact by UUID and another by one of its URNs — both records' changes must be applied. The case fails against the previous code.

## Notes

* If a *merged* record carries an additional URN owned by a third contact, the resulting URN-taken error is attributed to the first record's row rather than the row that supplied the URN. This isn't a regression — previously the error was attributed to both rows, including the first, wrongly — just a known limitation of merging records into a single scene.