### PR TITLE
Add batch trackers which record batch task completion

### DIFF
--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -37,9 +37,11 @@ type TaskID = queues.TaskID
 
 // BatchTask is embedded by tasks which are one batch of work split out from an owning task or object. BatchOwnerUUID
 // identifies that owner: the UUID of the parent object where there is one (flow start, broadcast), and otherwise the
-// ID of the creating task (group population) or a generated UUID (contact imports).
+// ID of the creating task (group population) or a generated UUID (contact imports). TotalBatches is the number of
+// batches in the set, carried by every batch so completion tracking needs no separate initialization.
 type BatchTask struct {
 	BatchOwnerUUID uuids.UUID `json:"batch_owner_uuid,omitempty"`
+	TotalBatches   int        `json:"total_batches,omitempty"`
 }
 
 // RecordComplete marks this batch as complete in its owner's tracker. The tracker isn't yet used to make completion
@@ -49,7 +51,7 @@ func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, tas
 		return // batch was queued before owner UUIDs were added
 	}
 
-	if _, _, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID); err != nil {
+	if _, _, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID, b.TotalBatches); err != nil {
 		slog.Error("error recording batch task completion", "error", err, "owner_uuid", b.BatchOwnerUUID)
 	}
 }

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -42,6 +42,18 @@ type BatchTask struct {
 	BatchOwnerUUID uuids.UUID `json:"batch_owner_uuid,omitempty"`
 }
 
+// RecordComplete marks this batch as complete in its owner's tracker. The tracker isn't yet used to make completion
+// decisions so any error here is logged rather than allowed to fail the batch.
+func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, taskID TaskID) {
+	if b.BatchOwnerUUID == "" {
+		return // batch was queued before owner UUIDs were added
+	}
+
+	if _, _, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID); err != nil {
+		slog.Error("error recording batch task completion", "error", err, "owner_uuid", b.BatchOwnerUUID)
+	}
+}
+
 // Task is the common interface for all task types
 type Task interface {
 	Type() string

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -60,6 +60,8 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		}
 	}
 
+	t.RecordComplete(ctx, rt, taskID)
+
 	// decrement the counter to see if the overall import is now finished
 	counter := NewCounter(fmt.Sprintf("contact_import_batches_remaining:%d", batch.ImportID), 24*time.Hour)
 	done, err := counter.Done(ctx, rt.VK)

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -142,15 +142,9 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting populate group batch counter key: %w", err)
 	}
 
-	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
-	// since nothing reads the tracker yet
-	if err := NewBatchTracker(uuids.UUID(taskID)).Init(ctx, rt.VK, len(batches)); err != nil {
-		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", taskID)
-	}
-
 	for _, batch := range batches {
 		task := &PopulateGroupBatch{
-			BatchTask:    BatchTask{BatchOwnerUUID: uuids.UUID(taskID)},
+			BatchTask:    BatchTask{BatchOwnerUUID: uuids.UUID(taskID), TotalBatches: len(batches)},
 			GroupID:      t.GroupID,
 			ContactIDs:   batch,
 			LockValue:    lock,

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -142,6 +142,11 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting populate group batch counter key: %w", err)
 	}
 
+	// initialize the tracker that batches will record their completion in (not yet read)
+	if err := NewBatchTracker(uuids.UUID(taskID)).Init(ctx, rt.VK, len(batches)); err != nil {
+		return fmt.Errorf("error initializing batch tracker: %w", err)
+	}
+
 	for _, batch := range batches {
 		task := &PopulateGroupBatch{
 			BatchTask:    BatchTask{BatchOwnerUUID: uuids.UUID(taskID)},

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -142,9 +142,10 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return fmt.Errorf("error setting populate group batch counter key: %w", err)
 	}
 
-	// initialize the tracker that batches will record their completion in (not yet read)
+	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
+	// since nothing reads the tracker yet
 	if err := NewBatchTracker(uuids.UUID(taskID)).Init(ctx, rt.VK, len(batches)); err != nil {
-		return fmt.Errorf("error initializing batch tracker: %w", err)
+		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", taskID)
 	}
 
 	for _, batch := range batches {

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -53,6 +53,8 @@ func (t *PopulateGroupBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		slog.Warn("failed to acquire locks for contacts during group population", "group_id", t.GroupID, "skipped", len(skipped))
 	}
 
+	t.RecordComplete(ctx, rt, taskID)
+
 	// decrement the counter to see if the overall population is now finished
 	counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, t.PopulationID), time.Hour)
 	done, err := counter.Done(ctx, rt.VK)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -115,9 +115,10 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	// create tasks for batches of contacts
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
 
-	// initialize the tracker that batches will record their completion in (not yet read)
+	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
+	// since nothing reads the tracker yet
 	if err := NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(idBatches)); err != nil {
-		return fmt.Errorf("error initializing batch tracker: %w", err)
+		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", ownerUUID)
 	}
 
 	for i, idBatch := range idBatches {

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -114,19 +114,16 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 
 	// create tasks for batches of contacts
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
-
-	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
-	// since nothing reads the tracker yet
-	if err := NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(idBatches)); err != nil {
-		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", ownerUUID)
-	}
-
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)
 
 		batch := bcast.CreateBatch(idBatch, isFirst, isLast)
-		err = Queue(ctx, rt, q, bcast.OrgID, &SendBroadcastBatch{BatchTask: BatchTask{BatchOwnerUUID: ownerUUID}, BroadcastBatch: batch}, false)
+		batchTask := &SendBroadcastBatch{
+			BatchTask:      BatchTask{BatchOwnerUUID: ownerUUID, TotalBatches: len(idBatches)},
+			BroadcastBatch: batch,
+		}
+		err = Queue(ctx, rt, q, bcast.OrgID, batchTask, false)
 		if err != nil {
 			if i == 0 {
 				return fmt.Errorf("error queuing broadcast batch: %w", err)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -114,6 +114,12 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 
 	// create tasks for batches of contacts
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
+
+	// initialize the tracker that batches will record their completion in (not yet read)
+	if err := NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(idBatches)); err != nil {
+		return fmt.Errorf("error initializing batch tracker: %w", err)
+	}
+
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)

--- a/core/tasks/send_broadcast_batch.go
+++ b/core/tasks/send_broadcast_batch.go
@@ -53,6 +53,7 @@ func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 
 	// if this broadcast was interrupted, we're done
 	if bcast.Status == models.BroadcastStatusInterrupted {
+		t.RecordComplete(ctx, rt, taskID)
 		return nil
 	}
 
@@ -79,6 +80,8 @@ func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 			return fmt.Errorf("error marking broadcast as complete: %w", err)
 		}
 	}
+
+	t.RecordComplete(ctx, rt, taskID)
 
 	return nil
 }

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -125,9 +125,10 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	// split the contact ids into batches to become batch tasks
 	idBatches := slices.Collect(slices.Chunk(contactIDs, FlowStartBatchSize))
 
-	// initialize the tracker that batches will record their completion in (not yet read)
+	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
+	// since nothing reads the tracker yet
 	if err := NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(idBatches)); err != nil {
-		return fmt.Errorf("error initializing batch tracker: %w", err)
+		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", ownerUUID)
 	}
 
 	for i, idBatch := range idBatches {

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -125,6 +125,11 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	// split the contact ids into batches to become batch tasks
 	idBatches := slices.Collect(slices.Chunk(contactIDs, FlowStartBatchSize))
 
+	// initialize the tracker that batches will record their completion in (not yet read)
+	if err := NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(idBatches)); err != nil {
+		return fmt.Errorf("error initializing batch tracker: %w", err)
+	}
+
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -125,16 +125,13 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	// split the contact ids into batches to become batch tasks
 	idBatches := slices.Collect(slices.Chunk(contactIDs, FlowStartBatchSize))
 
-	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
-	// since nothing reads the tracker yet
-	if err := NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(idBatches)); err != nil {
-		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", ownerUUID)
-	}
-
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
 		isLast := (i == len(idBatches)-1)
-		batchTask := &StartFlowBatch{BatchTask: BatchTask{BatchOwnerUUID: ownerUUID}, FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs))}
+		batchTask := &StartFlowBatch{
+			BatchTask:      BatchTask{BatchOwnerUUID: ownerUUID, TotalBatches: len(idBatches)},
+			FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs)),
+		}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {
 			if i == 0 {

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -64,6 +64,7 @@ func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *m
 
 	// if this start was interrupted, we're done
 	if start.Status == models.StartStatusInterrupted {
+		t.RecordComplete(ctx, rt, taskID)
 		return nil
 	}
 
@@ -84,6 +85,8 @@ func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *m
 			return fmt.Errorf("error marking start as complete: %w", err)
 		}
 	}
+
+	t.RecordComplete(ctx, rt, taskID)
 
 	return nil
 }

--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -15,9 +15,9 @@ const (
 )
 
 // BatchTracker is a Valkey-backed hash for tracking completion of a set of batch tasks split out from an owning task
-// or object. The owner initializes it with the total number of batches before queuing them, and each batch then calls
-// Done with its own task ID as it completes. Because completions are recorded as distinct hash fields, marking the
-// same batch as done more than once has no effect, and completion can't be reported before all batches are really done.
+// or object. Each batch calls Done with its own task ID and the total number of batches in the set (which all batches
+// carry in their payloads) as it completes. Because completions are recorded as distinct hash fields, marking the same
+// batch as done more than once has no effect, and completion can't be reported before all batches are really done.
 type BatchTracker struct {
 	key string
 }
@@ -27,23 +27,14 @@ func NewBatchTracker(ownerUUID uuids.UUID) *BatchTracker {
 	return &BatchTracker{key: fmt.Sprintf("%s:%s", batchTrackerKeyBase, ownerUUID)}
 }
 
-// Init records the total number of batches, and must be called before any of them are queued.
-func (t *BatchTracker) Init(ctx context.Context, vk *valkey.Pool, total int) error {
-	vc := vk.Get()
-	defer vc.Close()
-
-	_, err := trackerInit.DoContext(ctx, vc, t.key, total, int(batchTrackerTTL/time.Second))
-	return err
-}
-
 // Done records the batch with the given task ID as complete and returns the number of completed batches and the total,
-// so the caller can tell if it was the first (completed == 1) or last (completed >= total) to complete. A total of
-// zero means the tracker was never initialized or has expired.
-func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID) (int, int, error) {
+// so the caller can tell if it was the first (completed == 1) or last (completed >= total) to complete. A returned
+// total of zero means no batch has yet reported one (e.g. batches queued before totals were added to payloads).
+func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID, total int) (int, int, error) {
 	vc := vk.Get()
 	defer vc.Close()
 
-	vals, err := valkey.Ints(trackerDone.DoContext(ctx, vc, t.key, string(taskID), int(batchTrackerTTL/time.Second)))
+	vals, err := valkey.Ints(trackerDone.DoContext(ctx, vc, t.key, string(taskID), total, int(batchTrackerTTL/time.Second)))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -51,15 +42,12 @@ func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID)
 	return vals[0], vals[1], nil
 }
 
-var trackerInit = valkey.NewScript(1, `
-redis.call('HSET', KEYS[1], 'total', ARGV[1])
-redis.call('EXPIRE', KEYS[1], ARGV[2])
-return 1
-`)
-
 var trackerDone = valkey.NewScript(1, `
 redis.call('HSET', KEYS[1], ARGV[1], 1)
-redis.call('EXPIRE', KEYS[1], ARGV[2])
+if tonumber(ARGV[2]) > 0 then
+	redis.call('HSET', KEYS[1], 'total', ARGV[2])
+end
+redis.call('EXPIRE', KEYS[1], ARGV[3])
 local hasTotal = redis.call('HEXISTS', KEYS[1], 'total')
 local completed = redis.call('HLEN', KEYS[1]) - hasTotal
 local total = tonumber(redis.call('HGET', KEYS[1], 'total')) or 0

--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -1,0 +1,67 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/gocommon/uuids"
+)
+
+const (
+	batchTrackerKeyBase = "task_batches"
+	batchTrackerTTL     = 24 * time.Hour
+)
+
+// BatchTracker is a Valkey-backed hash for tracking completion of a set of batch tasks split out from an owning task
+// or object. The owner initializes it with the total number of batches before queuing them, and each batch then calls
+// Done with its own task ID as it completes. Because completions are recorded as distinct hash fields, marking the
+// same batch as done more than once has no effect, and completion can't be reported before all batches are really done.
+type BatchTracker struct {
+	key string
+}
+
+// NewBatchTracker creates a tracker for the batches owned by the object or task with the given UUID.
+func NewBatchTracker(ownerUUID uuids.UUID) *BatchTracker {
+	return &BatchTracker{key: fmt.Sprintf("%s:%s", batchTrackerKeyBase, ownerUUID)}
+}
+
+// Init records the total number of batches, and must be called before any of them are queued.
+func (t *BatchTracker) Init(ctx context.Context, vk *valkey.Pool, total int) error {
+	vc := vk.Get()
+	defer vc.Close()
+
+	_, err := trackerInit.DoContext(ctx, vc, t.key, total, int(batchTrackerTTL/time.Second))
+	return err
+}
+
+// Done records the batch with the given task ID as complete and returns the number of completed batches and the total,
+// so the caller can tell if it was the first (completed == 1) or last (completed >= total) to complete. A total of
+// zero means the tracker was never initialized or has expired.
+func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID) (int, int, error) {
+	vc := vk.Get()
+	defer vc.Close()
+
+	vals, err := valkey.Ints(trackerDone.DoContext(ctx, vc, t.key, string(taskID), int(batchTrackerTTL/time.Second)))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return vals[0], vals[1], nil
+}
+
+var trackerInit = valkey.NewScript(1, `
+redis.call('HSET', KEYS[1], 'total', ARGV[1])
+redis.call('EXPIRE', KEYS[1], ARGV[2])
+return 1
+`)
+
+var trackerDone = valkey.NewScript(1, `
+redis.call('HSET', KEYS[1], ARGV[1], 1)
+redis.call('EXPIRE', KEYS[1], ARGV[2])
+local hasTotal = redis.call('HEXISTS', KEYS[1], 'total')
+local completed = redis.call('HLEN', KEYS[1]) - hasTotal
+local total = tonumber(redis.call('HGET', KEYS[1], 'total')) or 0
+return {completed, total}
+`)

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -1,0 +1,57 @@
+package tasks_test
+
+import (
+	"testing"
+
+	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/mailroom/v26/core/tasks"
+	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchTracker(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	tracker := tasks.NewBatchTracker("7de40d16-0286-4938-be6b-9974e12e1b0f")
+
+	err := tracker.Init(ctx, rt.VK, 3)
+	assert.NoError(t, err)
+
+	ttl, err := valkey.Int(vc.Do("TTL", "task_batches:7de40d16-0286-4938-be6b-9974e12e1b0f"))
+	assert.NoError(t, err)
+	assert.Greater(t, ttl, 0)
+
+	// first batch to complete
+	completed, total, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, completed)
+	assert.Equal(t, 3, total)
+
+	// completing the same batch again changes nothing
+	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, completed)
+	assert.Equal(t, 3, total)
+
+	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, completed)
+	assert.Equal(t, 3, total)
+
+	// last batch to complete
+	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, completed)
+	assert.Equal(t, 3, total)
+
+	// completing a batch on an uninitialized (or expired) tracker reports a zero total
+	other := tasks.NewBatchTracker("50d61890-a760-4c00-bd85-c60bb0a5e5b7")
+	completed, total, err = other.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, completed)
+	assert.Equal(t, 0, total)
+}

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -18,40 +18,43 @@ func TestBatchTracker(t *testing.T) {
 
 	tracker := tasks.NewBatchTracker("7de40d16-0286-4938-be6b-9974e12e1b0f")
 
-	err := tracker.Init(ctx, rt.VK, 3)
+	// first batch to complete
+	completed, total, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 3)
 	assert.NoError(t, err)
+	assert.Equal(t, 1, completed)
+	assert.Equal(t, 3, total)
 
 	ttl, err := valkey.Int(vc.Do("TTL", "task_batches:7de40d16-0286-4938-be6b-9974e12e1b0f"))
 	assert.NoError(t, err)
 	assert.Greater(t, ttl, 0)
 
-	// first batch to complete
-	completed, total, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
-	assert.NoError(t, err)
-	assert.Equal(t, 1, completed)
-	assert.Equal(t, 3, total)
-
 	// completing the same batch again changes nothing
-	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
+	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 3)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
 	assert.Equal(t, 3, total)
 
-	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000")
+	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000", 3)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, completed)
 	assert.Equal(t, 3, total)
 
 	// last batch to complete
-	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
+	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000", 3)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, completed)
 	assert.Equal(t, 3, total)
 
-	// completing a batch on an uninitialized (or expired) tracker reports a zero total
+	// batches which don't know their total (queued before totals were added to payloads) still record completion
+	// and report a zero total until a batch which does know it completes
 	other := tasks.NewBatchTracker("50d61890-a760-4c00-bd85-c60bb0a5e5b7")
-	completed, total, err = other.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000")
+	completed, total, err = other.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000", 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
 	assert.Equal(t, 0, total)
+
+	completed, total, err = other.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, completed)
+	assert.Equal(t, 2, total)
 }

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -3,6 +3,7 @@ package contact
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -49,9 +50,10 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
 	ownerUUID := uuids.NewV7()
 
-	// initialize the tracker that batches will record their completion in (not yet read)
+	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
+	// since nothing reads the tracker yet
 	if err := tasks.NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(imp.BatchIDs)); err != nil {
-		return nil, 0, fmt.Errorf("error initializing batch tracker: %w", err)
+		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", ownerUUID)
 	}
 
 	// create tasks for all batches

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -3,7 +3,6 @@ package contact
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -50,15 +49,12 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
 	ownerUUID := uuids.NewV7()
 
-	// initialize the tracker that batches will record their completion in - failures logged rather than escalated
-	// since nothing reads the tracker yet
-	if err := tasks.NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(imp.BatchIDs)); err != nil {
-		slog.Error("error initializing batch tracker", "error", err, "owner_uuid", ownerUUID)
-	}
-
 	// create tasks for all batches
 	for _, bID := range imp.BatchIDs {
-		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{BatchOwnerUUID: ownerUUID}, ContactImportBatchID: bID}
+		task := &tasks.ImportContactBatch{
+			BatchTask:            tasks.BatchTask{BatchOwnerUUID: ownerUUID, TotalBatches: len(imp.BatchIDs)},
+			ContactImportBatchID: bID,
+		}
 		if err := tasks.Queue(ctx, rt, rt.Queues.Batch, r.OrgID, task, false); err != nil {
 			return nil, 0, fmt.Errorf("error queuing import contact batch task: %w", err)
 		}

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -49,6 +49,11 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
 	ownerUUID := uuids.NewV7()
 
+	// initialize the tracker that batches will record their completion in (not yet read)
+	if err := tasks.NewBatchTracker(ownerUUID).Init(ctx, rt.VK, len(imp.BatchIDs)); err != nil {
+		return nil, 0, fmt.Errorf("error initializing batch tracker: %w", err)
+	}
+
 	// create tasks for all batches
 	for _, bID := range imp.BatchIDs {
 		task := &tasks.ImportContactBatch{BatchTask: tasks.BatchTask{BatchOwnerUUID: ownerUUID}, ContactImportBatchID: bID}

--- a/web/contact/testdata/import.json
+++ b/web/contact/testdata/import.json
@@ -27,14 +27,16 @@
                     "type": "import_contact_batch",
                     "payload": {
                         "contact_import_batch_id": 30000,
-                        "batch_owner_uuid": "01969b47-0583-76f8-924e-9de1a11831b3"
+                        "batch_owner_uuid": "01969b47-0583-76f8-924e-9de1a11831b3",
+                        "total_batches": 2
                     }
                 },
                 {
                     "type": "import_contact_batch",
                     "payload": {
                         "contact_import_batch_id": 30001,
-                        "batch_owner_uuid": "01969b47-0583-76f8-924e-9de1a11831b3"
+                        "batch_owner_uuid": "01969b47-0583-76f8-924e-9de1a11831b3",
+                        "total_batches": 2
                     }
                 }
             ]


### PR DESCRIPTION
Stage 2a of the batch completion tracking change (#1171 was stage 1). Adds `BatchTracker` - a Valkey hash at `task_batches:<owner UUID>` in which each batch of a set records its completion using its own task ID:

* every batch's payload carries the total number of batches in its set (`BatchTask.TotalBatches`), so trackers need no upfront initialization and all tracker interaction lives in `BatchTask.RecordComplete`
* completions are distinct hash fields, so recording the same batch twice has no effect and completion can't be observed before all batches have really finished
* recording returns `(completed, total)` so a future reader can tell if it was the first or last batch to complete
* keys expire after 24 hours

Flow start, broadcast, group population and contact import batches all record their completion. `RecordComplete` skips batches queued before owner UUIDs existed and logs (rather than fails) on error since nothing depends on the tracker yet.

**Nothing reads the trackers in this stage.** All existing completion mechanisms (the import and group population counters, the `IsFirst`/`IsLast` flags on start and broadcast batches) continue to drive behavior untouched, so this deploys with no transition concerns in either direction. The next stage will switch completion decisions to the trackers - fixing runs being marked complete before all their batches have finished (last-queued isn't last-finished) - and then the old mechanisms can be removed.

Replaces #1130.