### PR TITLE
Make batch counter completion fire exactly once

### DIFF
--- a/core/tasks/utils.go
+++ b/core/tasks/utils.go
@@ -28,15 +28,16 @@ func (c *Counter) Init(ctx context.Context, vk *valkey.Pool, val int) error {
 	return err
 }
 
-// Done decrements the counter by 1 and returns true if the counter has reached zero, i.e. all batches are done.
-// The TTL is always reset to prevent orphaned keys.
+// Done decrements the counter by 1 and returns true if the counter has reached exactly zero, i.e. all batches are
+// done. Requiring exactly zero means that extra decrements (e.g. a re-queued batch task) can't make completion fire
+// more than once. The TTL is always reset to prevent orphaned keys.
 func (c *Counter) Done(ctx context.Context, vk *valkey.Pool) (bool, error) {
 	val, err := c.decrement(ctx, vk, -1)
 	if err != nil {
 		return false, err
 	}
 
-	return val <= 0, nil
+	return val == 0, nil
 }
 
 // Value returns the current counter value, or 0 if the key doesn't exist.

--- a/core/tasks/utils_test.go
+++ b/core/tasks/utils_test.go
@@ -56,6 +56,32 @@ func TestCounter(t *testing.T) {
 	assert.Greater(t, ttl, 0)
 }
 
+func TestCounterExpiredKey(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	counter := tasks.NewCounter("test_counter_expired", time.Minute)
+
+	err := counter.Init(ctx, rt.VK, 2)
+	assert.NoError(t, err)
+
+	// simulate the key expiring mid run
+	vc.Do("DEL", "test_counter_expired")
+
+	// remaining decrements recreate the key below zero and never report done - the run is deliberately left
+	// unfinished rather than being prematurely completed
+	done, err := counter.Done(ctx, rt.VK)
+	assert.NoError(t, err)
+	assert.False(t, done)
+
+	done, err = counter.Done(ctx, rt.VK)
+	assert.NoError(t, err)
+	assert.False(t, done)
+}
+
 func TestCounterDoneSetsExpiry(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()

--- a/core/tasks/utils_test.go
+++ b/core/tasks/utils_test.go
@@ -45,6 +45,11 @@ func TestCounter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, done)
 
+	// an extra decrement, e.g. from a re-queued task, shouldn't return true again
+	done, err = counter.Done(ctx, rt.VK)
+	assert.NoError(t, err)
+	assert.False(t, done)
+
 	// key should still exist with a TTL (not orphaned)
 	ttl, err = valkey.Int(vc.Do("TTL", "test_counter"))
 	assert.NoError(t, err)


### PR DESCRIPTION
## Problem

`Counter.Done` treated any value `<= 0` as done, so an extra decrement after completion — e.g. a re-queued batch task, or batch tasks queued twice for the same import — would report done again, causing duplicate completion side effects such as duplicate import-finished notifications.

## Changes

* Require the counter to reach exactly zero, so completion can only fire once per counter.
* Extend the counter test to assert that a decrement past zero doesn't report done again.

Note this changes behavior when a counter key expires mid-run: the run is now left unfinished (visible as stalled) rather than being prematurely — and possibly repeatedly — marked as finished with incorrect results.