### PR TITLE
Rework batch trackers to use per-owner started and batches keys

### DIFF
--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -44,6 +44,23 @@ type BatchTask struct {
 	TotalBatches   int        `json:"total_batches,omitempty"`
 }
 
+// RecordStarted marks processing of this batch's set as started in its owner's tracker and returns whether this was
+// the first batch of the set to start. Tracker errors are logged rather than escalated - the cost is just that the
+// owner is never marked as started.
+func (b *BatchTask) RecordStarted(ctx context.Context, rt *runtime.Runtime) bool {
+	if b.BatchOwnerUUID == "" {
+		return false // shouldn't happen but better than all such batches sharing a tracker
+	}
+
+	first, err := NewBatchTracker(b.BatchOwnerUUID).Started(ctx, rt.VK)
+	if err != nil {
+		slog.Error("error recording batch task start", "error", err, "owner_uuid", b.BatchOwnerUUID)
+		return false
+	}
+
+	return first
+}
+
 // RecordComplete marks this batch as complete in its owner's tracker and returns whether it was the last batch of its
 // set to complete. Tracker errors are logged rather than escalated since the batch's own work has already succeeded -
 // tho in that case completion of the set will never be detected.
@@ -52,13 +69,13 @@ func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, tas
 		return false // shouldn't happen but better than all such batches sharing a tracker
 	}
 
-	completed, total, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID, b.TotalBatches)
+	completed, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID)
 	if err != nil {
 		slog.Error("error recording batch task completion", "error", err, "owner_uuid", b.BatchOwnerUUID)
 		return false
 	}
 
-	return total > 0 && completed >= total
+	return b.TotalBatches > 0 && completed >= b.TotalBatches
 }
 
 // Task is the common interface for all task types

--- a/core/tasks/base_test.go
+++ b/core/tasks/base_test.go
@@ -13,6 +13,24 @@ import (
 // task ID for tests which call Perform directly instead of going through a queue
 const testTaskID = tasks.TaskID("01981fa0-3c74-7d6c-8000-1a2b3c4d5e6f")
 
+func TestRecordStarted(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	// a batch without an owner UUID (shouldn't happen) is never the first of its set
+	noOwner := &tasks.BatchTask{}
+	assert.False(t, noOwner.RecordStarted(ctx, rt))
+
+	b1 := &tasks.BatchTask{BatchOwnerUUID: "8677d4ea-895c-40fd-b6d9-e1eccd7d8ed4", TotalBatches: 3}
+	b2 := &tasks.BatchTask{BatchOwnerUUID: "8677d4ea-895c-40fd-b6d9-e1eccd7d8ed4", TotalBatches: 3}
+
+	// only the first batch of the set to start is told it was first
+	assert.True(t, b1.RecordStarted(ctx, rt))
+	assert.False(t, b1.RecordStarted(ctx, rt))
+	assert.False(t, b2.RecordStarted(ctx, rt))
+}
+
 func TestRecordComplete(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
@@ -34,8 +52,7 @@ func TestRecordComplete(t *testing.T) {
 	// last batch of the set to complete
 	assert.True(t, b.RecordComplete(ctx, rt, "01981fa0-0003-7000-8000-000000000000"))
 
-	// a batch without a total (shouldn't happen) still records completion but can't be considered the last, until a
-	// batch with a total completes
+	// a batch without a total (shouldn't happen) still records completion but can't consider itself the last
 	c1 := &tasks.BatchTask{BatchOwnerUUID: "50d61890-a760-4c00-bd85-c60bb0a5e5b7"}
 	assert.False(t, c1.RecordComplete(ctx, rt, "01981fa0-0004-7000-8000-000000000000"))
 

--- a/core/tasks/send_broadcast_batch.go
+++ b/core/tasks/send_broadcast_batch.go
@@ -57,8 +57,8 @@ func (t *SendBroadcastBatch) Perform(ctx context.Context, rt *runtime.Runtime, o
 		return nil
 	}
 
-	// if this is our first batch, mark as started
-	if t.IsFirst {
+	// if we're the first batch of the set to start, mark the broadcast itself as started
+	if t.RecordStarted(ctx, rt) {
 		if err := bcast.SetStarted(ctx, rt.DB); err != nil {
 			return fmt.Errorf("error marking broadcast as started: %w", err)
 		}

--- a/core/tasks/start_flow_batch.go
+++ b/core/tasks/start_flow_batch.go
@@ -68,8 +68,8 @@ func (t *StartFlowBatch) Perform(ctx context.Context, rt *runtime.Runtime, oa *m
 		return nil
 	}
 
-	// if this is our first batch, mark as started
-	if t.IsFirst {
+	// if we're the first batch of the set to start, mark the start itself as started
+	if t.RecordStarted(ctx, rt) {
 		if err := start.SetStarted(ctx, rt.DB); err != nil {
 			return fmt.Errorf("error marking start as started: %w", err)
 		}

--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -10,46 +10,50 @@ import (
 )
 
 const (
-	batchTrackerKeyBase = "task_batches"
+	batchTrackerKeyBase = "batch_task"
 	batchTrackerTTL     = 24 * time.Hour
 )
 
-// BatchTracker is a Valkey-backed hash for tracking completion of a set of batch tasks split out from an owning task
-// or object. Each batch calls Done with its own task ID and the total number of batches in the set (which all batches
-// carry in their payloads) as it completes. Because completions are recorded as distinct hash fields, marking the same
-// batch as done more than once has no effect, and completion can't be reported before all batches are really done.
+// BatchTracker tracks progress of a set of batch tasks split out from an owning task or object, using two Valkey keys:
+// a simple key marking that processing of the set has started, and a hash of the task IDs of completed batches. Because
+// completions are recorded as distinct hash fields, marking the same batch as done more than once has no effect, and
+// the completed count can't reach the total until all batches are really done.
 type BatchTracker struct {
-	key string
+	startedKey string
+	batchesKey string
 }
 
 // NewBatchTracker creates a tracker for the batches owned by the object or task with the given UUID.
 func NewBatchTracker(ownerUUID uuids.UUID) *BatchTracker {
-	return &BatchTracker{key: fmt.Sprintf("%s:%s", batchTrackerKeyBase, ownerUUID)}
+	return &BatchTracker{
+		startedKey: fmt.Sprintf("%s:%s:started", batchTrackerKeyBase, ownerUUID),
+		batchesKey: fmt.Sprintf("%s:%s:batches", batchTrackerKeyBase, ownerUUID),
+	}
 }
 
-// Done records the batch with the given task ID as complete and returns the number of completed batches and the total,
-// so the caller can tell if it was the first (completed == 1) or last (completed >= total) to complete. A returned
-// total of zero means no batch has yet reported one (e.g. batches queued before totals were added to payloads).
-func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID, total int) (int, int, error) {
+// Started records that processing of the set has started and returns whether this was the first batch to do so.
+func (t *BatchTracker) Started(ctx context.Context, vk *valkey.Pool) (bool, error) {
 	vc := vk.Get()
 	defer vc.Close()
 
-	vals, err := valkey.Ints(trackerDone.DoContext(ctx, vc, t.key, string(taskID), total, int(batchTrackerTTL/time.Second)))
+	reply, err := valkey.DoContext(vc, ctx, "SET", t.startedKey, 1, "NX", "EX", int(batchTrackerTTL/time.Second))
 	if err != nil {
-		return 0, 0, err
+		return false, err
 	}
 
-	return vals[0], vals[1], nil
+	return reply != nil, nil // SET .. NX returns nil if key already existed
+}
+
+// Done records the batch with the given task ID as complete and returns the number of completed batches.
+func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID) (int, error) {
+	vc := vk.Get()
+	defer vc.Close()
+
+	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, string(taskID), int(batchTrackerTTL/time.Second)))
 }
 
 var trackerDone = valkey.NewScript(1, `
 redis.call('HSET', KEYS[1], ARGV[1], 1)
-if tonumber(ARGV[2]) > 0 then
-	redis.call('HSET', KEYS[1], 'total', ARGV[2])
-end
-redis.call('EXPIRE', KEYS[1], ARGV[3])
-local hasTotal = redis.call('HEXISTS', KEYS[1], 'total')
-local completed = redis.call('HLEN', KEYS[1]) - hasTotal
-local total = tonumber(redis.call('HGET', KEYS[1], 'total')) or 0
-return {completed, total}
+redis.call('EXPIRE', KEYS[1], ARGV[2])
+return redis.call('HLEN', KEYS[1])
 `)

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -18,43 +18,39 @@ func TestBatchTracker(t *testing.T) {
 
 	tracker := tasks.NewBatchTracker("7de40d16-0286-4938-be6b-9974e12e1b0f")
 
+	// first batch to start
+	first, err := tracker.Started(ctx, rt.VK)
+	assert.NoError(t, err)
+	assert.True(t, first)
+
+	ttl, err := valkey.Int(vc.Do("TTL", "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:started"))
+	assert.NoError(t, err)
+	assert.Greater(t, ttl, 0)
+
+	// subsequent batches aren't first
+	first, err = tracker.Started(ctx, rt.VK)
+	assert.NoError(t, err)
+	assert.False(t, first)
+
 	// first batch to complete
-	completed, total, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 3)
+	completed, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
-	assert.Equal(t, 3, total)
 
-	ttl, err := valkey.Int(vc.Do("TTL", "task_batches:7de40d16-0286-4938-be6b-9974e12e1b0f"))
+	ttl, err = valkey.Int(vc.Do("TTL", "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:batches"))
 	assert.NoError(t, err)
 	assert.Greater(t, ttl, 0)
 
 	// completing the same batch again changes nothing
-	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 3)
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
-	assert.Equal(t, 3, total)
 
-	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000", 3)
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, completed)
-	assert.Equal(t, 3, total)
 
-	// last batch to complete
-	completed, total, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000", 3)
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, completed)
-	assert.Equal(t, 3, total)
-
-	// batches which don't know their total (queued before totals were added to payloads) still record completion
-	// and report a zero total until a batch which does know it completes
-	other := tasks.NewBatchTracker("50d61890-a760-4c00-bd85-c60bb0a5e5b7")
-	completed, total, err = other.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000", 0)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, completed)
-	assert.Equal(t, 0, total)
-
-	completed, total, err = other.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000", 2)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, completed)
-	assert.Equal(t, 2, total)
 }


### PR DESCRIPTION
Restructures the batch tracker from a single hash with special `total` field into two clearly-scoped keys per owner:

* `batch_task:<owner>:started` - simple key set with `SET .. NX` by the new `BatchTask.RecordStarted`, which returns whether the calling batch was the first of its set to start
* `batch_task:<owner>:batches` - hash of the task IDs of completed batches

The stored total is gone entirely - every batch payload carries `TotalBatches` so `RecordComplete` just compares the completed count against its own payload value.

Flow start and broadcast batches now use `RecordStarted` to decide when to mark their parent as started, instead of the `IsFirst` queue-order flag - meaning the *actually first to start* fires the transition, not the first queued. Creators still write `IsFirst` for one release so batches processed by workers on the previous version still mark their parent as started; the field and `CreateBatch` params can be dropped in a follow-up.

⚠️ Since this renames the tracker keys, batch sets in flight across a deploy would split their completion counts between old and new keys and never complete - so this should be deployed at a quiet moment. That only applies if a version that reads the old keys (v26.3.30+) is actually deployed first; if this rolls out together with the first tracker-reading version there's no window at all.