### PR TITLE
Use distinct log message for webhook request size limit errors

### DIFF
--- a/core/runner/handlers/error.go
+++ b/core/runner/handlers/error.go
@@ -30,9 +30,9 @@ func handleError(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 		// about it rather than let it silently degrade a message - error level is fanned out to sentry
 		log.Error("expression exceeded cost budget", "expression", event.Extra["expression"])
 	case events.ErrorCodeWebhookRequestSize:
-		// webhook requests exceeding the size limit are skipped, so we want to know when that's happening - error
-		// level is fanned out to sentry
-		log.Error("webhook size limit exceeded", "code", event.Code)
+		// requests exceeding the size limit are never sent, which can silently break flows that previously worked,
+		// so we want to know when that's happening - error level is fanned out to sentry
+		log.Error("webhook request size limit exceeded")
 	default:
 		log.Debug("error event", "code", event.Code)
 	}

--- a/core/runner/handlers/error_test.go
+++ b/core/runner/handlers/error_test.go
@@ -53,6 +53,5 @@ func TestError(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, logBuf.String(), "level=ERROR")
-	assert.Contains(t, logBuf.String(), "webhook size limit exceeded")
-	assert.Contains(t, logBuf.String(), "code=webhook:request_size")
+	assert.Contains(t, logBuf.String(), "webhook request size limit exceeded")
 }


### PR DESCRIPTION
The engine now only reports request size limits as error events (responses exceeding the size limit became warning events in goflow v0.285.0), so the error handler can give them a distinct log message — "webhook request size limit exceeded" instead of the generic "webhook size limit exceeded" — making these easier to distinguish in error reporting. The `code` log attribute is dropped since the message now carries that distinction.

Requests exceeding the size limit stay at error level because they are never sent, which can silently break flows that previously worked.