### PR TITLE
Change WrapEventHandler to pass the wrapped handler as an arg

### DIFF
--- a/core/runner/events.go
+++ b/core/runner/events.go
@@ -26,15 +26,21 @@ func RegisterEventHandler(eventType string, handler EventHandler) {
 	eventHandlers[eventType] = handler
 }
 
-// WrapEventHandler replaces the handler for the given event type with the one returned by wrap,
-// which receives the current handler so it can delegate to it. This allows extensions to add
-// their own handling of an event type whilst deferring to the existing handler.
-func WrapEventHandler(eventType string, wrap func(base EventHandler) EventHandler) {
+// WrappedEventHandler is like EventHandler but receives the handler it wrapped as its final
+// argument so it can delegate to it.
+type WrappedEventHandler func(context.Context, *runtime.Runtime, *models.OrgAssets, *Scene, events.Event, models.UserID, EventHandler) error
+
+// WrapEventHandler replaces the handler for the given event type with the given handler, which
+// receives the replaced handler as its final argument. This allows extensions to add their own
+// handling of an event type whilst deferring to the existing handler.
+func WrapEventHandler(eventType string, handler WrappedEventHandler) {
 	base := eventHandlers[eventType]
 	if base == nil {
 		panic(fmt.Errorf("no handler registered for type %s to wrap", eventType))
 	}
-	eventHandlers[eventType] = wrap(base)
+	eventHandlers[eventType] = func(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, s *Scene, e events.Event, userID models.UserID) error {
+		return handler(ctx, rt, oa, s, e, userID, base)
+	}
 }
 
 // TypeContactInterrupted is a pseudo event that lets add hooks for session interruption

--- a/core/runner/events_test.go
+++ b/core/runner/events_test.go
@@ -19,11 +19,9 @@ func TestWrapEventHandler(t *testing.T) {
 	})
 	defer delete(eventHandlers, "test_wrap")
 
-	WrapEventHandler("test_wrap", func(base EventHandler) EventHandler {
-		return func(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, s *Scene, e events.Event, userID models.UserID) error {
-			calls = append(calls, "wrapper")
-			return base(ctx, rt, oa, s, e, userID)
-		}
+	WrapEventHandler("test_wrap", func(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, s *Scene, e events.Event, userID models.UserID, base EventHandler) error {
+		calls = append(calls, "wrapper")
+		return base(ctx, rt, oa, s, e, userID)
 	})
 
 	err := eventHandlers["test_wrap"](context.Background(), nil, nil, nil, nil, models.NilUserID)
@@ -32,6 +30,8 @@ func TestWrapEventHandler(t *testing.T) {
 
 	// wrapping a type with no registered handler is a bug
 	assert.Panics(t, func() {
-		WrapEventHandler("test_unregistered", func(base EventHandler) EventHandler { return base })
+		WrapEventHandler("test_unregistered", func(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, s *Scene, e events.Event, userID models.UserID, base EventHandler) error {
+			return base(ctx, rt, oa, s, e, userID)
+		})
 	})
 }


### PR DESCRIPTION
Changes `runner.WrapEventHandler` to take a handler which receives the handler it replaces as its final argument, instead of a function that returns a handler.

This lets extensions write a wrapping handler as a plain named function — same shape as a regular `EventHandler` plus a `base` arg to delegate to, like the `next` parameter in HTTP middleware — with no closure ceremony or package-level state to hold the wrapped handler. Wrapping still composes: a second wrap receives the first wrap's handler as its base.