### PR TITLE
Remove legacy batch completion mechanisms replaced by batch trackers

### DIFF
--- a/core/models/broadcast.go
+++ b/core/models/broadcast.go
@@ -138,14 +138,12 @@ type BroadcastBatch struct {
 
 	ContactIDs []ContactID `json:"contact_ids"`
 	IsFirst    bool        `json:"is_first"`
-	IsLast     bool        `json:"is_last"`
 }
 
-func (b *Broadcast) CreateBatch(contactIDs []ContactID, isFirst, isLast bool) *BroadcastBatch {
+func (b *Broadcast) CreateBatch(contactIDs []ContactID, isFirst bool) *BroadcastBatch {
 	bb := &BroadcastBatch{
 		ContactIDs: contactIDs,
 		IsFirst:    isFirst,
-		IsLast:     isLast,
 	}
 
 	if b.ID != NilBroadcastID {

--- a/core/models/broadcast_test.go
+++ b/core/models/broadcast_test.go
@@ -131,7 +131,7 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 	assert.Equal(t, "", bcast.Query)
 	assert.Equal(t, models.NoExclusions, bcast.Exclusions)
 
-	batch := bcast.CreateBatch([]models.ContactID{testdb.Dan.ID, testdb.Bob.ID}, true, false)
+	batch := bcast.CreateBatch([]models.ContactID{testdb.Dan.ID, testdb.Bob.ID}, true)
 
 	assert.Equal(t, models.NilBroadcastID, batch.BroadcastID)
 	assert.NotNil(t, testdb.Org1.ID, batch.Broadcast)

--- a/core/models/start.go
+++ b/core/models/start.go
@@ -316,11 +316,10 @@ const sqlInsertStartGroup = `
 INSERT INTO flows_flowstart_groups(flowstart_id, contactgroup_id) VALUES(:flowstart_id, :contactgroup_id)`
 
 // CreateBatch creates a batch for this start using the passed in contact ids
-func (s *FlowStart) CreateBatch(contactIDs []ContactID, isFirst, isLast bool, totalContacts int) *FlowStartBatch {
+func (s *FlowStart) CreateBatch(contactIDs []ContactID, isFirst bool, totalContacts int) *FlowStartBatch {
 	b := &FlowStartBatch{
 		ContactIDs:    contactIDs,
 		IsFirst:       isFirst,
-		IsLast:        isLast,
 		TotalContacts: totalContacts,
 	}
 
@@ -341,7 +340,6 @@ type FlowStartBatch struct {
 
 	ContactIDs    []ContactID `json:"contact_ids"`
 	IsFirst       bool        `json:"is_first"`
-	IsLast        bool        `json:"is_last,omitempty"`
 	TotalContacts int         `json:"total_contacts"`
 }
 

--- a/core/models/start_test.go
+++ b/core/models/start_test.go
@@ -68,10 +68,10 @@ func TestStarts(t *testing.T) {
 	require.NoError(t, err)
 	assertdb.Query(t, rt.DB, `SELECT status, contact_count FROM flows_flowstart WHERE id = $1`, startID).Columns(map[string]any{"status": "Q", "contact_count": 5})
 
-	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, false, 3)
+	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 3)
 	assert.Equal(t, startID, batch.StartID)
 	assert.Equal(t, []models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, batch.ContactIDs)
-	assert.False(t, batch.IsLast)
+	assert.True(t, batch.IsFirst)
 	assert.Equal(t, 3, batch.TotalContacts)
 
 	history, err := models.ReadSessionHistory(start.SessionHistory)

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -633,8 +633,8 @@ func TestBroadcastWithLock(t *testing.T) {
 
 	test.MockUniverse()
 
-	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, false)
-	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID}, false, true)
+	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true)
+	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID}, false)
 
 	scenes, skipped, err := runner.BroadcastWithLock(ctx, rt, oa, bcast, batch1, models.StartModeBackground)
 	assert.NoError(t, err)
@@ -700,7 +700,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast2, err := models.GetBroadcastByID(ctx, rt.DB, b2.ID)
 	require.NoError(t, err)
 
-	skipBatch := bcast2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, true, true)
+	skipBatch := bcast2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, true)
 	scenes, skipped, err = runner.BroadcastWithLock(ctx, rt, oa, bcast2, skipBatch, models.StartModeSkip)
 	assert.NoError(t, err)
 	assert.Len(t, skipped, 0) // all contacts were locked successfully
@@ -723,7 +723,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast3, err := models.GetBroadcastByID(ctx, rt.DB, b3.ID)
 	require.NoError(t, err)
 
-	intBatch := bcast3.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, true, true)
+	intBatch := bcast3.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, true)
 	scenes, skipped, err = runner.BroadcastWithLock(ctx, rt, oa, bcast3, intBatch, models.StartModeInterrupt)
 	assert.NoError(t, err)
 	assert.Len(t, skipped, 0)

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -44,26 +44,21 @@ type BatchTask struct {
 	TotalBatches   int        `json:"total_batches,omitempty"`
 }
 
-// RecordComplete marks this batch as complete in its owner's tracker, and returns whether this was the last batch of
-// its set to complete, and whether that could actually be determined. It can't be determined for batches queued before
-// owner UUIDs and totals were added to payloads, or if the tracker can't be updated (logged rather than escalated
-// since the batch's own work has already succeeded) - in those cases the caller should fall back to a legacy
-// completion mechanism.
-func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, taskID TaskID) (bool, bool) {
+// RecordComplete marks this batch as complete in its owner's tracker and returns whether it was the last batch of its
+// set to complete. Tracker errors are logged rather than escalated since the batch's own work has already succeeded -
+// tho in that case completion of the set will never be detected.
+func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, taskID TaskID) bool {
 	if b.BatchOwnerUUID == "" {
-		return false, false // batch was queued before owner UUIDs were added
+		return false // shouldn't happen but better than all such batches sharing a tracker
 	}
 
 	completed, total, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID, b.TotalBatches)
 	if err != nil {
 		slog.Error("error recording batch task completion", "error", err, "owner_uuid", b.BatchOwnerUUID)
-		return false, false
-	}
-	if total == 0 {
-		return false, false // no batch in the set has reported the total
+		return false
 	}
 
-	return completed >= total, true
+	return total > 0 && completed >= total
 }
 
 // Task is the common interface for all task types

--- a/core/tasks/base_test.go
+++ b/core/tasks/base_test.go
@@ -18,42 +18,29 @@ func TestRecordComplete(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
-	// batches queued before owner UUIDs were added can't determine completion
-	legacy := &tasks.BatchTask{}
-	last, known := legacy.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000")
-	assert.False(t, last)
-	assert.False(t, known)
+	// a batch without an owner UUID (shouldn't happen) is never the last of its set
+	noOwner := &tasks.BatchTask{}
+	assert.False(t, noOwner.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000"))
 
 	b := &tasks.BatchTask{BatchOwnerUUID: "8677d4ea-895c-40fd-b6d9-e1eccd7d8ed4", TotalBatches: 3}
 
-	last, known = b.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000")
-	assert.False(t, last)
-	assert.True(t, known)
+	assert.False(t, b.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000"))
 
 	// completing the same batch again changes nothing
-	last, known = b.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000")
-	assert.False(t, last)
-	assert.True(t, known)
+	assert.False(t, b.RecordComplete(ctx, rt, "01981fa0-0001-7000-8000-000000000000"))
 
-	last, known = b.RecordComplete(ctx, rt, "01981fa0-0002-7000-8000-000000000000")
-	assert.False(t, last)
-	assert.True(t, known)
+	assert.False(t, b.RecordComplete(ctx, rt, "01981fa0-0002-7000-8000-000000000000"))
 
 	// last batch of the set to complete
-	last, known = b.RecordComplete(ctx, rt, "01981fa0-0003-7000-8000-000000000000")
-	assert.True(t, last)
-	assert.True(t, known)
+	assert.True(t, b.RecordComplete(ctx, rt, "01981fa0-0003-7000-8000-000000000000"))
 
-	// a batch without a total still records completion but reports unknown until a batch with a total completes
+	// a batch without a total (shouldn't happen) still records completion but can't be considered the last, until a
+	// batch with a total completes
 	c1 := &tasks.BatchTask{BatchOwnerUUID: "50d61890-a760-4c00-bd85-c60bb0a5e5b7"}
-	last, known = c1.RecordComplete(ctx, rt, "01981fa0-0004-7000-8000-000000000000")
-	assert.False(t, last)
-	assert.False(t, known)
+	assert.False(t, c1.RecordComplete(ctx, rt, "01981fa0-0004-7000-8000-000000000000"))
 
 	c2 := &tasks.BatchTask{BatchOwnerUUID: "50d61890-a760-4c00-bd85-c60bb0a5e5b7", TotalBatches: 2}
-	last, known = c2.RecordComplete(ctx, rt, "01981fa0-0005-7000-8000-000000000000")
-	assert.True(t, last)
-	assert.True(t, known)
+	assert.True(t, c2.RecordComplete(ctx, rt, "01981fa0-0005-7000-8000-000000000000"))
 }
 
 func TestReadTask(t *testing.T) {

--- a/core/tasks/import_contact_batch.go
+++ b/core/tasks/import_contact_batch.go
@@ -60,17 +60,8 @@ func (t *ImportContactBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		}
 	}
 
-	// mark this batch as complete and check if the overall import is now finished - falling back to the legacy
-	// counter for batches queued before completion tracking
-	done, known := t.RecordComplete(ctx, rt, taskID)
-	if !known {
-		counter := NewCounter(fmt.Sprintf("contact_import_batches_remaining:%d", batch.ImportID), 24*time.Hour)
-		done, err = counter.Done(ctx, rt.VK)
-		if err != nil {
-			return fmt.Errorf("error decrementing import batch counter: %w", err)
-		}
-	}
-	if done {
+	// mark this batch as complete and check if the overall import is now finished
+	if t.RecordComplete(ctx, rt, taskID) {
 		// reload the import to get the final statuses of all batches - the statuses loaded before this batch was
 		// processed are stale by now
 		imp, err = models.LoadContactImport(ctx, rt.DB, batch.ImportID)

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -16,8 +16,6 @@ import (
 
 func TestImportContactBatch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-	vc := rt.VK.Get()
-	defer vc.Close()
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
 
@@ -30,17 +28,18 @@ func TestImportContactBatch(t *testing.T) {
 		{"name": "Rowan", "language": "spa", "urns": ["tel:+16055740003"]}
 	]`))
 
-	vc.Do("SETEX", fmt.Sprintf("contact_import_batches_remaining:%d", importID), 10, 2)
+	// batches carry an owner UUID and total as the import endpoint creates them
+	batchTask := tasks.BatchTask{BatchOwnerUUID: "440e0ac2-8607-42d3-9a30-cb27b29a5c95", TotalBatches: 2}
 
 	// perform first batch task...
-	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{ContactImportBatchID: batch1ID})
+	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{BatchTask: batchTask, ContactImportBatchID: batch1ID})
 	testsuite.FlushTasks(t, rt)
 
 	// import is still in progress
 	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "O"})
 
 	// perform second batch task...
-	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{ContactImportBatchID: batch2ID})
+	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{BatchTask: batchTask, ContactImportBatchID: batch2ID})
 	testsuite.FlushTasks(t, rt)
 
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contact WHERE id >= 30000`).Returns(3)
@@ -59,40 +58,8 @@ func TestImportContactBatch(t *testing.T) {
 		})
 }
 
-func TestImportContactBatchTracked(t *testing.T) {
-	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
-
-	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
-	batch1ID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
-		{"name": "Norbert", "language": "eng", "urns": ["tel:+16055740001"]}
-	]`))
-	batch2ID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
-		{"name": "Leah", "urns": ["tel:+16055740002"]}
-	]`))
-
-	// batches carry an owner UUID and total as the import endpoint now creates them - no legacy counter needed
-	batchTask := tasks.BatchTask{BatchOwnerUUID: "440e0ac2-8607-42d3-9a30-cb27b29a5c95", TotalBatches: 2}
-
-	// perform first batch task... import still in progress
-	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{BatchTask: batchTask, ContactImportBatchID: batch1ID})
-	testsuite.FlushTasks(t, rt)
-
-	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "O"})
-
-	// perform second batch task... import completes via the tracker
-	testsuite.QueueBatchTask(t, rt, testdb.Org1, &tasks.ImportContactBatch{BatchTask: batchTask, ContactImportBatchID: batch2ID})
-	testsuite.FlushTasks(t, rt)
-
-	assertdb.Query(t, rt.DB, `SELECT status FROM contacts_contactimport WHERE id = $1`, importID).Columns(map[string]any{"status": "C"})
-	assertdb.Query(t, rt.DB, `SELECT count(*) FROM notifications_notification WHERE contact_import_id = $1 AND notification_type = 'import:finished'`, importID).Returns(1)
-}
-
 func TestImportContactBatchFailure(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	vc := rt.VK.Get()
-	defer vc.Close()
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
 
@@ -101,12 +68,13 @@ func TestImportContactBatchFailure(t *testing.T) {
 	// insert a batch with specs that can't be unmarshaled so that processing it fails
 	batchID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[{"urns": "should-be-an-array"}]`))
 
-	vc.Do("SETEX", fmt.Sprintf("contact_import_batches_remaining:%d", importID), 10, 1)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
-	task := &tasks.ImportContactBatch{ContactImportBatchID: batchID}
+	task := &tasks.ImportContactBatch{
+		BatchTask:            tasks.BatchTask{BatchOwnerUUID: "50aef7cc-8dbd-410b-b6b8-3f2b0bfb0a7b", TotalBatches: 1},
+		ContactImportBatchID: batchID,
+	}
 	assert.Error(t, task.Perform(ctx, rt, oa, testTaskID))
 
 	// batch and overall import should be marked as failed

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
-	"github.com/nyaruka/mailroom/v26/utils"
 	"github.com/nyaruka/vkutil/locks"
 )
 
@@ -22,7 +21,6 @@ import (
 const TypePopulateGroup = "populate_group"
 
 const populateGroupLockKey = "lock:pop_dyn_group_%d"
-const populateGroupBatchesRemainingKey = "populate_group_batches_remaining:%s"
 const populateBatchSize = 100
 
 func init() {
@@ -130,25 +128,15 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 		return nil
 	}
 
-	// chunk contacts into batches and queue a task for each
+	// chunk contacts into batches and queue a task for each - batches are owned by this task, identified by its ID
 	batches := slices.Collect(slices.Chunk(recheckIDs, populateBatchSize))
-
-	// generate a random ID for this population run so batch tasks can track completion
-	populationID := utils.RandomBase64(10)
-
-	// set valkey counter which batch tasks can decrement to know when population has completed
-	counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, populationID), time.Hour)
-	if err := counter.Init(ctx, rt.VK, len(batches)); err != nil {
-		return fmt.Errorf("error setting populate group batch counter key: %w", err)
-	}
 
 	for _, batch := range batches {
 		task := &PopulateGroupBatch{
-			BatchTask:    BatchTask{BatchOwnerUUID: uuids.UUID(taskID), TotalBatches: len(batches)},
-			GroupID:      t.GroupID,
-			ContactIDs:   batch,
-			LockValue:    lock,
-			PopulationID: populationID,
+			BatchTask:  BatchTask{BatchOwnerUUID: uuids.UUID(taskID), TotalBatches: len(batches)},
+			GroupID:    t.GroupID,
+			ContactIDs: batch,
+			LockValue:  lock,
 		}
 		if err := Queue(ctx, rt, rt.Queues.Batch, oa.OrgID(), task, false); err != nil {
 			return fmt.Errorf("error queuing populate group batch task: %w", err)

--- a/core/tasks/populate_group_batch.go
+++ b/core/tasks/populate_group_batch.go
@@ -23,10 +23,9 @@ func init() {
 type PopulateGroupBatch struct {
 	BatchTask
 
-	GroupID      models.GroupID     `json:"group_id"`
-	ContactIDs   []models.ContactID `json:"contact_ids"`
-	LockValue    string             `json:"lock_value"`
-	PopulationID string             `json:"population_id"`
+	GroupID    models.GroupID     `json:"group_id"`
+	ContactIDs []models.ContactID `json:"contact_ids"`
+	LockValue  string             `json:"lock_value"`
 }
 
 func (t *PopulateGroupBatch) Type() string {
@@ -53,17 +52,8 @@ func (t *PopulateGroupBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		slog.Warn("failed to acquire locks for contacts during group population", "group_id", t.GroupID, "skipped", len(skipped))
 	}
 
-	// mark this batch as complete and check if the overall population is now finished - falling back to the legacy
-	// counter for batches queued before completion tracking
-	done, known := t.RecordComplete(ctx, rt, taskID)
-	if !known {
-		counter := NewCounter(fmt.Sprintf(populateGroupBatchesRemainingKey, t.PopulationID), time.Hour)
-		done, err = counter.Done(ctx, rt.VK)
-		if err != nil {
-			return fmt.Errorf("error decrementing populate group batch counter: %w", err)
-		}
-	}
-	if done {
+	// mark this batch as complete and check if the overall population is now finished
+	if t.RecordComplete(ctx, rt, taskID) {
 		if err := models.UpdateGroupStatus(ctx, rt.DB, t.GroupID, models.GroupStatusReady); err != nil {
 			return fmt.Errorf("error updating query group status: %w", err)
 		}

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -45,7 +45,7 @@ func (t *SendBroadcast) WithAssets() models.Refresh {
 
 // Perform handles sending the broadcast by creating batches of broadcast sends for all the unique contacts
 func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
-	if err := createBroadcastBatches(ctx, rt, oa, t.Broadcast, taskID); err != nil {
+	if err := createBroadcastBatches(ctx, rt, oa, t.Broadcast); err != nil {
 		t.Broadcast.SetFailed(ctx, rt.DB)
 
 		// if error is user created query error.. don't escalate error to sentry
@@ -58,14 +58,7 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	return nil
 }
 
-func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast, taskID TaskID) error {
-	// batches are owned by the broadcast, identified by its UUID - tho unlike starts, broadcast UUIDs have always
-	// been serialized in task payloads so the fallback to task ID is just defensive
-	ownerUUID := uuids.UUID(bcast.UUID)
-	if ownerUUID == "" {
-		ownerUUID = uuids.UUID(taskID)
-	}
-
+func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast) error {
 	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
 		ContactIDs:      bcast.ContactIDs,
 		GroupIDs:        bcast.GroupIDs,
@@ -116,11 +109,10 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
-		isLast := (i == len(idBatches)-1)
 
-		batch := bcast.CreateBatch(idBatch, isFirst, isLast)
+		batch := bcast.CreateBatch(idBatch, isFirst)
 		batchTask := &SendBroadcastBatch{
-			BatchTask:      BatchTask{BatchOwnerUUID: ownerUUID, TotalBatches: len(idBatches)},
+			BatchTask:      BatchTask{BatchOwnerUUID: uuids.UUID(bcast.UUID), TotalBatches: len(idBatches)},
 			BroadcastBatch: batch,
 		}
 		err = Queue(ctx, rt, q, bcast.OrgID, batchTask, false)

--- a/core/tasks/send_broadcast_batch.go
+++ b/core/tasks/send_broadcast_batch.go
@@ -74,10 +74,8 @@ func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		slog.Warn("failed to acquire locks for contacts", "contacts", skipped)
 	}
 
-	// mark broadcast as done if this was the last batch to complete - falling back to the queuing order flag for
-	// batches queued before completion tracking
-	last, known := t.RecordComplete(ctx, rt, taskID)
-	if (known && last) || (!known && t.IsLast) {
+	// mark broadcast as done if this was the last batch to complete
+	if t.RecordComplete(ctx, rt, taskID) {
 		if err := bcast.SetCompleted(ctx, rt.DB); err != nil {
 			return fmt.Errorf("error marking broadcast as complete: %w", err)
 		}

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/i18n"
-	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
@@ -44,7 +43,7 @@ func (t *StartFlow) WithAssets() models.Refresh {
 }
 
 func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, taskID TaskID) error {
-	if err := createFlowStartBatches(ctx, rt, oa, t.FlowStart, taskID); err != nil {
+	if err := createFlowStartBatches(ctx, rt, oa, t.FlowStart); err != nil {
 		t.FlowStart.SetFailed(ctx, rt.DB)
 
 		// if error is user created query error.. don't escalate error to sentry
@@ -58,15 +57,7 @@ func (t *StartFlow) Perform(ctx context.Context, rt *runtime.Runtime, oa *models
 }
 
 // creates batches of flow starts for all the unique contacts
-func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart, taskID TaskID) error {
-	// batches are owned by the start, identified by its UUID
-	// TODO: fallback to task ID is a temporary workaround for tasks queued before start UUIDs were serialized,
-	// remove once this has been deployed and queues have cycled
-	ownerUUID := start.UUID
-	if ownerUUID == "" {
-		ownerUUID = uuids.UUID(taskID)
-	}
-
+func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, start *models.FlowStart) error {
 	flow, err := oa.FlowByID(start.FlowID)
 	if err != nil {
 		return fmt.Errorf("error loading flow: %w", err)
@@ -127,10 +118,9 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 
 	for i, idBatch := range idBatches {
 		isFirst := (i == 0)
-		isLast := (i == len(idBatches)-1)
 		batchTask := &StartFlowBatch{
-			BatchTask:      BatchTask{BatchOwnerUUID: ownerUUID, TotalBatches: len(idBatches)},
-			FlowStartBatch: start.CreateBatch(idBatch, isFirst, isLast, len(contactIDs)),
+			BatchTask:      BatchTask{BatchOwnerUUID: start.UUID, TotalBatches: len(idBatches)},
+			FlowStartBatch: start.CreateBatch(idBatch, isFirst, len(contactIDs)),
 		}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -79,10 +79,8 @@ func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *m
 		return err
 	}
 
-	// mark start as done if this was the last batch to complete - falling back to the queuing order flag for
-	// batches queued before completion tracking
-	last, known := t.RecordComplete(ctx, rt, taskID)
-	if (known && last) || (!known && t.IsLast) {
+	// mark start as done if this was the last batch to complete
+	if t.RecordComplete(ctx, rt, taskID) {
 		if err := start.SetCompleted(ctx, rt.DB); err != nil {
 			return fmt.Errorf("error marking start as complete: %w", err)
 		}

--- a/core/tasks/start_flow_batch_test.go
+++ b/core/tasks/start_flow_batch_test.go
@@ -28,11 +28,12 @@ func TestStartFlowBatchTask(t *testing.T) {
 
 	assertdb.Query(t, rt.DB, `SELECT status FROM flows_flowstart WHERE id = $1`, start1.ID).Returns("P")
 
-	batch1 := start1.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, false, 4)
-	batch2 := start1.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, false, true, 4)
+	start1BatchTask := tasks.BatchTask{BatchOwnerUUID: start1.UUID, TotalBatches: 2}
+	batch1 := start1.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 4)
+	batch2 := start1.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, false, 4)
 
 	// start the first batch...
-	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{FlowStartBatch: batch1}, false)
+	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: start1BatchTask, FlowStartBatch: batch1}, false)
 	assert.NoError(t, err)
 	testsuite.FlushTasks(t, rt)
 
@@ -51,7 +52,7 @@ func TestStartFlowBatchTask(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT status FROM flows_flowstart WHERE id = $1`, start1.ID).Returns("S")
 
 	// start the second and final batch...
-	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{FlowStartBatch: batch2}, false)
+	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: start1BatchTask, FlowStartBatch: batch2}, false)
 	assert.NoError(t, err)
 	testsuite.FlushTasks(t, rt)
 
@@ -64,11 +65,12 @@ func TestStartFlowBatchTask(t *testing.T) {
 	err = models.InsertFlowStart(ctx, rt.DB, start2)
 	require.NoError(t, err)
 
-	start2Batch1 := start2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, false, 4)
-	start2Batch2 := start2.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, false, true, 4)
+	start2BatchTask := tasks.BatchTask{BatchOwnerUUID: start2.UUID, TotalBatches: 2}
+	start2Batch1 := start2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 4)
+	start2Batch2 := start2.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, false, 4)
 
 	// start the first batch...
-	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{FlowStartBatch: start2Batch1}, false)
+	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: start2BatchTask, FlowStartBatch: start2Batch1}, false)
 	assert.NoError(t, err)
 	testsuite.FlushTasks(t, rt)
 
@@ -78,7 +80,7 @@ func TestStartFlowBatchTask(t *testing.T) {
 	rt.DB.MustExec(`UPDATE flows_flowstart SET status = 'I' WHERE id = $1`, start2.ID)
 
 	// start the second batch...
-	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{FlowStartBatch: start2Batch2}, false)
+	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: start2BatchTask, FlowStartBatch: start2Batch2}, false)
 	assert.NoError(t, err)
 	testsuite.FlushTasks(t, rt)
 
@@ -90,16 +92,17 @@ func TestStartFlowBatchTask(t *testing.T) {
 func TestStartFlowBatchTaskNonPersistedStart(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
 
 	// create a start
 	start := models.NewFlowStart(models.OrgID(1), models.StartTypeManual, testdb.SingleMessage.ID).
 		WithContactIDs([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID, testdb.Dan.ID})
 
-	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, true, 2)
+	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 2)
 
 	// start the first batch...
-	err := tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{FlowStartBatch: batch}, false)
+	batchTask := tasks.BatchTask{BatchOwnerUUID: start.UUID, TotalBatches: 1}
+	err := tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: batchTask, FlowStartBatch: batch}, false)
 	assert.NoError(t, err)
 	testsuite.FlushTasks(t, rt)
 

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -38,12 +37,6 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 	}
 	if imp.Status != models.ImportStatusProcessing {
 		return nil, 0, fmt.Errorf("import is not processing")
-	}
-
-	// set valkey counter which batch tasks can decrement to know when import has completed
-	counter := tasks.NewCounter(fmt.Sprintf("contact_import_batches_remaining:%d", imp.ID), 24*time.Hour)
-	if err := counter.Init(ctx, rt.VK, len(imp.BatchIDs)); err != nil {
-		return nil, 0, fmt.Errorf("error setting import batch counter key: %w", err)
 	}
 
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task


### PR DESCRIPTION
Final stage of moving batch task completion onto the `task_batches` trackers. Now that completion decisions are tracker-driven (#1175), this removes the mechanisms they replaced:

* `is_last` flags on flow start and broadcast batches (`is_first` stays - it drives marking the start/broadcast as *started*, which the tracker can't since it only records completions)
* the `contact_import_batches_remaining` and `populate_group_batches_remaining` counters and their initialization, and the `population_id` field that keyed the latter
* the fallback branches in the batch tasks that used those when tracker state wasn't available
* the temporary fallback to using task IDs as batch owner UUIDs for starts queued before start UUIDs were serialized

`BatchTask.RecordComplete` is simplified to return a single bool now that callers no longer need to distinguish "not the last batch" from "couldn't be determined".

The flow interruption progress counter (`interrupt_flow_progress`) is unchanged - it's read directly by the web app so its key and integer value are a cross-service contract.

⚠️ Should only be deployed once v26.3.30 is deployed and any tasks queued by earlier versions have drained, since batches queued without owner UUIDs and totals will no longer complete their parent object via the removed fallbacks.