### PR TITLE
Error import records whose URNs are too long to save

### DIFF
--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/stringsx"
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/flows"
@@ -105,6 +108,13 @@ func getOrCreateContacts(ctx context.Context, db *sqlx.DB, oa *models.OrgAssets,
 		addError := func(s string, args ...any) { imp.errors = append(imp.errors, fmt.Sprintf(s, args...)) }
 		spec := imp.spec
 
+		// URN validation limits path length but identities (scheme:path) also have to fit in the database, and
+		// imports are one of the few places un-checked URNs can come from
+		if urn, ok := findOversizedURN(spec.URNs); ok {
+			addError("URN '%s' is too long", stringsx.TruncateEllipsis(string(urn.Identity()), 32))
+			continue
+		}
+
 		isActive := spec.Status == "" || spec.Status == core.ContactStatusActive
 
 		uuid := spec.UUID
@@ -178,6 +188,20 @@ func getOrCreateContacts(ctx context.Context, db *sqlx.DB, oa *models.OrgAssets,
 	}
 
 	return nil
+}
+
+// contacts_contacturn.identity is varchar(255) so URNs whose identities exceed that can't be saved
+const maxURNIdentityLength = 255
+
+// returns the first URN whose normalized identity is too long to be saved, if any
+func findOversizedURN(urnz []urns.URN) (urns.URN, bool) {
+	for _, urn := range urnz {
+		urn := urn.Normalize()
+		if utf8.RuneCountInString(string(urn.Identity())) > maxURNIdentityLength {
+			return urn, true
+		}
+	}
+	return urns.NilURN, false
 }
 
 // loads any import contacts for which we have UUIDs

--- a/core/imports/contacts_test.go
+++ b/core/imports/contacts_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/dbutil"
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -151,6 +152,55 @@ func TestContactImports(t *testing.T) {
 		err = os.WriteFile("testdata/contacts.json", testJSON, 0600)
 		require.NoError(t, err)
 	}
+}
+
+func TestImportBatchOversizedURN(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+
+	testdb.InsertContact(t, rt, testdb.Org1, "afe1a37f-a01d-4a02-b06a-25dc47db1b52", "Bob", "eng", models.ContactStatusActive)
+
+	// a URN with a path at the 255 char validation limit has an identity too long for the database
+	longURN := "ext:" + strings.Repeat("x", 255)
+
+	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
+	batchID := testdb.InsertContactImportBatch(t, rt, importID, jsonx.MustMarshal([]map[string]any{
+		{"uuid": "afe1a37f-a01d-4a02-b06a-25dc47db1b52", "name": "Bobby", "urns": []string{longURN}, "_import_row": 2},
+		{"name": "Ann", "urns": []string{longURN}, "_import_row": 3},
+		{"name": "Zephyrine", "urns": []string{"tel:+16055740021"}, "_import_row": 4},
+	}))
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshFields|models.RefreshGroups)
+	require.NoError(t, err)
+
+	batch, err := models.LoadContactImportBatch(ctx, rt.DB, batchID)
+	require.NoError(t, err)
+
+	// batch should complete rather than failing entirely because of the oversized URNs
+	err = imports.ImportBatch(ctx, rt, oa, batch, testdb.Admin.ID)
+	assert.NoError(t, err)
+
+	results := &struct {
+		Status     string          `db:"status"`
+		NumCreated int             `db:"num_created"`
+		NumErrored int             `db:"num_errored"`
+		Errors     json.RawMessage `db:"errors"`
+	}{}
+	err = rt.DB.Get(results, `SELECT status, num_created, num_errored, errors FROM contacts_contactimportbatch WHERE id = $1`, batchID)
+	require.NoError(t, err)
+
+	assert.Equal(t, "C", results.Status)
+	assert.Equal(t, 1, results.NumCreated) // Zephyrine
+	assert.Equal(t, 2, results.NumErrored)
+	test.AssertEqualJSON(t, []byte(`[
+		{"record": 0, "row": 2, "message": "URN 'ext:xxxxxxxxxxxxxxxxxxxxxxxxx...' is too long"},
+		{"record": 1, "row": 3, "message": "URN 'ext:xxxxxxxxxxxxxxxxxxxxxxxxx...' is too long"}
+	]`), results.Errors, "errors mismatch")
+
+	// the record referencing Bob by UUID errored so his name is unchanged
+	assertdb.Query(t, rt.DB, `SELECT name FROM contacts_contact WHERE uuid = 'afe1a37f-a01d-4a02-b06a-25dc47db1b52'`).Columns(map[string]any{"name": "Bob"})
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE name = 'Zephyrine'`).Returns(1)
 }
 
 func TestContactSpecUnmarshal(t *testing.T) {


### PR DESCRIPTION
## Problem

URN validation limits the *path* component to 255 chars, but the URN's identity (`scheme:path`) is stored in a 255 char column — so e.g. an `ext:` URN with a 255 char path passes validation and then fails the insert with a database error. For imports that failed the **entire batch**, and non-atomically: contacts created earlier in the batch (committed immediately) kept none of their imported names, fields or groups, and the batch reported no results.

## Changes

* Check each record's normalized URN identities fit the column (rune-counted, matching varchar semantics) before processing, and error just the offending record ("URN 'ext:xxx...' is too long") instead of failing the batch.
* Add a test covering an oversized URN on a record referencing a contact by UUID, on a record creating a contact, and an unaffected record in the same batch.

The identity is the binding column — if it fits, the path and scheme columns necessarily fit, and the display component is already bounded by URN validation. Longer term this check belongs in the URN library's validation (bounding the identity, not just the path), which would protect all callers.