### PR TITLE
Use batch trackers to make completion decisions

### DIFF
--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -44,16 +44,26 @@ type BatchTask struct {
 	TotalBatches   int        `json:"total_batches,omitempty"`
 }
 
-// RecordComplete marks this batch as complete in its owner's tracker. The tracker isn't yet used to make completion
-// decisions so any error here is logged rather than allowed to fail the batch.
-func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, taskID TaskID) {
+// RecordComplete marks this batch as complete in its owner's tracker, and returns whether this was the last batch of
+// its set to complete, and whether that could actually be determined. It can't be determined for batches queued before
+// owner UUIDs and totals were added to payloads, or if the tracker can't be updated (logged rather than escalated
+// since the batch's own work has already succeeded) - in those cases the caller should fall back to a legacy
+// completion mechanism.
+func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, taskID TaskID) (bool, bool) {
 	if b.BatchOwnerUUID == "" {
-		return // batch was queued before owner UUIDs were added
+		return false, false // batch was queued before owner UUIDs were added
 	}
 
-	if _, _, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID, b.TotalBatches); err != nil {
+	completed, total, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID, b.TotalBatches)
+	if err != nil {
 		slog.Error("error recording batch task completion", "error", err, "owner_uuid", b.BatchOwnerUUID)
+		return false, false
 	}
+	if total == 0 {
+		return false, false // no batch in the set has reported the total
+	}
+
+	return completed >= total, true
 }
 
 // Task is the common interface for all task types

--- a/core/tasks/base_test.go
+++ b/core/tasks/base_test.go
@@ -5,12 +5,56 @@ import (
 
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
+	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // task ID for tests which call Perform directly instead of going through a queue
 const testTaskID = tasks.TaskID("01981fa0-3c74-7d6c-8000-1a2b3c4d5e6f")
+
+func TestRecordComplete(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	// batches queued before owner UUIDs were added can't determine completion
+	legacy := &tasks.BatchTask{}
+	last, known := legacy.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000")
+	assert.False(t, last)
+	assert.False(t, known)
+
+	b := &tasks.BatchTask{BatchOwnerUUID: "8677d4ea-895c-40fd-b6d9-e1eccd7d8ed4", TotalBatches: 3}
+
+	last, known = b.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000")
+	assert.False(t, last)
+	assert.True(t, known)
+
+	// completing the same batch again changes nothing
+	last, known = b.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000")
+	assert.False(t, last)
+	assert.True(t, known)
+
+	last, known = b.RecordComplete(ctx, rt, "01981fa0-0002-7000-8000-000000000000")
+	assert.False(t, last)
+	assert.True(t, known)
+
+	// last batch of the set to complete
+	last, known = b.RecordComplete(ctx, rt, "01981fa0-0003-7000-8000-000000000000")
+	assert.True(t, last)
+	assert.True(t, known)
+
+	// a batch without a total still records completion but reports unknown until a batch with a total completes
+	c1 := &tasks.BatchTask{BatchOwnerUUID: "50d61890-a760-4c00-bd85-c60bb0a5e5b7"}
+	last, known = c1.RecordComplete(ctx, rt, "01981fa0-0004-7000-8000-000000000000")
+	assert.False(t, last)
+	assert.False(t, known)
+
+	c2 := &tasks.BatchTask{BatchOwnerUUID: "50d61890-a760-4c00-bd85-c60bb0a5e5b7", TotalBatches: 2}
+	last, known = c2.RecordComplete(ctx, rt, "01981fa0-0005-7000-8000-000000000000")
+	assert.True(t, last)
+	assert.True(t, known)
+}
 
 func TestReadTask(t *testing.T) {
 	task, err := tasks.ReadTask("populate_group", []byte(`{

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -60,13 +60,15 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		}
 	}
 
-	t.RecordComplete(ctx, rt, taskID)
-
-	// decrement the counter to see if the overall import is now finished
-	counter := NewCounter(fmt.Sprintf("contact_import_batches_remaining:%d", batch.ImportID), 24*time.Hour)
-	done, err := counter.Done(ctx, rt.VK)
-	if err != nil {
-		return fmt.Errorf("error decrementing import batch counter: %w", err)
+	// mark this batch as complete and check if the overall import is now finished - falling back to the legacy
+	// counter for batches queued before completion tracking
+	done, known := t.RecordComplete(ctx, rt, taskID)
+	if !known {
+		counter := NewCounter(fmt.Sprintf("contact_import_batches_remaining:%d", batch.ImportID), 24*time.Hour)
+		done, err = counter.Done(ctx, rt.VK)
+		if err != nil {
+			return fmt.Errorf("error decrementing import batch counter: %w", err)
+		}
 	}
 	if done {
 		// reload the import to get the final statuses of all batches - the statuses loaded before this batch was

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -59,6 +59,36 @@ func TestImportContactBatch(t *testing.T) {
 		})
 }
 
+func TestImportContactBatchTracked(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+
+	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
+	batch1ID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
+		{"name": "Norbert", "language": "eng", "urns": ["tel:+16055740001"]}
+	]`))
+	batch2ID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
+		{"name": "Leah", "urns": ["tel:+16055740002"]}
+	]`))
+
+	// batches carry an owner UUID and total as the import endpoint now creates them - no legacy counter needed
+	batchTask := tasks.BatchTask{BatchOwnerUUID: "440e0ac2-8607-42d3-9a30-cb27b29a5c95", TotalBatches: 2}
+
+	// perform first batch task... import still in progress
+	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{BatchTask: batchTask, ContactImportBatchID: batch1ID})
+	testsuite.FlushTasks(t, rt)
+
+	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "O"})
+
+	// perform second batch task... import completes via the tracker
+	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{BatchTask: batchTask, ContactImportBatchID: batch2ID})
+	testsuite.FlushTasks(t, rt)
+
+	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "C"})
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM notifications_notification WHERE contact_import_id = $1 AND notification_type = 'import:finished'`, importID).Returns(1)
+}
+
 func TestImportContactBatchFailure(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -53,13 +53,15 @@ func (t *PopulateGroupBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		slog.Warn("failed to acquire locks for contacts during group population", "group_id", t.GroupID, "skipped", len(skipped))
 	}
 
-	t.RecordComplete(ctx, rt, taskID)
-
-	// decrement the counter to see if the overall population is now finished
-	counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, t.PopulationID), time.Hour)
-	done, err := counter.Done(ctx, rt.VK)
-	if err != nil {
-		return fmt.Errorf("error decrementing populate group batch counter: %w", err)
+	// mark this batch as complete and check if the overall population is now finished - falling back to the legacy
+	// counter for batches queued before completion tracking
+	done, known := t.RecordComplete(ctx, rt, taskID)
+	if !known {
+		counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, t.PopulationID), time.Hour)
+		done, err = counter.Done(ctx, rt.VK)
+		if err != nil {
+			return fmt.Errorf("error decrementing populate group batch counter: %w", err)
+		}
 	}
 	if done {
 		if err := models.UpdateGroupStatus(ctx, rt.DB, t.GroupID, models.GroupStatusReady); err != nil {

--- a/core/tasks/send_broadcast_batch.go
+++ b/core/tasks/send_broadcast_batch.go
@@ -74,14 +74,14 @@ func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		slog.Warn("failed to acquire locks for contacts", "contacts", skipped)
 	}
 
-	// if this is our last batch, mark broadcast as done
-	if t.IsLast {
+	// mark broadcast as done if this was the last batch to complete - falling back to the queuing order flag for
+	// batches queued before completion tracking
+	last, known := t.RecordComplete(ctx, rt, taskID)
+	if (known && last) || (!known && t.IsLast) {
 		if err := bcast.SetCompleted(ctx, rt.DB); err != nil {
 			return fmt.Errorf("error marking broadcast as complete: %w", err)
 		}
 	}
-
-	t.RecordComplete(ctx, rt, taskID)
 
 	return nil
 }

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -79,14 +79,14 @@ func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *m
 		return err
 	}
 
-	// if this is our last batch, mark start as done
-	if t.IsLast {
+	// mark start as done if this was the last batch to complete - falling back to the queuing order flag for
+	// batches queued before completion tracking
+	last, known := t.RecordComplete(ctx, rt, taskID)
+	if (known && last) || (!known && t.IsLast) {
 		if err := start.SetCompleted(ctx, rt.DB); err != nil {
 			return fmt.Errorf("error marking start as complete: %w", err)
 		}
 	}
-
-	t.RecordComplete(ctx, rt, taskID)
 
 	return nil
 }


### PR DESCRIPTION
Stage 2b of the batch completion tracking change (#1171 added owner UUIDs to batch payloads, #1173 added the trackers as write-only). Completion decisions now come from the trackers:

* `BatchTask.RecordComplete` returns whether this was the last batch of its set to complete, and whether that could be determined at all
* flow start and broadcast batches mark their run complete when they were the *last to finish* rather than the last to be queued - fixing runs showing as complete while earlier-queued batches were still running
* contact import and group population batches use the same signal in place of their decrement counters

Legacy mechanisms are kept as fallbacks for one release, used only when a batch can't determine completion from its tracker (no owner UUID or total in its payload - i.e. queued before the previous release - or a tracker error):

* starts/broadcasts fall back to the `IsLast` queuing-order flag
* imports/populations fall back to their counters, which are still initialized by their creators

Error-path behavior is unchanged: a batch that fails before recording completion leaves its run unfinished, exactly as a failed batch left counters undecremented and `IsLast` unfired before. A later change can remove the counters, the `IsFirst`/`IsLast` flags and the group population run IDs once this has been deployed.