### PR TITLE
Use a named constant for max contact name length

### DIFF
--- a/core/goflow/engine.go
+++ b/core/goflow/engine.go
@@ -17,6 +17,9 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// MaxContactNameLength is the maximum length of a contact name (matches the database column)
+const MaxContactNameLength = 128
+
 var eng, simulator flows.Engine
 var engInit, simulatorInit sync.Once
 
@@ -91,7 +94,7 @@ func Engine(rt *runtime.Runtime) flows.Engine {
 			WithEvaluationBudget(excellent.DefaultEvaluationBudget).
 			WithMaxStepsPerSprint(rt.Config.MaxStepsPerSprint).
 			WithMaxSprintsPerSession(rt.Config.MaxSprintsPerSession).
-			WithMaxNameChars(128).
+			WithMaxNameChars(MaxContactNameLength).
 			WithMaxFieldChars(rt.Config.MaxValueLength).
 			WithMaxResultChars(rt.Config.MaxValueLength).
 			WithWebhookLimits(256*1024, rt.Config.WebhooksMaxBodyBytes).
@@ -121,7 +124,7 @@ func Simulator(ctx context.Context, rt *runtime.Runtime) flows.Engine {
 			WithEvaluationBudget(excellent.DefaultEvaluationBudget).
 			WithMaxStepsPerSprint(rt.Config.MaxStepsPerSprint).
 			WithMaxSprintsPerSession(rt.Config.MaxSprintsPerSession).
-			WithMaxNameChars(128).
+			WithMaxNameChars(MaxContactNameLength).
 			WithMaxFieldChars(rt.Config.MaxValueLength).
 			WithMaxResultChars(rt.Config.MaxValueLength).
 			WithWebhookLimits(256*1024, rt.Config.WebhooksMaxBodyBytes).

--- a/core/runner/hooks/update_contact_name.go
+++ b/core/runner/hooks/update_contact_name.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/goflow/core/events"
+	"github.com/nyaruka/mailroom/v26/core/goflow"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
 	"github.com/nyaruka/mailroom/v26/runtime"
@@ -25,7 +26,7 @@ func (h *updateContactName) Execute(ctx context.Context, rt *runtime.Runtime, tx
 	for s, args := range scenes {
 		// we only care about the last name change
 		event := args[len(args)-1].(*events.ContactNameChanged)
-		updates = append(updates, &nameUpdate{s.ContactID(), null.String(fmt.Sprintf("%.128s", event.Name))})
+		updates = append(updates, &nameUpdate{s.ContactID(), null.String(fmt.Sprintf("%.*s", goflow.MaxContactNameLength, event.Name))})
 	}
 
 	return models.BulkQuery(ctx, "updating contact name", tx, sqlUpdateContactName, updates)


### PR DESCRIPTION
Replaces the magic number 128 used for contact name truncation with a single named constant, `goflow.MaxContactNameLength`, used by both the engine builders (`WithMaxNameChars`) and the contact name update hook. Keeps all three call sites in sync with the `contacts_contact.name` column length.

The constant lives in `core/goflow` rather than `core/models` because `core/models` already imports `core/goflow`, so the reverse import would be a cycle.