### PR TITLE
Pass queued task ID to task Perform methods

### DIFF
--- a/core/models/start.go
+++ b/core/models/start.go
@@ -80,7 +80,7 @@ func (e Exclusions) Value() (driver.Value, error) { return json.Marshal(e) }
 // FlowStart represents the top level flow start in our system
 type FlowStart struct {
 	ID          StartID         `json:"start_id"` // null for non-persisted tasks used by flow actions
-	UUID        uuids.UUID      `json:"-"`
+	UUID        uuids.UUID      `json:"uuid,omitempty"`
 	OrgID       OrgID           `json:"org_id"`
 	Status      StartStatus     `json:"-"`
 	StartType   StartType       `json:"start_type"`

--- a/core/models/start_test.go
+++ b/core/models/start_test.go
@@ -138,6 +138,7 @@ func TestStartsBuilding(t *testing.T) {
 		},
 		"query": "language != \"\"",
 		"start_id": null,
-		"start_type": "M"
+		"start_type": "M",
+		"uuid": "72b553cc-c00b-44e6-bb48-4710e784acb8"
 	}`, testdb.Ann.ID, testdb.Bob.ID, testdb.TestersGroup.ID, testdb.Favorites.ID, testdb.DoctorsGroup.ID), marshalled)
 }

--- a/core/runner/handlers/testdata/session_triggered.json
+++ b/core/runner/handlers/testdata/session_triggered.json
@@ -94,6 +94,7 @@
                     "type": "start_flow",
                     "payload": {
                         "start_id": null,
+                        "uuid": "1b2083ab-a0cb-48da-924e-9de1a11831b3",
                         "org_id": 1,
                         "start_type": "F",
                         "created_by_id": null,
@@ -230,6 +231,7 @@
                     "type": "start_flow",
                     "payload": {
                         "start_id": null,
+                        "uuid": "ad9bdcfa-5604-4542-98c7-1f0d5859f77e",
                         "org_id": 1,
                         "start_type": "F",
                         "created_by_id": null,

--- a/core/runner/handlers/testdata/session_triggered_by_query.json
+++ b/core/runner/handlers/testdata/session_triggered_by_query.json
@@ -70,6 +70,7 @@
                     "type": "start_flow",
                     "payload": {
                         "start_id": null,
+                        "uuid": "1b2083ab-a0cb-48da-924e-9de1a11831b3",
                         "org_id": 1,
                         "start_type": "F",
                         "created_by_id": null,

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -31,6 +31,9 @@ func RegisterType(name string, initFunc func() Task) {
 	registeredTypes[name] = initFunc
 }
 
+// TaskID is the unique ID assigned to a task when it's queued
+type TaskID = queues.TaskID
+
 // Task is the common interface for all task types
 type Task interface {
 	Type() string
@@ -40,8 +43,8 @@ type Task interface {
 
 	WithAssets() models.Refresh
 
-	// Perform performs the task
-	Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error
+	// Perform performs the task, and is passed the unique ID the task was queued with
+	Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error
 }
 
 // Performs a raw task popped from a queue
@@ -62,7 +65,7 @@ func Perform(ctx context.Context, rt *runtime.Runtime, task *queues.Task) error 
 
 	start := time.Now()
 
-	err = typedTask.Perform(ctx, rt, oa)
+	err = typedTask.Perform(ctx, rt, oa, task.ID)
 
 	if duration := time.Since(start); duration >= slowThreshold(typedTask.Timeout()) {
 		slog.Error("task took longer than expected", "org", oa.OrgID(), "type", typedTask.Type(), "duration", duration, "timeout", typedTask.Timeout())

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/runtime"
@@ -34,11 +35,11 @@ func RegisterType(name string, initFunc func() Task) {
 // TaskID is the unique ID assigned to a task when it's queued
 type TaskID = queues.TaskID
 
-// BatchTask is embedded by tasks which are one batch of work split out from an owning task or object. BatchOwnerID
+// BatchTask is embedded by tasks which are one batch of work split out from an owning task or object. BatchOwnerUUID
 // identifies that owner: the UUID of the parent object where there is one (flow start, broadcast), and otherwise the
-// ID of the creating task (group population) or a generated ID (contact imports).
+// ID of the creating task (group population) or a generated UUID (contact imports).
 type BatchTask struct {
-	BatchOwnerID TaskID `json:"batch_owner_id,omitempty"`
+	BatchOwnerUUID uuids.UUID `json:"batch_owner_uuid,omitempty"`
 }
 
 // Task is the common interface for all task types

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -34,11 +34,11 @@ func RegisterType(name string, initFunc func() Task) {
 // TaskID is the unique ID assigned to a task when it's queued
 type TaskID = queues.TaskID
 
-// BatchTask is embedded by tasks which are one batch of work within a run of batches. ParentID identifies the run
-// the batch belongs to: the UUID of the parent object where there is one (flow start, broadcast), and otherwise the
-// ID of the creating task (group population) or a generated run ID (contact imports).
+// BatchTask is embedded by tasks which are one batch of work split out from an owning task or object. BatchOwnerID
+// identifies that owner: the UUID of the parent object where there is one (flow start, broadcast), and otherwise the
+// ID of the creating task (group population) or a generated ID (contact imports).
 type BatchTask struct {
-	ParentID TaskID `json:"parent_id,omitempty"`
+	BatchOwnerID TaskID `json:"batch_owner_id,omitempty"`
 }
 
 // Task is the common interface for all task types

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -34,6 +34,12 @@ func RegisterType(name string, initFunc func() Task) {
 // TaskID is the unique ID assigned to a task when it's queued
 type TaskID = queues.TaskID
 
+// BatchTask is embedded by tasks which are one batch of work within a run of batches, and records the ID of the
+// task (or endpoint generated run ID) that created the batch
+type BatchTask struct {
+	ParentID TaskID `json:"parent_id,omitempty"`
+}
+
 // Task is the common interface for all task types
 type Task interface {
 	Type() string

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -34,8 +34,9 @@ func RegisterType(name string, initFunc func() Task) {
 // TaskID is the unique ID assigned to a task when it's queued
 type TaskID = queues.TaskID
 
-// BatchTask is embedded by tasks which are one batch of work within a run of batches, and records the ID of the
-// task (or endpoint generated run ID) that created the batch
+// BatchTask is embedded by tasks which are one batch of work within a run of batches. ParentID identifies the run
+// the batch belongs to: the UUID of the parent object where there is one (flow start, broadcast), and otherwise the
+// ID of the creating task (group population) or a generated run ID (contact imports).
 type BatchTask struct {
 	ParentID TaskID `json:"parent_id,omitempty"`
 }

--- a/core/tasks/base_test.go
+++ b/core/tasks/base_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// task ID for tests which call Perform directly instead of going through a queue
+const testTaskID = tasks.TaskID("01981fa0-3c74-7d6c-8000-1a2b3c4d5e6f")
+
 func TestReadTask(t *testing.T) {
 	task, err := tasks.ReadTask("populate_group", []byte(`{
 		"group_id": 23,

--- a/core/tasks/bulk_campaign_trigger.go
+++ b/core/tasks/bulk_campaign_trigger.go
@@ -52,7 +52,7 @@ func (t *BulkCampaignTrigger) WithAssets() models.Refresh {
 	return models.RefreshCampaigns
 }
 
-func (t *BulkCampaignTrigger) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *BulkCampaignTrigger) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	p := oa.CampaignPointByID(t.PointID)
 	if p == nil || p.FireVersion != t.FireVersion {
 		slog.Info("skipping campaign trigger for point that no longer exists or has been updated", "point", t.PointID, "fire_version", t.FireVersion)

--- a/core/tasks/bulk_campaign_trigger_test.go
+++ b/core/tasks/bulk_campaign_trigger_test.go
@@ -36,7 +36,7 @@ func TestBulkCampaignTrigger(t *testing.T) {
 	}
 
 	oa := testdb.Org1.Load(t, rt)
-	err := task.Perform(ctx, rt, oa)
+	err := task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	testsuite.AssertContactInFlow(t, rt, testdb.Ann, testdb.IVRFlow) // event skipped Ann because she has a waiting session
@@ -53,7 +53,7 @@ func TestBulkCampaignTrigger(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Bob.ID, testdb.Ann.ID, testdb.Dan.ID},
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// everyone still in the same flows
@@ -77,7 +77,7 @@ func TestBulkCampaignTrigger(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Bob.ID, testdb.Ann.ID, testdb.Dan.ID},
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// everyone should be in campaign point flow
@@ -100,7 +100,7 @@ func TestBulkCampaignTrigger(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Bob.ID, testdb.Ann.ID, testdb.Dan.ID},
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// task should be a noop, no new sessions created
@@ -121,7 +121,7 @@ func TestBulkCampaignTrigger(t *testing.T) {
 		ContactIDs:  []models.ContactID{testdb.Bob.ID, testdb.Ann.ID, testdb.Dan.ID},
 		FireVersion: 1,
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// task should be a noop, no new sessions created
@@ -150,7 +150,7 @@ func TestBulkCampaignTriggerModes(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID, testdb.Dan.ID},
 	}
-	err := task.Perform(ctx, rt, oa)
+	err := task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	testsuite.AssertContactInFlow(t, rt, testdb.Ann, testdb.Favorites)   // skipped, still in Favorites
@@ -167,7 +167,7 @@ func TestBulkCampaignTriggerModes(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID, testdb.Dan.ID},
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// all 4 contacts should have received messages
@@ -188,7 +188,7 @@ func TestBulkCampaignTriggerModes(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID, testdb.Dan.ID},
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// all 4 contacts have sessions so all should be skipped - no new messages
@@ -205,7 +205,7 @@ func TestBulkCampaignTriggerModes(t *testing.T) {
 		FireVersion: 1,
 		ContactIDs:  []models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID, testdb.Dan.ID},
 	}
-	err = task.Perform(ctx, rt, oa)
+	err = task.Perform(ctx, rt, oa, testTaskID)
 	assert.NoError(t, err)
 
 	// all contacts should have received messages (4 from step 2 + 4 new = 8)

--- a/core/tasks/bulk_wait_expire.go
+++ b/core/tasks/bulk_wait_expire.go
@@ -44,7 +44,7 @@ func (t *BulkWaitExpire) WithAssets() models.Refresh {
 }
 
 // Perform creates the actual task
-func (t *BulkWaitExpire) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *BulkWaitExpire) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	for _, e := range t.Expirations {
 		err := QueueContact(ctx, rt, oa.OrgID(), e.ContactID, &ctasks.WaitExpired{SessionUUID: e.SessionUUID, SprintUUID: e.SprintUUID})
 		if err != nil {

--- a/core/tasks/bulk_wait_timeout.go
+++ b/core/tasks/bulk_wait_timeout.go
@@ -44,7 +44,7 @@ func (t *BulkWaitTimeout) WithAssets() models.Refresh {
 }
 
 // Perform creates the actual task
-func (t *BulkWaitTimeout) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *BulkWaitTimeout) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	for _, e := range t.Timeouts {
 		err := QueueContact(ctx, rt, oa.OrgID(), e.ContactID, &ctasks.WaitTimeout{SessionUUID: e.SessionUUID, SprintUUID: e.SprintUUID})
 		if err != nil {

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -38,7 +38,7 @@ func (t *ImportContactBatch) WithAssets() models.Refresh {
 }
 
 // Perform figures out the membership for a query based group then repopulates it
-func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	batch, err := models.LoadContactImportBatch(ctx, rt.DB, t.ContactImportBatchID)
 	if err != nil {
 		return fmt.Errorf("error loading contact import batch: %w", err)

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -21,6 +21,8 @@ func init() {
 
 // ImportContactBatch is our task to import a batch of contacts
 type ImportContactBatch struct {
+	BatchTask
+
 	ContactImportBatchID models.ContactImportBatchID `json:"contact_import_batch_id"`
 }
 

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -77,7 +77,7 @@ func TestImportContactBatchFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	task := &tasks.ImportContactBatch{ContactImportBatchID: batchID}
-	assert.Error(t, task.Perform(ctx, rt, oa))
+	assert.Error(t, task.Perform(ctx, rt, oa, testTaskID))
 
 	// batch and overall import should be marked as failed
 	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimportbatch WHERE id = $1`, batchID).Columns(map[string]any{"status": "F"})

--- a/core/tasks/interrupt_channel.go
+++ b/core/tasks/interrupt_channel.go
@@ -37,7 +37,7 @@ func (t *InterruptChannel) WithAssets() models.Refresh {
 }
 
 // Perform implements tasks.Task
-func (t *InterruptChannel) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *InterruptChannel) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	vc := rt.VK.Get()
 	defer vc.Close()
 

--- a/core/tasks/interrupt_contacts.go
+++ b/core/tasks/interrupt_contacts.go
@@ -36,7 +36,7 @@ func (t *InterruptContacts) WithAssets() models.Refresh {
 	return models.RefreshNone
 }
 
-func (t *InterruptContacts) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *InterruptContacts) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	if _, _, err := runner.InterruptWithLock(ctx, rt, oa, t.ContactIDs, nil, flows.SessionStatusInterrupted); err != nil {
 		return err
 	}

--- a/core/tasks/interrupt_flow.go
+++ b/core/tasks/interrupt_flow.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/nyaruka/goflow/flows"
@@ -65,7 +64,7 @@ func (t *InterruptFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	}
 
 	for i, batch := range batches {
-		task := &InterruptSessionBatch{Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID, BatchID: strconv.Itoa(i)}
+		task := &InterruptSessionBatch{Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID, BatchNum: i}
 
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queueing interrupt session batch task: %w", err)

--- a/core/tasks/interrupt_flow.go
+++ b/core/tasks/interrupt_flow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/nyaruka/goflow/flows"
@@ -63,8 +64,8 @@ func (t *InterruptFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting flow interrupt batches remaining key: %w", err)
 	}
 
-	for _, batch := range batches {
-		task := &InterruptSessionBatch{Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID}
+	for i, batch := range batches {
+		task := &InterruptSessionBatch{Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID, BatchID: strconv.Itoa(i)}
 
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queueing interrupt session batch task: %w", err)

--- a/core/tasks/interrupt_flow.go
+++ b/core/tasks/interrupt_flow.go
@@ -64,7 +64,7 @@ func (t *InterruptFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	}
 
 	for _, batch := range batches {
-		task := &InterruptSessionBatch{BatchTask: BatchTask{ParentID: taskID}, Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID}
+		task := &InterruptSessionBatch{Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID}
 
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queueing interrupt session batch task: %w", err)

--- a/core/tasks/interrupt_flow.go
+++ b/core/tasks/interrupt_flow.go
@@ -63,8 +63,8 @@ func (t *InterruptFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting flow interrupt batches remaining key: %w", err)
 	}
 
-	for i, batch := range batches {
-		task := &InterruptSessionBatch{Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID, BatchNum: i}
+	for _, batch := range batches {
+		task := &InterruptSessionBatch{BatchTask: BatchTask{ParentID: taskID}, Sessions: batch, Status: flows.SessionStatusInterrupted, FlowID: t.FlowID}
 
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queueing interrupt session batch task: %w", err)

--- a/core/tasks/interrupt_flow.go
+++ b/core/tasks/interrupt_flow.go
@@ -42,7 +42,7 @@ func (t *InterruptFlow) WithAssets() models.Refresh {
 	return models.RefreshNone
 }
 
-func (t *InterruptFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *InterruptFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	sessionRefs, err := models.GetWaitingSessionsForFlow(ctx, rt.DB, t.FlowID)
 	if err != nil {
 		return fmt.Errorf("error getting waiting sessions for flow: %w", err)

--- a/core/tasks/interrupt_session_batch.go
+++ b/core/tasks/interrupt_session_batch.go
@@ -28,7 +28,7 @@ type InterruptSessionBatch struct {
 	Sessions []models.SessionRef `json:"sessions"           validate:"required"`
 	Status   flows.SessionStatus `json:"status"             validate:"required"`
 	FlowID   models.FlowID       `json:"flow_id,omitempty"`
-	BatchID  string              `json:"batch_id,omitempty"` // not yet read, will identify this batch in completion tracking
+	BatchNum int                 `json:"batch_num,omitempty"` // not yet read, will identify this batch in completion tracking
 }
 
 func (t *InterruptSessionBatch) Type() string {

--- a/core/tasks/interrupt_session_batch.go
+++ b/core/tasks/interrupt_session_batch.go
@@ -25,8 +25,6 @@ func init() {
 // InterruptSessionBatch is our task for interrupting a batch of specific sessions. The sessions will only be modified
 // if they are still the contact's waiting session when the task runs.
 type InterruptSessionBatch struct {
-	BatchTask
-
 	Sessions []models.SessionRef `json:"sessions"          validate:"required"`
 	Status   flows.SessionStatus `json:"status"            validate:"required"`
 	FlowID   models.FlowID       `json:"flow_id,omitempty"`

--- a/core/tasks/interrupt_session_batch.go
+++ b/core/tasks/interrupt_session_batch.go
@@ -43,7 +43,7 @@ func (t *InterruptSessionBatch) WithAssets() models.Refresh {
 	return models.RefreshNone
 }
 
-func (t *InterruptSessionBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *InterruptSessionBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	contactIDs := make([]models.ContactID, len(t.Sessions))
 	sessions := make(map[models.ContactID]core.SessionUUID, len(t.Sessions))
 	for i, s := range t.Sessions {

--- a/core/tasks/interrupt_session_batch.go
+++ b/core/tasks/interrupt_session_batch.go
@@ -25,9 +25,10 @@ func init() {
 // InterruptSessionBatch is our task for interrupting a batch of specific sessions. The sessions will only be modified
 // if they are still the contact's waiting session when the task runs.
 type InterruptSessionBatch struct {
-	Sessions []models.SessionRef `json:"sessions"          validate:"required"`
-	Status   flows.SessionStatus `json:"status"            validate:"required"`
+	Sessions []models.SessionRef `json:"sessions"           validate:"required"`
+	Status   flows.SessionStatus `json:"status"             validate:"required"`
 	FlowID   models.FlowID       `json:"flow_id,omitempty"`
+	BatchID  string              `json:"batch_id,omitempty"` // not yet read, will identify this batch in completion tracking
 }
 
 func (t *InterruptSessionBatch) Type() string {

--- a/core/tasks/interrupt_session_batch.go
+++ b/core/tasks/interrupt_session_batch.go
@@ -25,10 +25,11 @@ func init() {
 // InterruptSessionBatch is our task for interrupting a batch of specific sessions. The sessions will only be modified
 // if they are still the contact's waiting session when the task runs.
 type InterruptSessionBatch struct {
-	Sessions []models.SessionRef `json:"sessions"           validate:"required"`
-	Status   flows.SessionStatus `json:"status"             validate:"required"`
+	BatchTask
+
+	Sessions []models.SessionRef `json:"sessions"          validate:"required"`
+	Status   flows.SessionStatus `json:"status"            validate:"required"`
 	FlowID   models.FlowID       `json:"flow_id,omitempty"`
-	BatchNum int                 `json:"batch_num,omitempty"` // not yet read, will identify this batch in completion tracking
 }
 
 func (t *InterruptSessionBatch) Type() string {

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
@@ -143,7 +144,7 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 
 	for _, batch := range batches {
 		task := &PopulateGroupBatch{
-			BatchTask:    BatchTask{BatchOwnerID: taskID},
+			BatchTask:    BatchTask{BatchOwnerUUID: uuids.UUID(taskID)},
 			GroupID:      t.GroupID,
 			ContactIDs:   batch,
 			LockValue:    lock,

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -141,14 +141,13 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting populate group batch counter key: %w", err)
 	}
 
-	for i, batch := range batches {
+	for _, batch := range batches {
 		task := &PopulateGroupBatch{
+			BatchTask:    BatchTask{ParentID: taskID},
 			GroupID:      t.GroupID,
 			ContactIDs:   batch,
 			LockValue:    lock,
 			PopulationID: populationID,
-			ParentID:     taskID,
-			BatchNum:     i,
 		}
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queuing populate group batch task: %w", err)

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -7,13 +7,13 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
-	"github.com/nyaruka/mailroom/v26/utils"
 	"github.com/nyaruka/vkutil/locks"
 )
 
@@ -132,8 +132,8 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	// chunk contacts into batches and queue a task for each
 	batches := slices.Collect(slices.Chunk(recheckIDs, populateBatchSize))
 
-	// generate a random ID for this population run so batch tasks can track completion
-	populationID := utils.RandomBase64(10)
+	// this task's ID identifies this population run so batch tasks can track completion
+	populationID := string(taskID)
 
 	// set valkey counter which batch tasks can decrement to know when population has completed
 	counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, populationID), time.Hour)
@@ -141,12 +141,13 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting populate group batch counter key: %w", err)
 	}
 
-	for _, batch := range batches {
+	for i, batch := range batches {
 		task := &PopulateGroupBatch{
 			GroupID:      t.GroupID,
 			ContactIDs:   batch,
 			LockValue:    lock,
 			PopulationID: populationID,
+			BatchID:      strconv.Itoa(i),
 		}
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queuing populate group batch task: %w", err)

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/nyaruka/mailroom/v26/utils"
 	"github.com/nyaruka/vkutil/locks"
 )
 
@@ -131,8 +132,8 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	// chunk contacts into batches and queue a task for each
 	batches := slices.Collect(slices.Chunk(recheckIDs, populateBatchSize))
 
-	// this task's ID identifies this population run so batch tasks can track completion
-	populationID := string(taskID)
+	// generate a random ID for this population run so batch tasks can track completion
+	populationID := utils.RandomBase64(10)
 
 	// set valkey counter which batch tasks can decrement to know when population has completed
 	counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, populationID), time.Hour)
@@ -146,6 +147,7 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 			ContactIDs:   batch,
 			LockValue:    lock,
 			PopulationID: populationID,
+			ParentID:     taskID,
 			BatchNum:     i,
 		}
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/nyaruka/goflow/contactql"
@@ -147,7 +146,7 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 			ContactIDs:   batch,
 			LockValue:    lock,
 			PopulationID: populationID,
-			BatchID:      strconv.Itoa(i),
+			BatchNum:     i,
 		}
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queuing populate group batch task: %w", err)

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -143,7 +143,7 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 
 	for _, batch := range batches {
 		task := &PopulateGroupBatch{
-			BatchTask:    BatchTask{ParentID: taskID},
+			BatchTask:    BatchTask{BatchOwnerID: taskID},
 			GroupID:      t.GroupID,
 			ContactIDs:   batch,
 			LockValue:    lock,

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -49,7 +49,7 @@ func (t *PopulateGroup) WithAssets() models.Refresh {
 }
 
 // Perform figures out the membership for a query based group then queues batch tasks to repopulate it
-func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	locker := locks.NewLocker(fmt.Sprintf(populateGroupLockKey, t.GroupID), time.Hour)
 	lock, err := locker.Grab(ctx, rt.VK, time.Minute*5)
 	if err != nil {

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -41,7 +41,7 @@ func (t *PopulateGroupBatch) WithAssets() models.Refresh {
 }
 
 // Perform re-evaluates group membership for a batch of contacts
-func (t *PopulateGroupBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *PopulateGroupBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	skipped, err := runner.ReevaluateGroupsWithLock(ctx, rt, oa, t.ContactIDs)
 	if err != nil {
 		return fmt.Errorf("error populating group membership: %w", err)

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -21,14 +21,12 @@ func init() {
 
 // PopulateGroupBatch is our task to re-evaluate group membership for a batch of contacts
 type PopulateGroupBatch struct {
+	BatchTask
+
 	GroupID      models.GroupID     `json:"group_id"`
 	ContactIDs   []models.ContactID `json:"contact_ids"`
 	LockValue    string             `json:"lock_value"`
 	PopulationID string             `json:"population_id"`
-
-	// not yet read, will replace PopulationID as the completion tracker scope and identify this batch within it
-	ParentID TaskID `json:"parent_id"`
-	BatchNum int    `json:"batch_num"`
 }
 
 func (t *PopulateGroupBatch) Type() string {

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -25,7 +25,10 @@ type PopulateGroupBatch struct {
 	ContactIDs   []models.ContactID `json:"contact_ids"`
 	LockValue    string             `json:"lock_value"`
 	PopulationID string             `json:"population_id"`
-	BatchNum     int                `json:"batch_num"` // not yet read, will identify this batch in completion tracking
+
+	// not yet read, will replace PopulationID as the completion tracker scope and identify this batch within it
+	ParentID TaskID `json:"parent_id"`
+	BatchNum int    `json:"batch_num"`
 }
 
 func (t *PopulateGroupBatch) Type() string {

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -25,7 +25,7 @@ type PopulateGroupBatch struct {
 	ContactIDs   []models.ContactID `json:"contact_ids"`
 	LockValue    string             `json:"lock_value"`
 	PopulationID string             `json:"population_id"`
-	BatchID      string             `json:"batch_id"` // not yet read, will identify this batch in completion tracking
+	BatchNum     int                `json:"batch_num"` // not yet read, will identify this batch in completion tracking
 }
 
 func (t *PopulateGroupBatch) Type() string {

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -25,6 +25,7 @@ type PopulateGroupBatch struct {
 	ContactIDs   []models.ContactID `json:"contact_ids"`
 	LockValue    string             `json:"lock_value"`
 	PopulationID string             `json:"population_id"`
+	BatchID      string             `json:"batch_id"` // not yet read, will identify this batch in completion tracking
 }
 
 func (t *PopulateGroupBatch) Type() string {

--- a/core/tasks/populate_group_test.go
+++ b/core/tasks/populate_group_test.go
@@ -45,7 +45,7 @@ func TestPopulateGroupTask(t *testing.T) {
 		GroupID: group1.ID,
 		Query:   "gender = F",
 	}
-	err = task1.Perform(ctx, rt, oa)
+	err = task1.Perform(ctx, rt, oa, testTaskID)
 	require.NoError(t, err)
 
 	// group should be evaluating after parent task completes
@@ -68,7 +68,7 @@ func TestPopulateGroupTask(t *testing.T) {
 		GroupID: group2.ID,
 		Query:   "!!!",
 	}
-	err = task2.Perform(ctx, rt, oa)
+	err = task2.Perform(ctx, rt, oa, testTaskID)
 	require.NoError(t, err)
 
 	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactgroup WHERE id = $1`, group2.ID).Returns("X")

--- a/core/tasks/process_contact_queue.go
+++ b/core/tasks/process_contact_queue.go
@@ -42,7 +42,7 @@ func (t *ProcessContactQueue) WithAssets() models.Refresh {
 
 // Perform is called when an event comes in for a contact. To make sure we don't get into a situation of being off by one,
 // this task ingests and handles all the events for a contact, one by one.
-func (t *ProcessContactQueue) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *ProcessContactQueue) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	// try to get the lock for this contact, waiting up to 10 seconds
 	locks, _, err := clocks.TryToLock(ctx, rt, oa, []models.ContactID{t.ContactID}, time.Second*10)
 	if err != nil {

--- a/core/tasks/schedule_campaign_point.go
+++ b/core/tasks/schedule_campaign_point.go
@@ -38,7 +38,7 @@ func (t *ScheduleCampaignPoint) WithAssets() models.Refresh {
 }
 
 // Perform creates the actual event fires to schedule the given campaign point
-func (t *ScheduleCampaignPoint) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *ScheduleCampaignPoint) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	locker := locks.NewLocker(fmt.Sprintf(scheduleLockKey, t.PointID), time.Hour)
 	lock, err := locker.Grab(ctx, rt.VK, time.Minute*5)
 	if err != nil {

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
@@ -60,9 +61,9 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast, taskID TaskID) error {
 	// batches are owned by the broadcast, identified by its UUID - tho unlike starts, broadcast UUIDs have always
 	// been serialized in task payloads so the fallback to task ID is just defensive
-	ownerID := TaskID(bcast.UUID)
-	if ownerID == "" {
-		ownerID = taskID
+	ownerUUID := uuids.UUID(bcast.UUID)
+	if ownerUUID == "" {
+		ownerUUID = uuids.UUID(taskID)
 	}
 
 	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
@@ -118,7 +119,7 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 		isLast := (i == len(idBatches)-1)
 
 		batch := bcast.CreateBatch(idBatch, isFirst, isLast)
-		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{BatchOwnerID: ownerID}, BroadcastBatch: batch}, false)
+		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{BatchOwnerUUID: ownerUUID}, BroadcastBatch: batch}, false)
 		if err != nil {
 			if i == 0 {
 				return fmt.Errorf("error queuing broadcast batch: %w", err)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -44,7 +44,7 @@ func (t *SendBroadcast) WithAssets() models.Refresh {
 
 // Perform handles sending the broadcast by creating batches of broadcast sends for all the unique contacts
 func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
-	if err := createBroadcastBatches(ctx, rt, oa, t.Broadcast); err != nil {
+	if err := createBroadcastBatches(ctx, rt, oa, t.Broadcast, taskID); err != nil {
 		t.Broadcast.SetFailed(ctx, rt.DB)
 
 		// if error is user created query error.. don't escalate error to sentry
@@ -57,7 +57,7 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	return nil
 }
 
-func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast) error {
+func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast, taskID TaskID) error {
 	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
 		ContactIDs:      bcast.ContactIDs,
 		GroupIDs:        bcast.GroupIDs,
@@ -111,7 +111,7 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 		isLast := (i == len(idBatches)-1)
 
 		batch := bcast.CreateBatch(idBatch, isFirst, isLast)
-		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BroadcastBatch: batch}, false)
+		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{ParentID: taskID}, BroadcastBatch: batch}, false)
 		if err != nil {
 			if i == 0 {
 				return fmt.Errorf("error queuing broadcast batch: %w", err)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -58,11 +58,11 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 }
 
 func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast, taskID TaskID) error {
-	// batches are identified as belonging to this run by the broadcast's UUID, tho unlike starts, broadcast UUIDs
-	// have always been serialized in task payloads so the fallback to task ID is just defensive
-	runID := TaskID(bcast.UUID)
-	if runID == "" {
-		runID = taskID
+	// batches are owned by the broadcast, identified by its UUID - tho unlike starts, broadcast UUIDs have always
+	// been serialized in task payloads so the fallback to task ID is just defensive
+	ownerID := TaskID(bcast.UUID)
+	if ownerID == "" {
+		ownerID = taskID
 	}
 
 	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
@@ -118,7 +118,7 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 		isLast := (i == len(idBatches)-1)
 
 		batch := bcast.CreateBatch(idBatch, isFirst, isLast)
-		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{ParentID: runID}, BroadcastBatch: batch}, false)
+		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{BatchOwnerID: ownerID}, BroadcastBatch: batch}, false)
 		if err != nil {
 			if i == 0 {
 				return fmt.Errorf("error queuing broadcast batch: %w", err)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -43,7 +43,7 @@ func (t *SendBroadcast) WithAssets() models.Refresh {
 }
 
 // Perform handles sending the broadcast by creating batches of broadcast sends for all the unique contacts
-func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	if err := createBroadcastBatches(ctx, rt, oa, t.Broadcast); err != nil {
 		t.Broadcast.SetFailed(ctx, rt.DB)
 

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -58,6 +58,12 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 }
 
 func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast, taskID TaskID) error {
+	// batches are identified as belonging to this run by the broadcast's UUID, falling back to this task's ID
+	runID := TaskID(bcast.UUID)
+	if runID == "" {
+		runID = taskID
+	}
+
 	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
 		ContactIDs:      bcast.ContactIDs,
 		GroupIDs:        bcast.GroupIDs,
@@ -111,7 +117,7 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 		isLast := (i == len(idBatches)-1)
 
 		batch := bcast.CreateBatch(idBatch, isFirst, isLast)
-		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{ParentID: taskID}, BroadcastBatch: batch}, false)
+		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{ParentID: runID}, BroadcastBatch: batch}, false)
 		if err != nil {
 			if i == 0 {
 				return fmt.Errorf("error queuing broadcast batch: %w", err)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -58,7 +58,8 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 }
 
 func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast, taskID TaskID) error {
-	// batches are identified as belonging to this run by the broadcast's UUID, falling back to this task's ID
+	// batches are identified as belonging to this run by the broadcast's UUID, tho unlike starts, broadcast UUIDs
+	// have always been serialized in task payloads so the fallback to task ID is just defensive
 	runID := TaskID(bcast.UUID)
 	if runID == "" {
 		runID = taskID

--- a/core/tasks/send_broadcast_batch.go
+++ b/core/tasks/send_broadcast_batch.go
@@ -35,7 +35,7 @@ func (t *SendBroadcastBatch) WithAssets() models.Refresh {
 	return models.RefreshNone
 }
 
-func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	var bcast *models.Broadcast
 	var err error
 

--- a/core/tasks/send_broadcast_batch.go
+++ b/core/tasks/send_broadcast_batch.go
@@ -19,6 +19,8 @@ func init() {
 
 // SendBroadcastBatch is the task to send broadcast batches
 type SendBroadcastBatch struct {
+	BatchTask
+
 	*models.BroadcastBatch
 }
 

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -58,6 +58,13 @@ func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models
 
 // creates batches of flow starts for all the unique contacts
 func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart, taskID TaskID) error {
+	// batches are identified as belonging to this run by the start's UUID, falling back to this task's ID for
+	// payloads queued before starts included their UUID
+	runID := TaskID(start.UUID)
+	if runID == "" {
+		runID = taskID
+	}
+
 	flow, err := oa.FlowByID(start.FlowID)
 	if err != nil {
 		return fmt.Errorf("error loading flow: %w", err)
@@ -119,7 +126,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)
-		batchTask := &StartFlowBatch{BatchTask: BatchTask{ParentID: taskID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
+		batchTask := &StartFlowBatch{BatchTask: BatchTask{ParentID: runID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {
 			if i == 0 {

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -42,7 +42,7 @@ func (t *StartFlow) WithAssets() models.Refresh {
 	return models.RefreshNone
 }
 
-func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	if err := createFlowStartBatches(ctx, rt, oa, t.FlowStart); err != nil {
 		t.FlowStart.SetFailed(ctx, rt.DB)
 

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -43,7 +43,7 @@ func (t *StartFlow) WithAssets() models.Refresh {
 }
 
 func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
-	if err := createFlowStartBatches(ctx, rt, oa, t.FlowStart); err != nil {
+	if err := createFlowStartBatches(ctx, rt, oa, t.FlowStart, taskID); err != nil {
 		t.FlowStart.SetFailed(ctx, rt.DB)
 
 		// if error is user created query error.. don't escalate error to sentry
@@ -57,7 +57,7 @@ func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models
 }
 
 // creates batches of flow starts for all the unique contacts
-func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart) error {
+func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart, taskID TaskID) error {
 	flow, err := oa.FlowByID(start.FlowID)
 	if err != nil {
 		return fmt.Errorf("error loading flow: %w", err)
@@ -119,7 +119,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)
-		batchTask := &StartFlowBatch{FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
+		batchTask := &StartFlowBatch{BatchTask: BatchTask{ParentID: taskID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {
 			if i == 0 {

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/i18n"
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
@@ -61,9 +62,9 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	// batches are owned by the start, identified by its UUID
 	// TODO: fallback to task ID is a temporary workaround for tasks queued before start UUIDs were serialized,
 	// remove once this has been deployed and queues have cycled
-	ownerID := TaskID(start.UUID)
-	if ownerID == "" {
-		ownerID = taskID
+	ownerUUID := start.UUID
+	if ownerUUID == "" {
+		ownerUUID = uuids.UUID(taskID)
 	}
 
 	flow, err := oa.FlowByID(start.FlowID)
@@ -127,7 +128,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)
-		batchTask := &StartFlowBatch{BatchTask: BatchTask{BatchOwnerID: ownerID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
+		batchTask := &StartFlowBatch{BatchTask: BatchTask{BatchOwnerUUID: ownerUUID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {
 			if i == 0 {

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -58,8 +58,9 @@ func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models
 
 // creates batches of flow starts for all the unique contacts
 func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart, taskID TaskID) error {
-	// batches are identified as belonging to this run by the start's UUID, falling back to this task's ID for
-	// payloads queued before starts included their UUID
+	// batches are identified as belonging to this run by the start's UUID
+	// TODO: fallback to task ID is a temporary workaround for tasks queued before start UUIDs were serialized,
+	// remove once this has been deployed and queues have cycled
 	runID := TaskID(start.UUID)
 	if runID == "" {
 		runID = taskID

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -58,12 +58,12 @@ func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models
 
 // creates batches of flow starts for all the unique contacts
 func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart, taskID TaskID) error {
-	// batches are identified as belonging to this run by the start's UUID
+	// batches are owned by the start, identified by its UUID
 	// TODO: fallback to task ID is a temporary workaround for tasks queued before start UUIDs were serialized,
 	// remove once this has been deployed and queues have cycled
-	runID := TaskID(start.UUID)
-	if runID == "" {
-		runID = taskID
+	ownerID := TaskID(start.UUID)
+	if ownerID == "" {
+		ownerID = taskID
 	}
 
 	flow, err := oa.FlowByID(start.FlowID)
@@ -127,7 +127,7 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)
-		batchTask := &StartFlowBatch{BatchTask: BatchTask{ParentID: runID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
+		batchTask := &StartFlowBatch{BatchTask: BatchTask{BatchOwnerID: ownerID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {
 			if i == 0 {

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -30,6 +30,8 @@ func init() {
 
 // StartFlowBatch is the start flow batch task
 type StartFlowBatch struct {
+	BatchTask
+
 	*models.FlowStartBatch
 }
 

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -46,7 +46,7 @@ func (t *StartFlowBatch) WithAssets() models.Refresh {
 	return models.RefreshNone
 }
 
-func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
 	var start *models.FlowStart
 	var err error
 

--- a/utils/queues/base.go
+++ b/utils/queues/base.go
@@ -9,6 +9,9 @@ import (
 	"github.com/nyaruka/gocommon/queues"
 )
 
+// TaskID is the unique ID assigned to a task when it's pushed
+type TaskID = queues.TaskID
+
 // Task is a wrapper for encoding a task
 type Task struct {
 	ID         queues.TaskID   `json:"-"`

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
 	"github.com/nyaruka/mailroom/v26/runtime"
@@ -45,9 +46,12 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 		return nil, 0, fmt.Errorf("error setting import batch counter key: %w", err)
 	}
 
+	// generate an ID for this run of batches since unlike other batch tasks, these have no parent task
+	runID := tasks.TaskID(uuids.NewV7())
+
 	// create tasks for all batches
 	for _, bID := range imp.BatchIDs {
-		task := &tasks.ImportContactBatch{ContactImportBatchID: bID}
+		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{ParentID: runID}, ContactImportBatchID: bID}
 		if err := tasks.Queue(ctx, rt, rt.Queues.Batch, r.OrgID, task, false); err != nil {
 			return nil, 0, fmt.Errorf("error queuing import contact batch task: %w", err)
 		}

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -46,12 +46,12 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 		return nil, 0, fmt.Errorf("error setting import batch counter key: %w", err)
 	}
 
-	// generate an ID for this run of batches since unlike other batch tasks, these have no parent task
-	runID := tasks.TaskID(uuids.NewV7())
+	// generate an ID to own this set of batches since unlike other batch tasks, these have no parent task
+	ownerID := tasks.TaskID(uuids.NewV7())
 
 	// create tasks for all batches
 	for _, bID := range imp.BatchIDs {
-		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{ParentID: runID}, ContactImportBatchID: bID}
+		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{BatchOwnerID: ownerID}, ContactImportBatchID: bID}
 		if err := tasks.Queue(ctx, rt, rt.Queues.Batch, r.OrgID, task, false); err != nil {
 			return nil, 0, fmt.Errorf("error queuing import contact batch task: %w", err)
 		}

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -46,12 +46,12 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 		return nil, 0, fmt.Errorf("error setting import batch counter key: %w", err)
 	}
 
-	// generate an ID to own this set of batches since unlike other batch tasks, these have no parent task
-	ownerID := tasks.TaskID(uuids.NewV7())
+	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
+	ownerUUID := uuids.NewV7()
 
 	// create tasks for all batches
 	for _, bID := range imp.BatchIDs {
-		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{BatchOwnerID: ownerID}, ContactImportBatchID: bID}
+		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{BatchOwnerUUID: ownerUUID}, ContactImportBatchID: bID}
 		if err := tasks.Queue(ctx, rt, rt.Queues.Batch, r.OrgID, task, false); err != nil {
 			return nil, 0, fmt.Errorf("error queuing import contact batch task: %w", err)
 		}

--- a/web/contact/testdata/import.json
+++ b/web/contact/testdata/import.json
@@ -27,14 +27,14 @@
                     "type": "import_contact_batch",
                     "payload": {
                         "contact_import_batch_id": 30000,
-                        "parent_id": "01969b47-0583-76f8-924e-9de1a11831b3"
+                        "batch_owner_id": "01969b47-0583-76f8-924e-9de1a11831b3"
                     }
                 },
                 {
                     "type": "import_contact_batch",
                     "payload": {
                         "contact_import_batch_id": 30001,
-                        "parent_id": "01969b47-0583-76f8-924e-9de1a11831b3"
+                        "batch_owner_id": "01969b47-0583-76f8-924e-9de1a11831b3"
                     }
                 }
             ]

--- a/web/contact/testdata/import.json
+++ b/web/contact/testdata/import.json
@@ -26,13 +26,15 @@
                 {
                     "type": "import_contact_batch",
                     "payload": {
-                        "contact_import_batch_id": 30000
+                        "contact_import_batch_id": 30000,
+                        "parent_id": "01969b47-0583-76f8-924e-9de1a11831b3"
                     }
                 },
                 {
                     "type": "import_contact_batch",
                     "payload": {
-                        "contact_import_batch_id": 30001
+                        "contact_import_batch_id": 30001,
+                        "parent_id": "01969b47-0583-76f8-924e-9de1a11831b3"
                     }
                 }
             ]

--- a/web/contact/testdata/import.json
+++ b/web/contact/testdata/import.json
@@ -27,14 +27,14 @@
                     "type": "import_contact_batch",
                     "payload": {
                         "contact_import_batch_id": 30000,
-                        "batch_owner_id": "01969b47-0583-76f8-924e-9de1a11831b3"
+                        "batch_owner_uuid": "01969b47-0583-76f8-924e-9de1a11831b3"
                     }
                 },
                 {
                     "type": "import_contact_batch",
                     "payload": {
                         "contact_import_batch_id": 30001,
-                        "batch_owner_id": "01969b47-0583-76f8-924e-9de1a11831b3"
+                        "batch_owner_uuid": "01969b47-0583-76f8-924e-9de1a11831b3"
                     }
                 }
             ]

--- a/web/flow/testdata/start.json
+++ b/web/flow/testdata/start.json
@@ -87,6 +87,7 @@
                     "type": "start_flow",
                     "payload": {
                         "start_id": 30000,
+                        "uuid": "1b2083ab-a0cb-48da-924e-9de1a11831b3",
                         "org_id": 1,
                         "start_type": "M",
                         "created_by_id": 4,

--- a/workers_test.go
+++ b/workers_test.go
@@ -20,7 +20,7 @@ type testTask struct{}
 func (t *testTask) Type() string               { return "test" }
 func (t *testTask) Timeout() time.Duration     { return 5 * time.Second }
 func (t *testTask) WithAssets() models.Refresh { return models.RefreshNone }
-func (t *testTask) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets) error {
+func (t *testTask) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID tasks.TaskID) error {
 	time.Sleep(100 * time.Millisecond)
 	return nil
 }


### PR DESCRIPTION
Every queued task already gets a unique UUIDv7 assigned at push time (returned by `Push`, restored by `Pop`, and included in worker logs) but the ID wasn't visible to the task itself. This extends `Task.Perform` with a `taskID` param so tasks can use their own queue-assigned identity, and re-exports the `TaskID` type from our queues package wrapper.

It also introduces an embedded `BatchTask` struct for tasks which are one batch of work split out from an owning task or object:

```go
type BatchTask struct {
	BatchOwnerUUID uuids.UUID `json:"batch_owner_uuid,omitempty"`
}
```

`BatchOwnerUUID` identifies the owner of the batch, using the owning object's UUID where there is one (easier debugging - state for a set of batches will be findable from the object):

* `StartFlowBatch` - the flow start's UUID (now included in start task payloads), falling back to the creating task's ID
* `SendBroadcastBatch` - the broadcast's UUID (always set, even for non-persisted broadcasts), falling back to the creating task's ID
* `PopulateGroupBatch` - the creating `PopulateGroup` task's ID (population runs have no persisted object)
* `ImportContactBatch` - a generated UUID (batches are created by an endpoint rather than a parent task, and imports have no UUID)

`InterruptSessionBatch` is deliberately excluded: its progress key is read directly by the web app (which derives it from the flow ID), so that mechanism stays as is.

This is stage 1 of a two stage change to how batch completion is tracked (see #1130): batch tasks will resolve their per-owner completion tracker key from `BatchOwnerUUID` and mark themselves complete in it, replacing the ad-hoc valkey counters (imports, group population) and the `IsFirst`/`IsLast` flags (starts, broadcasts) which can mark a set of batches complete before all of them have actually finished. This stage is purely additive - `BatchOwnerUUID` is written but not yet read, and existing fields, values and behavior are untouched - so it deploys with no transition concerns, and by the time stage 2 starts reading `BatchOwnerUUID` all in-flight batches will carry it.

Tests that invoke `Perform` directly pass a fixed UUIDv7 constant.