### PR TITLE
Log failure to mark an import batch as failed instead of ignoring it

### DIFF
--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"time"
 
@@ -52,7 +53,9 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 
 	// if any error occurs this batch should be marked as failed
 	if batchErr != nil {
-		batch.SetFailed(ctx, rt.DB)
+		if err := batch.SetFailed(ctx, rt.DB); err != nil {
+			slog.Error("error marking import batch as failed", "error", err, "batch_id", batch.ID)
+		}
 	}
 
 	// decrement the counter to see if the overall import is now finished

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -54,7 +54,7 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 	// if any error occurs this batch should be marked as failed
 	if batchErr != nil {
 		if err := batch.SetFailed(ctx, rt.DB); err != nil {
-			slog.Error("error marking import batch as failed", "error", err, "batch_id", batch.ID)
+			slog.Error("error marking import batch as failed", "error", err, "import_id", batch.ImportID, "batch_id", batch.ID)
 		}
 	}
 


### PR DESCRIPTION
## Problem

If marking an errored import batch as failed itself failed (e.g. a DB error), the error was silently discarded — the batch stayed marked as processing with no trace of what happened.

## Changes

* Log the error from `SetFailed` via `slog`. Processing still continues to the counter decrement so the overall import isn't left hanging.