### PR TITLE
Publish flow activity change notifications to per-flow sockets

### DIFF
--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -30,6 +30,19 @@ func HistorySocket(contactUUID core.ContactUUID, ticketUUID ...core.TicketUUID) 
 	return fmt.Sprintf("%s:%s", SocketHistoryNamespace, contactUUID)
 }
 
+// SocketFlowNamespace is the realtime pub/sub namespace for things happening to a specific flow that its editors care
+// about. A flow socket is addressed as "flow:<flow-uuid>" and carries typed payloads - currently just activity change
+// notifications, but it's deliberately per-flow rather than per-feature so that other flow level updates (e.g.
+// revisions, issues) can be published to the same socket later. Like the other namespaces it's a client subscription,
+// authorized per-session by the subscribe proxy, which records the same "socket-subs:" presence key - so mailroom
+// only publishes to it when someone actually has the flow open.
+const SocketFlowNamespace = "flow"
+
+// FlowSocket returns the realtime pub/sub socket for the given flow, addressed as "flow:<flow-uuid>".
+func FlowSocket(flowUUID assets.FlowUUID) string {
+	return fmt.Sprintf("%s:%s", SocketFlowNamespace, flowUUID)
+}
+
 // SocketNotificationsNamespace is the realtime pub/sub namespace for a user's notifications within a workspace. A
 // notification socket is addressed as "notifications:<org-uuid>:<user-uuid>". Like history sockets it's a client
 // subscription, authorized per-session by the subscribe proxy, which records the same "socket-subs:" presence key -
@@ -130,6 +143,30 @@ func PublishToHistory(ctx context.Context, rt *runtime.Runtime, contactUUID core
 
 	if err := rt.Centrifugo.Publish(ctx, pubs...); err != nil {
 		return fmt.Errorf("error publishing history events: %w", err)
+	}
+
+	return nil
+}
+
+// PublishFlowActivity publishes an activity change notification to each given flow's socket, telling any live
+// watchers (i.e. open editors) that the flow's activity counts have changed and are worth re-fetching. The payload is
+// deliberately just a typed ping rather than the counts themselves - the activity read endpoint stays the single
+// source of truth (it also includes state this code never sees, like node active counts), and watchers re-fetch from
+// it on their own debounced schedule. As with the other socket publishes it's best-effort and a no-op for any flow
+// that currently has no watchers - the centrifugo service resolves subscriber presence for the whole batch in a
+// single lookup, so in the overwhelmingly common case of nobody watching this costs one valkey round-trip.
+func PublishFlowActivity(ctx context.Context, rt *runtime.Runtime, flowUUIDs []assets.FlowUUID) error {
+	if len(flowUUIDs) == 0 {
+		return nil
+	}
+
+	pubs := make([]*centrifugo.Publication, len(flowUUIDs))
+	for i, flowUUID := range flowUUIDs {
+		pubs[i] = &centrifugo.Publication{Channel: FlowSocket(flowUUID), Data: json.RawMessage(`{"type":"activity"}`)}
+	}
+
+	if err := rt.Centrifugo.Publish(ctx, pubs...); err != nil {
+		return fmt.Errorf("error publishing flow activity: %w", err)
 	}
 
 	return nil

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -27,6 +27,46 @@ func TestHistorySocket(t *testing.T) {
 	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf:019905d4-5f7b-71b8-bcb8-6a68de2d91d2", models.HistorySocket(contact, ticket))
 }
 
+func TestFlowSocket(t *testing.T) {
+	flow := assets.FlowUUID("9de3663f-c5c5-4c92-9f45-ecbc09abcc85")
+
+	assert.Equal(t, "flow:9de3663f-c5c5-4c92-9f45-ecbc09abcc85", models.FlowSocket(flow))
+}
+
+func TestPublishFlowActivity(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	mock := rt.Centrifugo.Client.(*centrifugo.MockClient)
+
+	flow1 := assets.FlowUUID("9de3663f-c5c5-4c92-9f45-ecbc09abcc85")
+	flow2 := assets.FlowUUID("70c38f94-ab42-4666-86fd-3c76139110d3")
+
+	// no flows is a no-op
+	require.NoError(t, models.PublishFlowActivity(ctx, rt, nil))
+	assert.Empty(t, mock.Publications())
+
+	// neither flow's socket is subscribed yet, so nothing is published
+	require.NoError(t, models.PublishFlowActivity(ctx, rt, []assets.FlowUUID{flow1, flow2}))
+	assert.Empty(t, mock.Publications())
+
+	// mark flow1's socket subscribed (as the authorizing service would) - now it alone receives the typed ping
+	_, err := vc.Do("SET", centrifugo.SubscriptionKey(models.FlowSocket(flow1)), "1")
+	require.NoError(t, err)
+
+	require.NoError(t, models.PublishFlowActivity(ctx, rt, []assets.FlowUUID{flow1, flow2}))
+
+	sent := testsuite.CentrifugoHistory(t, rt, models.FlowSocket(flow1))
+	require.Len(t, sent, 1)
+	assert.JSONEq(t, `{"type": "activity"}`, string(sent[0]))
+
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, models.FlowSocket(flow2)))
+}
+
 func TestNotificationSocket(t *testing.T) {
 	org := models.OrgUUID("bf0514a5-9407-44c9-b0f9-3f36f9c18414")
 	user := assets.UserUUID("ad9fdf9f-56ab-422a-b77d-e3ec26091a25")

--- a/core/runner/handlers/sprint_ended.go
+++ b/core/runner/handlers/sprint_ended.go
@@ -140,6 +140,7 @@ func handleSprintEnded(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 
 		scene.AttachPreCommitHook(hooks.InsertContactFires, hooks.FiresSet{Create: newFires, Delete: delFires})
 		scene.AttachPreCommitHook(hooks.InsertFlowStats, event)
+		scene.AttachPostCommitHook(hooks.PublishFlowActivity, event)
 	}
 	return nil
 }

--- a/core/runner/hooks/publish_flow_activity.go
+++ b/core/runner/hooks/publish_flow_activity.go
@@ -1,0 +1,41 @@
+package hooks
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/runtime"
+)
+
+// PublishFlowActivity is our hook for notifying live watchers of flows (e.g. open editors) that activity in those
+// flows has changed
+var PublishFlowActivity runner.PostCommitHook = &publishFlowActivity{}
+
+type publishFlowActivity struct{}
+
+func (h *publishFlowActivity) Order() int { return 10 }
+
+func (h *publishFlowActivity) Execute(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, scenes map[*runner.Scene][]any) error {
+	// gather the distinct flows traversed by the committed sprints - the same segments the insert flow stats hook
+	// counts, so a notification goes out exactly when there are new counts to see
+	seen := make(map[assets.FlowUUID]bool, 10)
+	for scene := range scenes {
+		for _, seg := range scene.Sprint.Segments() {
+			seen[seg.Flow().Asset().(*models.Flow).UUID()] = true
+		}
+	}
+
+	flowUUIDs := slices.Sorted(maps.Keys(seen)) // for test determinism
+
+	// realtime delivery is best-effort - a publish failure shouldn't fail processing of already committed scenes
+	if err := models.PublishFlowActivity(ctx, rt, flowUUIDs); err != nil {
+		slog.Error("error publishing flow activity", "error", err)
+	}
+
+	return nil
+}

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -234,13 +234,21 @@ func TestBulkCommitPublishesEvents(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	// someone is watching Ann's history socket
+	// someone is watching Ann's history socket, and someone has the flow open in an editor
 	socket := models.HistorySocket(testdb.Ann.UUID)
 	_, err = vc.Do("SET", centrifugo.SubscriptionKey(socket), "1")
+	require.NoError(t, err)
+	flowSocket := models.FlowSocket(flow.UUID)
+	_, err = vc.Do("SET", centrifugo.SubscriptionKey(flowSocket), "1")
 	require.NoError(t, err)
 
 	trig := triggers.NewBuilder(flow.Reference()).Manual().Build()
 	testsuite.StartSessions(t, rt, oa, []*testdb.Contact{testdb.Ann}, trig)
+
+	// the flow's subscribed socket received a single activity change ping for the commit
+	flowSent := testsuite.CentrifugoHistory(t, rt, flowSocket)
+	require.Len(t, flowSent, 1)
+	assert.JSONEq(t, `{"type": "activity"}`, string(flowSent[0]))
 
 	// the subscribed socket received the persisted events plus the ephemeral contact_flow_changed
 	sent := testsuite.CentrifugoHistory(t, rt, socket)

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -234,21 +234,13 @@ func TestBulkCommitPublishesEvents(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	// someone is watching Ann's history socket, and someone has the flow open in an editor
+	// someone is watching Ann's history socket
 	socket := models.HistorySocket(testdb.Ann.UUID)
 	_, err = vc.Do("SET", centrifugo.SubscriptionKey(socket), "1")
-	require.NoError(t, err)
-	flowSocket := models.FlowSocket(flow.UUID)
-	_, err = vc.Do("SET", centrifugo.SubscriptionKey(flowSocket), "1")
 	require.NoError(t, err)
 
 	trig := triggers.NewBuilder(flow.Reference()).Manual().Build()
 	testsuite.StartSessions(t, rt, oa, []*testdb.Contact{testdb.Ann}, trig)
-
-	// the flow's subscribed socket received a single activity change ping for the commit
-	flowSent := testsuite.CentrifugoHistory(t, rt, flowSocket)
-	require.Len(t, flowSent, 1)
-	assert.JSONEq(t, `{"type": "activity"}`, string(flowSent[0]))
 
 	// the subscribed socket received the persisted events plus the ephemeral contact_flow_changed
 	sent := testsuite.CentrifugoHistory(t, rt, socket)
@@ -350,6 +342,47 @@ func TestBulkCommitPublishesNotifications(t *testing.T) {
 	require.NoError(t, json.Unmarshal(sent[0], &decoded))
 	assert.Equal(t, "tickets:opened", decoded["type"])
 	assert.Equal(t, false, decoded["is_seen"])
+}
+
+func TestBulkCommitPublishesFlowActivity(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData|testsuite.ResetDynamo)
+
+	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
+	other, parent, child := testFlows[1], testFlows[2], testFlows[3]
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshFlows)
+	require.NoError(t, err)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	// all three flows are open in editors
+	parentSocket := models.FlowSocket(parent.UUID)
+	childSocket := models.FlowSocket(child.UUID)
+	otherSocket := models.FlowSocket(other.UUID)
+	for _, s := range []string{parentSocket, childSocket, otherSocket} {
+		_, err = vc.Do("SET", centrifugo.SubscriptionKey(s), "1")
+		require.NoError(t, err)
+	}
+
+	// start two contacts in a flow that enters a subflow, committed as a single batch
+	trig := triggers.NewBuilder(parent.Reference()).Manual().Build()
+	testsuite.StartSessions(t, rt, oa, []*testdb.Contact{testdb.Bob, testdb.Cat}, trig)
+
+	// both scenes' segments in the parent collapse to a single activity ping on its socket
+	parentSent := testsuite.CentrifugoHistory(t, rt, parentSocket)
+	require.Len(t, parentSent, 1)
+	assert.JSONEq(t, `{"type": "activity"}`, string(parentSent[0]))
+
+	// and traversing into the subflow pinged its socket too, again just once
+	childSent := testsuite.CentrifugoHistory(t, rt, childSocket)
+	require.Len(t, childSent, 1)
+	assert.JSONEq(t, `{"type": "activity"}`, string(childSent[0]))
+
+	// while the untraversed flow's socket got nothing
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, otherSocket))
 }
 
 func TestSessionFailedStart(t *testing.T) {


### PR DESCRIPTION
Adds realtime notification of flow activity changes so the flow editor can update its activity counts as they happen rather than blind polling.

## What changed

* New `flow` socket namespace: `FlowSocket(flowUUID)` addresses a per-flow pub/sub socket as `flow:<flow-uuid>`, and `PublishFlowActivity` publishes a `{"type": "activity"}` ping to each given flow's socket.
* New `PublishFlowActivity` post commit hook collects the distinct flows traversed by committed sprints' segments — the same segments the `InsertFlowStats` hook counts, so a ping goes out exactly when there are new counts to see — and publishes one ping per flow per commit batch. Attached in the sprint ended handler alongside `InsertFlowStats`.

## Design notes for reviewers

* The socket is deliberately per-flow rather than per-feature: payloads are typed, so other flow-level updates (revisions, issues, etc.) can be published to the same socket later without new plumbing.
* The payload is just a ping, not the counts. The activity read endpoint stays the single source of truth — it also reflects state this code path never sees (node active counts, count squashing) — and watchers re-fetch from it on their own debounced schedule.
* Publishing is presence-gated like the existing history/notifications sockets: a flow nobody is watching costs only the shared subscriber lookup, with no marshaling or publish. Delivery is best-effort — a publish failure is logged, never fails already-committed scenes.
* Subscription authorization (namespace `flow`, requiring editor access to the flow) is handled by the subscribe proxy service, which is being updated separately.

## Testing

New unit tests for the socket helper and publish function (presence gating, payload, no-op cases) and an end-to-end assertion that a subscribed flow socket receives exactly one ping when a session commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)