### PR TITLE
Make batch trackers also count completions recorded under pre-rename keys

### DIFF
--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -21,6 +21,7 @@ const (
 type BatchTracker struct {
 	startedKey string
 	batchesKey string
+	legacyKey  string
 }
 
 // NewBatchTracker creates a tracker for the batches owned by the object or task with the given UUID.
@@ -28,6 +29,7 @@ func NewBatchTracker(ownerUUID uuids.UUID) *BatchTracker {
 	return &BatchTracker{
 		startedKey: fmt.Sprintf("%s:%s:started", batchTrackerKeyBase, ownerUUID),
 		batchesKey: fmt.Sprintf("%s:%s:batches", batchTrackerKeyBase, ownerUUID),
+		legacyKey:  fmt.Sprintf("task_batches:%s", ownerUUID), // TODO: remove once all sets tracked under it have drained
 	}
 }
 
@@ -49,11 +51,19 @@ func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID)
 	vc := vk.Get()
 	defer vc.Close()
 
-	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, string(taskID), int(batchTrackerTTL/time.Second)))
+	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, t.legacyKey, string(taskID), int(batchTrackerTTL/time.Second)))
 }
 
-var trackerDone = valkey.NewScript(1, `
+// completions recorded under the pre-rename key (a hash of task IDs plus a 'total' field) are counted too, so that
+// sets in flight when the rename deployed still complete - and its TTL is refreshed so it outlives even sets that
+// take days to drain from the queue
+var trackerDone = valkey.NewScript(2, `
 redis.call('HSET', KEYS[1], ARGV[1], 1)
 redis.call('EXPIRE', KEYS[1], ARGV[2])
-return redis.call('HLEN', KEYS[1])
+local completed = redis.call('HLEN', KEYS[1])
+if redis.call('EXISTS', KEYS[2]) == 1 then
+	redis.call('EXPIRE', KEYS[2], ARGV[2])
+	completed = completed + redis.call('HLEN', KEYS[2]) - redis.call('HEXISTS', KEYS[2], 'total')
+end
+return completed
 `)

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -53,4 +53,20 @@ func TestBatchTracker(t *testing.T) {
 	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, completed)
+
+	// completions recorded under the pre-rename key are counted too, excluding its 'total' field, and its TTL refreshed
+	vc.Do("HSET", "task_batches:af31b7a8-4a1a-4a71-9a52-1a2b7b39d9b0", "01981fa0-0004-7000-8000-000000000000", 1, "total", 3)
+
+	straddling := tasks.NewBatchTracker("af31b7a8-4a1a-4a71-9a52-1a2b7b39d9b0")
+	completed, err = straddling.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, completed)
+
+	completed, err = straddling.Done(ctx, rt.VK, "01981fa0-0006-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, completed)
+
+	ttl, err = valkey.Int(vc.Do("TTL", "task_batches:af31b7a8-4a1a-4a71-9a52-1a2b7b39d9b0"))
+	assert.NoError(t, err)
+	assert.Greater(t, ttl, 0)
 }


### PR DESCRIPTION
The tracker key rename (#1178) means batch sets in flight across its deploy would have completions split between the old `task_batches:<owner>` hash and the new `batch_task:<owner>:batches` hash, and so never reach their total. That was going to be handled by deploying at a quiet moment, but a large throttled-queue backlog can keep sets in flight for days or weeks, so this makes `Done` transitional instead:

* completions found under the pre-rename key are added to the count (its `total` field excluded) - each batch runs exactly once so every completion lives under exactly one of the two keys and the sum is exact
* the pre-rename key's TTL is refreshed on every `Done` so it outlives sets that take longer than its original 24h TTL to drain from the queue

This makes the rename deployable with no window at all. The legacy-key read should be removed once all sets tracked under the old keys have drained.