### PR TITLE
Remove transitional batch tracker code no longer needed post deploy

### DIFF
--- a/core/models/broadcast.go
+++ b/core/models/broadcast.go
@@ -137,13 +137,11 @@ type BroadcastBatch struct {
 	Broadcast   *Broadcast  `json:"broadcast,omitempty"`
 
 	ContactIDs []ContactID `json:"contact_ids"`
-	IsFirst    bool        `json:"is_first"`
 }
 
-func (b *Broadcast) CreateBatch(contactIDs []ContactID, isFirst bool) *BroadcastBatch {
+func (b *Broadcast) CreateBatch(contactIDs []ContactID) *BroadcastBatch {
 	bb := &BroadcastBatch{
 		ContactIDs: contactIDs,
-		IsFirst:    isFirst,
 	}
 
 	if b.ID != NilBroadcastID {

--- a/core/models/broadcast_test.go
+++ b/core/models/broadcast_test.go
@@ -131,7 +131,7 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 	assert.Equal(t, "", bcast.Query)
 	assert.Equal(t, models.NoExclusions, bcast.Exclusions)
 
-	batch := bcast.CreateBatch([]models.ContactID{testdb.Dan.ID, testdb.Bob.ID}, true)
+	batch := bcast.CreateBatch([]models.ContactID{testdb.Dan.ID, testdb.Bob.ID})
 
 	assert.Equal(t, models.NilBroadcastID, batch.BroadcastID)
 	assert.NotNil(t, testdb.Org1.ID, batch.Broadcast)

--- a/core/models/start.go
+++ b/core/models/start.go
@@ -316,10 +316,9 @@ const sqlInsertStartGroup = `
 INSERT INTO flows_flowstart_groups(flowstart_id, contactgroup_id) VALUES(:flowstart_id, :contactgroup_id)`
 
 // CreateBatch creates a batch for this start using the passed in contact ids
-func (s *FlowStart) CreateBatch(contactIDs []ContactID, isFirst bool, totalContacts int) *FlowStartBatch {
+func (s *FlowStart) CreateBatch(contactIDs []ContactID, totalContacts int) *FlowStartBatch {
 	b := &FlowStartBatch{
 		ContactIDs:    contactIDs,
-		IsFirst:       isFirst,
 		TotalContacts: totalContacts,
 	}
 
@@ -339,7 +338,6 @@ type FlowStartBatch struct {
 	Start   *FlowStart `json:"start,omitempty"`
 
 	ContactIDs    []ContactID `json:"contact_ids"`
-	IsFirst       bool        `json:"is_first"`
 	TotalContacts int         `json:"total_contacts"`
 }
 

--- a/core/models/start_test.go
+++ b/core/models/start_test.go
@@ -68,10 +68,9 @@ func TestStarts(t *testing.T) {
 	require.NoError(t, err)
 	assertdb.Query(t, rt.DB, `SELECT status, contact_count FROM flows_flowstart WHERE id = $1`, startID).Columns(map[string]any{"status": "Q", "contact_count": 5})
 
-	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 3)
+	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, 3)
 	assert.Equal(t, startID, batch.StartID)
 	assert.Equal(t, []models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, batch.ContactIDs)
-	assert.True(t, batch.IsFirst)
 	assert.Equal(t, 3, batch.TotalContacts)
 
 	history, err := models.ReadSessionHistory(start.SessionHistory)

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -633,8 +633,8 @@ func TestBroadcastWithLock(t *testing.T) {
 
 	test.MockUniverse()
 
-	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true)
-	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID}, false)
+	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID})
+	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID})
 
 	scenes, skipped, err := runner.BroadcastWithLock(ctx, rt, oa, bcast, batch1, models.StartModeBackground)
 	assert.NoError(t, err)
@@ -700,7 +700,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast2, err := models.GetBroadcastByID(ctx, rt.DB, b2.ID)
 	require.NoError(t, err)
 
-	skipBatch := bcast2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, true)
+	skipBatch := bcast2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID})
 	scenes, skipped, err = runner.BroadcastWithLock(ctx, rt, oa, bcast2, skipBatch, models.StartModeSkip)
 	assert.NoError(t, err)
 	assert.Len(t, skipped, 0) // all contacts were locked successfully
@@ -723,7 +723,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast3, err := models.GetBroadcastByID(ctx, rt.DB, b3.ID)
 	require.NoError(t, err)
 
-	intBatch := bcast3.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, true)
+	intBatch := bcast3.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID})
 	scenes, skipped, err = runner.BroadcastWithLock(ctx, rt, oa, bcast3, intBatch, models.StartModeInterrupt)
 	assert.NoError(t, err)
 	assert.Len(t, skipped, 0)

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -108,9 +108,7 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	// create tasks for batches of contacts
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
 	for i, idBatch := range idBatches {
-		isFirst := (i == 0)
-
-		batch := bcast.CreateBatch(idBatch, isFirst)
+		batch := bcast.CreateBatch(idBatch)
 		batchTask := &SendBroadcastBatch{
 			BatchTask:      BatchTask{BatchOwnerUUID: uuids.UUID(bcast.UUID), TotalBatches: len(idBatches)},
 			BroadcastBatch: batch,

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -117,10 +117,9 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	idBatches := slices.Collect(slices.Chunk(contactIDs, FlowStartBatchSize))
 
 	for i, idBatch := range idBatches {
-		isFirst := (i == 0)
 		batchTask := &StartFlowBatch{
 			BatchTask:      BatchTask{BatchOwnerUUID: start.UUID, TotalBatches: len(idBatches)},
-			FlowStartBatch: start.CreateBatch(idBatch, isFirst, len(contactIDs)),
+			FlowStartBatch: start.CreateBatch(idBatch, len(contactIDs)),
 		}
 
 		if err := Queue(ctx, rt, q, start.OrgID, batchTask, false); err != nil {

--- a/core/tasks/start_flow_batch_test.go
+++ b/core/tasks/start_flow_batch_test.go
@@ -29,8 +29,8 @@ func TestStartFlowBatchTask(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT status FROM flows_flowstart WHERE id = $1`, start1.ID).Returns("P")
 
 	start1BatchTask := tasks.BatchTask{BatchOwnerUUID: start1.UUID, TotalBatches: 2}
-	batch1 := start1.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 4)
-	batch2 := start1.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, false, 4)
+	batch1 := start1.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, 4)
+	batch2 := start1.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, 4)
 
 	// start the first batch...
 	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: start1BatchTask, FlowStartBatch: batch1}, false)
@@ -66,8 +66,8 @@ func TestStartFlowBatchTask(t *testing.T) {
 	require.NoError(t, err)
 
 	start2BatchTask := tasks.BatchTask{BatchOwnerUUID: start2.UUID, TotalBatches: 2}
-	start2Batch1 := start2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 4)
-	start2Batch2 := start2.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, false, 4)
+	start2Batch1 := start2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, 4)
+	start2Batch2 := start2.CreateBatch([]models.ContactID{testdb.Cat.ID, testdb.Dan.ID}, 4)
 
 	// start the first batch...
 	err = tasks.Queue(ctx, rt, rt.Queues.Throttled, testdb.Org1.ID, &tasks.StartFlowBatch{BatchTask: start2BatchTask, FlowStartBatch: start2Batch1}, false)
@@ -98,7 +98,7 @@ func TestStartFlowBatchTaskNonPersistedStart(t *testing.T) {
 	start := models.NewFlowStart(models.OrgID(1), models.StartTypeManual, testdb.SingleMessage.ID).
 		WithContactIDs([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID, testdb.Dan.ID})
 
-	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, true, 2)
+	batch := start.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, 2)
 
 	// start the first batch...
 	batchTask := tasks.BatchTask{BatchOwnerUUID: start.UUID, TotalBatches: 1}

--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -21,7 +21,6 @@ const (
 type BatchTracker struct {
 	startedKey string
 	batchesKey string
-	legacyKey  string
 }
 
 // NewBatchTracker creates a tracker for the batches owned by the object or task with the given UUID.
@@ -29,7 +28,6 @@ func NewBatchTracker(ownerUUID uuids.UUID) *BatchTracker {
 	return &BatchTracker{
 		startedKey: fmt.Sprintf("%s:%s:started", batchTrackerKeyBase, ownerUUID),
 		batchesKey: fmt.Sprintf("%s:%s:batches", batchTrackerKeyBase, ownerUUID),
-		legacyKey:  fmt.Sprintf("task_batches:%s", ownerUUID), // TODO: remove once all sets tracked under it have drained
 	}
 }
 
@@ -51,19 +49,11 @@ func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID)
 	vc := vk.Get()
 	defer vc.Close()
 
-	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, t.legacyKey, string(taskID), int(batchTrackerTTL/time.Second)))
+	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, string(taskID), int(batchTrackerTTL/time.Second)))
 }
 
-// completions recorded under the pre-rename key (a hash of task IDs plus a 'total' field) are counted too, so that
-// sets in flight when the rename deployed still complete - and its TTL is refreshed so it outlives even sets that
-// take days to drain from the queue
-var trackerDone = valkey.NewScript(2, `
+var trackerDone = valkey.NewScript(1, `
 redis.call('HSET', KEYS[1], ARGV[1], 1)
 redis.call('EXPIRE', KEYS[1], ARGV[2])
-local completed = redis.call('HLEN', KEYS[1])
-if redis.call('EXISTS', KEYS[2]) == 1 then
-	redis.call('EXPIRE', KEYS[2], ARGV[2])
-	completed = completed + redis.call('HLEN', KEYS[2]) - redis.call('HEXISTS', KEYS[2], 'total')
-end
-return completed
+return redis.call('HLEN', KEYS[1])
 `)

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -53,20 +53,4 @@ func TestBatchTracker(t *testing.T) {
 	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, completed)
-
-	// completions recorded under the pre-rename key are counted too, excluding its 'total' field, and its TTL refreshed
-	vc.Do("HSET", "task_batches:af31b7a8-4a1a-4a71-9a52-1a2b7b39d9b0", "01981fa0-0004-7000-8000-000000000000", 1, "total", 3)
-
-	straddling := tasks.NewBatchTracker("af31b7a8-4a1a-4a71-9a52-1a2b7b39d9b0")
-	completed, err = straddling.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000")
-	assert.NoError(t, err)
-	assert.Equal(t, 2, completed)
-
-	completed, err = straddling.Done(ctx, rt.VK, "01981fa0-0006-7000-8000-000000000000")
-	assert.NoError(t, err)
-	assert.Equal(t, 3, completed)
-
-	ttl, err = valkey.Int(vc.Do("TTL", "task_batches:af31b7a8-4a1a-4a71-9a52-1a2b7b39d9b0"))
-	assert.NoError(t, err)
-	assert.Greater(t, ttl, 0)
 }


### PR DESCRIPTION
Final cleanup now that batch completion tracking is fully tracker-driven and all sets tracked under earlier mechanisms have drained:

* Remove the transitional read of pre-rename `task_batches:<owner>` keys from the tracker (#1179) - all sets recorded under them have completed
* Remove the `is_first` flag from flow start and broadcast batches and slim `CreateBatch` - `BatchTask.RecordStarted` has been deciding the started transition since the previous release, and no deployed version reads the flag anymore