### PR TITLE
Truncate imported contact names to what can be stored

### DIFF
--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/flows"
@@ -139,7 +140,8 @@ func getOrCreateContacts(ctx context.Context, db *sqlx.DB, oa *models.OrgAssets,
 		addModifier(modifiers.NewURNs(spec.URNs, modifiers.URNsAppend))
 
 		if spec.Name != nil {
-			addModifier(modifiers.NewName(*spec.Name))
+			// truncate to what we can save so the name in the resulting event matches what is stored
+			addModifier(modifiers.NewName(stringsx.Truncate(*spec.Name, models.MaxContactNameLength)))
 		}
 		if spec.Language != nil {
 			lang, err := i18n.ParseLanguage(*spec.Language)

--- a/core/imports/contacts_test.go
+++ b/core/imports/contacts_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/dbutil"
@@ -151,6 +152,43 @@ func TestContactImports(t *testing.T) {
 		err = os.WriteFile("testdata/contacts.json", testJSON, 0600)
 		require.NoError(t, err)
 	}
+}
+
+func TestImportBatchLongName(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+
+	longName := strings.Repeat("abcdefghij", 20) // 200 chars
+
+	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
+	batchID := testdb.InsertContactImportBatch(t, rt, importID, jsonx.MustMarshal([]map[string]any{
+		{"name": longName, "urns": []string{"tel:+16055740031"}, "_import_row": 2},
+	}))
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshFields|models.RefreshGroups)
+	require.NoError(t, err)
+
+	batch, err := models.LoadContactImportBatch(ctx, rt.DB, batchID)
+	require.NoError(t, err)
+
+	err = imports.ImportBatch(ctx, rt, oa, batch, testdb.Admin.ID)
+	require.NoError(t, err)
+
+	// name is truncated to what can be stored
+	truncated := longName[:models.MaxContactNameLength] // safe to slice by bytes because input is ASCII
+	var name string
+	require.NoError(t, rt.DB.Get(&name, `SELECT name FROM contacts_contact WHERE id = (SELECT contact_id FROM contacts_contacturn WHERE identity = 'tel:+16055740031')`))
+	assert.Equal(t, truncated, name)
+
+	// and the name changed event in the contact's history matches what was stored
+	eventName := ""
+	for _, item := range testsuite.GetHistoryItems(t, rt, false, time.Time{}) {
+		if item.Data["type"] == "contact_name_changed" {
+			eventName = item.Data["name"].(string)
+		}
+	}
+	assert.Equal(t, truncated, eventName)
 }
 
 func TestContactSpecUnmarshal(t *testing.T) {

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -49,6 +49,9 @@ const (
 	defaultURNPriority = 0
 )
 
+// MaxContactNameLength is the maximum length we can save for a contact name
+const MaxContactNameLength = 128
+
 // nil versions of ID types
 const (
 	NilURNID     = URNID(0)

--- a/core/runner/hooks/update_contact_name.go
+++ b/core/runner/hooks/update_contact_name.go
@@ -2,8 +2,8 @@ package hooks
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
@@ -25,7 +25,7 @@ func (h *updateContactName) Execute(ctx context.Context, rt *runtime.Runtime, tx
 	for s, args := range scenes {
 		// we only care about the last name change
 		event := args[len(args)-1].(*events.ContactNameChanged)
-		updates = append(updates, &nameUpdate{s.ContactID(), null.String(fmt.Sprintf("%.128s", event.Name))})
+		updates = append(updates, &nameUpdate{s.ContactID(), null.String(stringsx.Truncate(event.Name, models.MaxContactNameLength))})
 	}
 
 	return models.BulkQuery(ctx, "updating contact name", tx, sqlUpdateContactName, updates)


### PR DESCRIPTION
## Problem

Contact names are truncated to the engine's field value limit (640) when the name modifier is applied, but to 128 when written to the database — so the name recorded in the contact's history event could differ from what was actually saved.

## Changes

* Truncate imported names to a new shared `MaxContactNameLength` constant before building the name modifier, so the resulting history event matches storage.
* Use the same constant in the name update hook instead of a magic number (the hook keeps truncating as a safety net for other paths).
* Test asserts both the stored name and the name in the recorded history event are the truncated value.

Known limitation: names set from flows still record the event before the database truncation, so the same mismatch remains on that path — fixing it needs a name-specific length limit in the engine, which is a separate upstream change.