### PR TITLE
Report all modifier errors against contact import records

### DIFF
--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -70,14 +70,17 @@ func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 		return fmt.Errorf("error applying modifiers: %w", err)
 	}
 
-	// extract certain errors from events
+	// extract errors from events so they can be reported against their records - e.g. invalid URNs which modifiers
+	// skip, or URNs already taken by other contacts
 	for contact, evts := range eventsByContact {
 		for _, evt := range evts {
 			switch typed := evt.(type) {
 			case *events.Error:
+				imp := importsByContact[contact]
 				if typed.Code == events.ErrorCodeURNTaken {
-					imp := importsByContact[contact]
 					imp.errors = append(imp.errors, fmt.Sprintf("URN %s already taken by another contact", typed.Extra["urn"]))
+				} else {
+					imp.errors = append(imp.errors, typed.Text)
 				}
 			}
 		}

--- a/core/imports/testdata/contacts.json
+++ b/core/imports/testdata/contacts.json
@@ -1090,5 +1090,120 @@
                 }
             }
         ]
+    },
+    {
+        "label": "errors from modifiers like invalid URNs are reported against records",
+        "specs": [
+            {
+                "uuid": "ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "name": "Anne III",
+                "urns": [
+                    "tel:7777777777777777777777777777777777777777777777777777777777777777777777"
+                ],
+                "_import_row": 2
+            }
+        ],
+        "num_created": 0,
+        "num_updated": 1,
+        "num_errored": 0,
+        "expected_errors": [
+            {
+                "row": 2,
+                "record": 0,
+                "message": "'tel:7777777777777777777777777777777777777777777777777777777777777777777777' is not valid URN"
+            }
+        ],
+        "expected_contacts": [
+            {
+                "uuid": "ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "name": "Anne III",
+                "language": "",
+                "status": "archived",
+                "urns": [
+                    "tel:+16055700001",
+                    "tel:+16055700005"
+                ],
+                "fields": {},
+                "groups": [],
+                "_import_row": 0
+            },
+            {
+                "uuid": "b26fcae1-abb6-49f8-95cf-9fca95f1c30a",
+                "name": "Bob",
+                "language": "kin",
+                "status": "active",
+                "urns": [
+                    "tel:+16055700002",
+                    "tel:+593979000002"
+                ],
+                "fields": {
+                    "age": "28",
+                    "joined": "2020-01-01T10:45:30.000000Z"
+                },
+                "groups": [],
+                "_import_row": 0
+            },
+            {
+                "uuid": "21ba4570-846e-4143-a7eb-cc4cc9ec3e6b",
+                "name": "Cat",
+                "language": "spa",
+                "status": "active",
+                "urns": [
+                    "tel:+16055700003",
+                    "tel:+593979000001"
+                ],
+                "fields": {
+                    "age": "39",
+                    "joined": "2020-02-01T17:15:30.000000Z"
+                },
+                "groups": [
+                    "5e9d8fab-5e7e-4f51-b533-261af5dea70d",
+                    "c153e265-f7c9-4539-9dbc-9b358714b638"
+                ],
+                "_import_row": 0
+            },
+            {
+                "uuid": "b87ff1cf-63b4-427d-a851-494c098c6807",
+                "name": "Blake",
+                "language": "",
+                "status": "blocked",
+                "urns": [
+                    "tel:+16055700007"
+                ],
+                "fields": {},
+                "groups": [],
+                "_import_row": 0
+            },
+            {
+                "uuid": "a57b9391-cd23-4136-99b2-e3c62e5695d5",
+                "name": "Ivan",
+                "language": "",
+                "status": "active",
+                "urns": [
+                    "tel:+16055700008"
+                ],
+                "fields": {},
+                "groups": [],
+                "_import_row": 0
+            }
+        ],
+        "expected_history": [
+            {
+                "PK": "con#ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
+                "SK": "evt#01969b48-1adb-76f8-a502-6fb7f5d04e3f",
+                "OrgID": 1,
+                "TTL": "2026-05-04T12:31:57Z",
+                "Data": {
+                    "_user": {
+                        "name": "Andy Admin",
+                        "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
+                    },
+                    "_via": "import",
+                    "created_on": "2025-05-04T12:31:57.123456789Z",
+                    "name": "Anne III",
+                    "type": "contact_name_changed"
+                }
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## Problem

Only URN-taken errors from applying modifiers were surfaced as import errors. Other error events — a URN being invalid and skipped, a contact exceeding the URN limit, group additions skipped because the contact is blocked or stopped — were silently dropped, so records appeared to import cleanly while some of their data was ignored.

## Changes

* Surface all error events from applying modifiers against their import records, keeping the friendlier wording for the URN-taken case.
* Add a snapshot test case where a record referencing a contact by UUID carries an invalid URN — the URN error is now reported against that row while the record's other changes still apply.

Every error event the import modifiers can emit represents data that wasn't applied, so none of this is noise; error volume stays bounded by batch size.