### PR TITLE
Remove support for opt-ins on broadcasts and messages

### DIFF
--- a/core/crons/fire_schedules_test.go
+++ b/core/crons/fire_schedules_test.go
@@ -22,11 +22,11 @@ func TestFireSchedules(t *testing.T) {
 
 	// add a one-time schedule and tie a broadcast to it
 	s1 := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodNever, time.Now().Add(-2*time.Hour))
-	b1 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", "eng", map[i18n.Language]string{"eng": "Hi", "spa": "Hola"}, nil, s1, []*testdb.Contact{testdb.Ann, testdb.Cat}, nil)
+	b1 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", "eng", map[i18n.Language]string{"eng": "Hi", "spa": "Hola"}, s1, []*testdb.Contact{testdb.Ann, testdb.Cat}, nil)
 
 	// add a repeating schedule and tie another broadcast to it
 	s2 := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodDaily, time.Now().Add(-time.Hour))
-	b2 := testdb.InsertBroadcast(t, rt, testdb.Org1, "01998781-12e7-75ff-b276-404730892c3d", "eng", map[i18n.Language]string{"eng": "Bye", "spa": "Chau"}, nil, s2, nil, []*testdb.Group{testdb.DoctorsGroup})
+	b2 := testdb.InsertBroadcast(t, rt, testdb.Org1, "01998781-12e7-75ff-b276-404730892c3d", "eng", map[i18n.Language]string{"eng": "Bye", "spa": "Chau"}, s2, nil, []*testdb.Group{testdb.DoctorsGroup})
 
 	// add a one-time schedule and tie a trigger to it
 	s3 := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodNever, time.Now().Add(-2*time.Hour))

--- a/core/models/broadcast.go
+++ b/core/models/broadcast.go
@@ -43,7 +43,6 @@ type Broadcast struct {
 	Translations      core.BroadcastTranslations `json:"translations"`
 	BaseLanguage      i18n.Language              `json:"base_language"`
 	Expressions       bool                       `json:"expressions"`
-	OptInID           OptInID                    `json:"optin_id,omitempty"`
 	TemplateID        TemplateID                 `json:"template_id,omitempty"`
 	TemplateVariables []string                   `json:"template_variables,omitempty"`
 	GroupIDs          []GroupID                  `json:"group_ids,omitempty"`
@@ -64,7 +63,6 @@ type dbBroadcast struct {
 	Status            BroadcastStatus                   `db:"status"`
 	Translations      JSONB[core.BroadcastTranslations] `db:"translations"`
 	BaseLanguage      i18n.Language                     `db:"base_language"`
-	OptInID           OptInID                           `db:"optin_id"`
 	TemplateID        TemplateID                        `db:"template_id"`
 	TemplateVariables pq.StringArray                    `db:"template_variables"`
 	URNs              pq.StringArray                    `db:"urns"`
@@ -80,7 +78,7 @@ var ErrNoRecipients = errors.New("can't create broadcast with no recipients")
 
 // NewBroadcast creates a new broadcast with the passed in parameters
 func NewBroadcast(orgID OrgID, translations core.BroadcastTranslations,
-	baseLanguage i18n.Language, expressions bool, optInID OptInID, groupIDs []GroupID, contactIDs []ContactID, urns []urns.URN, query string, exclude Exclusions, createdByID UserID) *Broadcast {
+	baseLanguage i18n.Language, expressions bool, groupIDs []GroupID, contactIDs []ContactID, urns []urns.URN, query string, exclude Exclusions, createdByID UserID) *Broadcast {
 
 	return &Broadcast{
 		UUID:         core.NewBroadcastUUID(),
@@ -89,7 +87,6 @@ func NewBroadcast(orgID OrgID, translations core.BroadcastTranslations,
 		Translations: translations,
 		BaseLanguage: baseLanguage,
 		Expressions:  expressions,
-		OptInID:      optInID,
 		GroupIDs:     groupIDs,
 		ContactIDs:   contactIDs,
 		URNs:         urns,
@@ -124,7 +121,7 @@ func NewBroadcastFromEvent(ctx context.Context, tx DBorTx, oa *OrgAssets, event 
 		}
 	}
 
-	bcast := NewBroadcast(oa.OrgID(), event.Translations, event.BaseLanguage, false, NilOptInID, groupIDs, contactIDs, event.URNs, event.ContactQuery, NoExclusions, NilUserID)
+	bcast := NewBroadcast(oa.OrgID(), event.Translations, event.BaseLanguage, false, groupIDs, contactIDs, event.URNs, event.ContactQuery, NoExclusions, NilUserID)
 	bcast.TemplateID = templateID
 	bcast.TemplateVariables = event.TemplateVariables
 	return bcast, nil
@@ -204,7 +201,6 @@ func InsertBroadcast(ctx context.Context, db DBorTx, bcast *Broadcast) error {
 		Status:            bcast.Status,
 		Translations:      JSONB[core.BroadcastTranslations]{bcast.Translations},
 		BaseLanguage:      bcast.BaseLanguage,
-		OptInID:           bcast.OptInID,
 		TemplateID:        bcast.TemplateID,
 		TemplateVariables: StringArray(bcast.TemplateVariables),
 		URNs:              StringArray(bcast.URNs),
@@ -256,7 +252,6 @@ func InsertChildBroadcast(ctx context.Context, db DBorTx, parent *Broadcast) (*B
 		Translations:      parent.Translations,
 		BaseLanguage:      parent.BaseLanguage,
 		Expressions:       parent.Expressions,
-		OptInID:           parent.OptInID,
 		TemplateID:        parent.TemplateID,
 		TemplateVariables: parent.TemplateVariables,
 		GroupIDs:          parent.GroupIDs,
@@ -283,15 +278,15 @@ type broadcastGroup struct {
 
 const sqlInsertBroadcast = `
 INSERT INTO
-	msgs_broadcast( uuid,  org_id,  parent_id, created_on, modified_on,  status,  translations,  base_language,  template_id,  template_variables,  urns,  query,  node_uuid,  exclusions,  optin_id,  schedule_id, is_active)
-			VALUES(:uuid, :org_id, :parent_id, NOW()     , NOW(),       :status, :translations, :base_language, :template_id, :template_variables, :urns, :query, :node_uuid, :exclusions, :optin_id, :schedule_id,      TRUE)
+	msgs_broadcast( uuid,  org_id,  parent_id, created_on, modified_on,  status,  translations,  base_language,  template_id,  template_variables,  urns,  query,  node_uuid,  exclusions,  schedule_id, is_active)
+			VALUES(:uuid, :org_id, :parent_id, NOW()     , NOW(),       :status, :translations, :base_language, :template_id, :template_variables, :urns, :query, :node_uuid, :exclusions, :schedule_id,      TRUE)
 RETURNING id`
 
 const sqlInsertBroadcastContacts = `INSERT INTO msgs_broadcast_contacts(broadcast_id, contact_id) VALUES(:broadcast_id, :contact_id)`
 const sqlInsertBroadcastGroups = `INSERT INTO msgs_broadcast_groups(broadcast_id, contactgroup_id) VALUES(:broadcast_id, :contactgroup_id)`
 
 const sqlGetBroadcastByID = `
-SELECT id, uuid, org_id, status, translations, base_language, optin_id, template_id, template_variables, created_by_id
+SELECT id, uuid, org_id, status, translations, base_language, template_id, template_variables, created_by_id
   FROM msgs_broadcast 
  WHERE id = $1`
 
@@ -309,7 +304,6 @@ func GetBroadcastByID(ctx context.Context, db DBorTx, bcastID BroadcastID) (*Bro
 		Translations:      b.Translations.V,
 		BaseLanguage:      b.BaseLanguage,
 		Expressions:       true,
-		OptInID:           b.OptInID,
 		TemplateID:        b.TemplateID,
 		TemplateVariables: b.TemplateVariables,
 		CreatedByID:       b.CreatedByID,

--- a/core/models/broadcast_test.go
+++ b/core/models/broadcast_test.go
@@ -24,14 +24,11 @@ func TestBroadcasts(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	optIn := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
-
 	bcast := models.NewBroadcast(
 		testdb.Org1.ID,
 		core.BroadcastTranslations{"eng": {Text: "Hi there"}},
 		"eng",
 		true,
-		optIn.ID,
 		[]models.GroupID{testdb.DoctorsGroup.ID},
 		[]models.ContactID{testdb.Dan.ID, testdb.Bob.ID, testdb.Ann.ID},
 		[]urns.URN{"tel:+593979012345"},
@@ -74,13 +71,12 @@ func TestInsertChildBroadcast(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	optIn := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
 	schedID := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodDaily, time.Now())
-	bcast := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", `eng`, map[i18n.Language]string{`eng`: "Hello"}, optIn, schedID, []*testdb.Contact{testdb.Bob, testdb.Ann}, nil)
+	bcast := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", `eng`, map[i18n.Language]string{`eng`: "Hello"}, schedID, []*testdb.Contact{testdb.Bob, testdb.Ann}, nil)
 
 	var bj json.RawMessage
 	err := rt.DB.GetContext(ctx, &bj, `SELECT ROW_TO_JSON(r) FROM (
-		SELECT id, org_id, translations, base_language, optin_id, template_id, template_variables, query, created_by_id, parent_id FROM msgs_broadcast WHERE id = $1
+		SELECT id, org_id, translations, base_language, template_id, template_variables, query, created_by_id, parent_id FROM msgs_broadcast WHERE id = $1
 	) r`, bcast.ID)
 	require.NoError(t, err)
 
@@ -92,7 +88,6 @@ func TestInsertChildBroadcast(t *testing.T) {
 	assert.Equal(t, parent.ID, child.ParentID)
 	assert.Equal(t, parent.OrgID, child.OrgID)
 	assert.Equal(t, parent.BaseLanguage, child.BaseLanguage)
-	assert.Equal(t, parent.OptInID, child.OptInID)
 	assert.Equal(t, parent.TemplateID, child.TemplateID)
 	assert.Equal(t, parent.TemplateVariables, child.TemplateVariables)
 }
@@ -103,7 +98,6 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	translations := core.BroadcastTranslations{"eng": {Text: "Hi there"}}
-	optIn := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
 
 	// create a broadcast which doesn't actually exist in the DB
 	bcast := models.NewBroadcast(
@@ -111,7 +105,6 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 		translations,
 		"eng",
 		true,
-		optIn.ID,
 		[]models.GroupID{testdb.DoctorsGroup.ID},
 		[]models.ContactID{testdb.Dan.ID, testdb.Bob.ID, testdb.Ann.ID},
 		[]urns.URN{"tel:+593979012345"},
@@ -124,7 +117,6 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 	assert.Equal(t, testdb.Org1.ID, bcast.OrgID)
 	assert.Equal(t, i18n.Language("eng"), bcast.BaseLanguage)
 	assert.Equal(t, translations, bcast.Translations)
-	assert.Equal(t, optIn.ID, bcast.OptInID)
 	assert.Equal(t, []models.GroupID{testdb.DoctorsGroup.ID}, bcast.GroupIDs)
 	assert.Equal(t, []models.ContactID{testdb.Dan.ID, testdb.Bob.ID, testdb.Ann.ID}, bcast.ContactIDs)
 	assert.Equal(t, []urns.URN{"tel:+593979012345"}, bcast.URNs)
@@ -154,7 +146,6 @@ func TestBroadcastSend(t *testing.T) {
 		translations      core.BroadcastTranslations
 		baseLanguage      i18n.Language
 		expressions       bool
-		optInID           models.OptInID
 		templateID        models.TemplateID
 		templateVariables []string
 		expected          []byte
@@ -325,7 +316,6 @@ func TestBroadcastSend(t *testing.T) {
 			Translations:      tc.translations,
 			BaseLanguage:      tc.baseLanguage,
 			Expressions:       tc.expressions,
-			OptInID:           tc.optInID,
 			TemplateID:        tc.templateID,
 			TemplateVariables: tc.templateVariables,
 		}

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -164,7 +164,6 @@ type Msg struct {
 		Text         string                   `db:"text"`
 		Attachments  pq.StringArray           `db:"attachments"`
 		QuickReplies JSONB[[]core.QuickReply] `db:"quickreplies"`
-		OptInID      OptInID                  `db:"optin_id"`
 		Locale       i18n.Locale              `db:"locale"`
 		Templating   *Templating              `db:"templating"`
 
@@ -215,7 +214,6 @@ func (m *Msg) ExternalIdentifier() string    { return string(m.m.ExternalIdentif
 func (m *Msg) MsgCount() int                 { return m.m.MsgCount }
 func (m *Msg) ChannelID() ChannelID          { return m.m.ChannelID }
 func (m *Msg) OrgID() OrgID                  { return m.m.OrgID }
-func (m *Msg) OptInID() OptInID              { return m.m.OptInID }
 func (m *Msg) ContactID() ContactID          { return m.m.ContactID }
 
 func (m *Msg) ContactURNID() URNID         { return m.m.ContactURNID }
@@ -348,20 +346,20 @@ func NewOutgoingIVR(cfg *runtime.Config, orgID OrgID, call *Call, flow *Flow, ev
 func NewOutgoingFlowMsg(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact, flow *Flow, event *events.MsgCreated, replyTo *MsgInRef) (*MsgOut, error) {
 	highPriority := replyTo != nil
 
-	return newMsgOut(rt, org, channel, contact, event, flow, NilBroadcastID, NilOptInID, NilUserID, replyTo, highPriority)
+	return newMsgOut(rt, org, channel, contact, event, flow, NilBroadcastID, NilUserID, replyTo, highPriority)
 }
 
 // NewOutgoingBroadcastMsg creates an outgoing message which is part of a broadcast
 func NewOutgoingBroadcastMsg(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact, event *events.MsgCreated, b *Broadcast) (*MsgOut, error) {
-	return newMsgOut(rt, org, channel, contact, event, nil, b.ID, b.OptInID, b.CreatedByID, nil, false)
+	return newMsgOut(rt, org, channel, contact, event, nil, b.ID, b.CreatedByID, nil, false)
 }
 
 // NewOutgoingChatMsg creates an outgoing message from chat
 func NewOutgoingChatMsg(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact, event *events.MsgCreated, userID UserID) (*MsgOut, error) {
-	return newMsgOut(rt, org, channel, contact, event, nil, NilBroadcastID, NilOptInID, userID, nil, true)
+	return newMsgOut(rt, org, channel, contact, event, nil, NilBroadcastID, userID, nil, true)
 }
 
-func newMsgOut(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact, event *events.MsgCreated, flow *Flow, broadcastID BroadcastID, optInID OptInID, userID UserID, replyTo *MsgInRef, highPriority bool) (*MsgOut, error) {
+func newMsgOut(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact, event *events.MsgCreated, flow *Flow, broadcastID BroadcastID, userID UserID, replyTo *MsgInRef, highPriority bool) (*MsgOut, error) {
 	out := event.Msg
 
 	msg := &Msg{}
@@ -374,7 +372,6 @@ func newMsgOut(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact
 	m.Text = out.Text()
 	m.Locale = out.Locale()
 	m.QuickReplies = JSONB[[]core.QuickReply]{out.QuickReplies()}
-	m.OptInID = optInID
 	m.HighPriority = highPriority
 	m.Direction = DirectionOut
 	m.Status = MsgStatusQueued
@@ -454,7 +451,6 @@ SELECT
 	broadcast_id,
 	flow_id,
 	ticket_uuid,
-	optin_id,
 	text,
 	attachments,
 	quickreplies,
@@ -495,7 +491,6 @@ SELECT
 	m.broadcast_id,
 	m.flow_id,
 	m.ticket_uuid,
-	m.optin_id,
 	m.text,
 	m.attachments,
 	m.quickreplies,
@@ -585,10 +580,10 @@ const sqlInsertMsgSQL = `
 INSERT INTO
 msgs_msg(uuid, text, attachments, quickreplies, locale, templating, high_priority, created_on, modified_on, sent_on, direction, status,
 		 visibility, msg_type, msg_count, error_count, next_attempt, failed_reason, channel_id, is_android,
-		 contact_id, contact_urn_id, org_id, flow_id, broadcast_id, ticket_uuid, optin_id, created_by_id)
+		 contact_id, contact_urn_id, org_id, flow_id, broadcast_id, ticket_uuid, created_by_id)
   VALUES(:uuid, :text, :attachments, :quickreplies, :locale, :templating, :high_priority, :created_on, now(), :sent_on, :direction, :status,
 		 :visibility, :msg_type, :msg_count, :error_count, :next_attempt, :failed_reason, :channel_id, :is_android,
-		 :contact_id, :contact_urn_id, :org_id, :flow_id, :broadcast_id, :ticket_uuid, :optin_id, :created_by_id)
+		 :contact_id, :contact_urn_id, :org_id, :flow_id, :broadcast_id, :ticket_uuid, :created_by_id)
 RETURNING id, modified_on`
 
 // MarkMessageHandled updates a message after handling

--- a/core/models/schedule.go
+++ b/core/models/schedule.go
@@ -303,7 +303,6 @@ SELECT ROW_TO_JSON(s) FROM (
                 b.translations,
                 b.base_language,
                 TRUE AS expressions,
-                b.optin_id,
                 b.template_id,
                 b.template_variables,
                 (SELECT ARRAY_AGG(bc.contact_id) FROM (SELECT contact_id FROM msgs_broadcast_contacts WHERE broadcast_id = b.id) bc) AS contact_ids,

--- a/core/models/schedule_test.go
+++ b/core/models/schedule_test.go
@@ -90,12 +90,10 @@ func TestGetExpired(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
-	optIn := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
-
 	// add a schedule and tie a broadcast to it
 	s1 := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodNever, time.Now().Add(-24*time.Hour))
 
-	testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", "eng", map[i18n.Language]string{"eng": "Test message", "fra": "Un Message"}, optIn, s1,
+	testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", "eng", map[i18n.Language]string{"eng": "Test message", "fra": "Un Message"}, s1,
 		[]*testdb.Contact{testdb.Ann, testdb.Cat}, []*testdb.Group{testdb.DoctorsGroup},
 	)
 
@@ -134,7 +132,6 @@ func TestGetExpired(t *testing.T) {
 	assert.Equal(t, "Test message", bcast.Translations["eng"].Text)
 	assert.Equal(t, "Un Message", bcast.Translations["fra"].Text)
 	assert.True(t, bcast.Expressions)
-	assert.Equal(t, optIn.ID, bcast.OptInID)
 	assert.Equal(t, testdb.Org1.ID, bcast.OrgID)
 	assert.Equal(t, []models.ContactID{testdb.Ann.ID, testdb.Cat.ID}, bcast.ContactIDs)
 	assert.Equal(t, []models.GroupID{testdb.DoctorsGroup.ID}, bcast.GroupIDs)

--- a/core/msgio/courier.go
+++ b/core/msgio/courier.go
@@ -145,11 +145,6 @@ func NewCourierMsg(oa *models.OrgAssets, mo *models.MsgOut, ch *models.Channel) 
 		msg.Origin = MsgOriginChat
 	}
 
-	if mo.OptInID() != models.NilOptInID {
-		// an optin on a broadcast message means use it for authentication
-		msg.URNAuth = mo.URN.AuthTokens[fmt.Sprintf("optin:%d", mo.OptInID())]
-	}
-
 	if mo.Templating() != nil {
 		tpl := oa.TemplateByUUID(mo.Templating().Template.UUID)
 		if tpl != nil {

--- a/core/msgio/courier_test.go
+++ b/core/msgio/courier_test.go
@@ -27,15 +27,14 @@ func TestNewCourierMsg(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo)
 
-	// create an opt-in and a new contact with an auth token for it
-	optInID := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Joke Of The Day").ID
+	// create a new contact with a URN with an auth token
 	testFred := testdb.InsertContact(t, rt, testdb.Org1, "fed2d179-73ac-44fd-b838-7f866fef0a3a", "Fred", "eng", models.ContactStatusActive)
-	testdb.InsertContactURN(t, rt, testdb.Org1, testFred, "tel:+593979123456", 1000, map[string]string{fmt.Sprintf("optin:%d", optInID): "sesame"})
+	testdb.InsertContactURN(t, rt, testdb.Org1, testFred, "tel:+593979123456", 1000, map[string]string{"default": "sesame"})
 
 	// add a second URN to Ann so we can test other_urns
 	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, "whatsapp:16055741111", 100, nil)
 
-	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOptIns)
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 	require.False(t, oa.Org().Suspended())
 
@@ -153,13 +152,13 @@ func TestNewCourierMsg(t *testing.T) {
 	}`, string(jsonx.MustMarshal(msgEvent2.CreatedOn().In(time.UTC))), session.UUID(), sprint.UUID(), msg2.UUID()))
 
 	// try a broadcast message which won't have session and flow fields set and won't be high priority
-	bcast := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", `eng`, map[i18n.Language]string{`eng`: "Blast"}, nil, models.NilScheduleID, []*testdb.Contact{testFred}, nil)
+	bcast := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", `eng`, map[i18n.Language]string{`eng`: "Blast"}, models.NilScheduleID, []*testdb.Contact{testFred}, nil)
 	msgEvent3 := events.NewMsgCreated(
 		core.NewMsgOut(fredURN, assets.NewChannelReference(testdb.TwilioChannel.UUID, "Test Channel"), &core.MsgContent{Text: "Blast"}, nil, i18n.NilLocale, ""),
 		bcast.UUID,
 		"",
 	)
-	msg3, err := models.NewOutgoingBroadcastMsg(rt, oa.Org(), twilio, fred, msgEvent3, &models.Broadcast{ID: bcast.ID, OptInID: optInID, CreatedByID: testdb.Admin.ID})
+	msg3, err := models.NewOutgoingBroadcastMsg(rt, oa.Org(), twilio, fred, msgEvent3, &models.Broadcast{ID: bcast.ID, CreatedByID: testdb.Admin.ID})
 	require.NoError(t, err)
 
 	err = models.InsertMessages(ctx, rt.DB, []*models.Msg{msg3.Msg})

--- a/core/runner/handlers/msg_created_test.go
+++ b/core/runner/handlers/msg_created_test.go
@@ -30,7 +30,7 @@ func TestMsgCreated(t *testing.T) {
 	rt.DB.MustExec(`UPDATE contacts_contacturn SET identity = 'facebook:12345', path='12345', scheme='facebook' WHERE contact_id = $1`, testdb.Dan.ID)
 	rt.DB.MustExec(`UPDATE contacts_contact SET language='eng' WHERE id = $1`, testdb.Dan.ID)
 
-	testdb.InsertBroadcast(t, rt, testdb.Org1, "01999b42-f414-7161-8814-fbef26d9d0d3", "eng", map[i18n.Language]string{"eng": "Cats or dogs?"}, nil, models.NilScheduleID, nil, nil)
+	testdb.InsertBroadcast(t, rt, testdb.Org1, "01999b42-f414-7161-8814-fbef26d9d0d3", "eng", map[i18n.Language]string{"eng": "Cats or dogs?"}, models.NilScheduleID, nil, nil)
 
 	runTests(t, rt, "testdata/msg_created.json")
 

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -626,7 +626,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
-	b1 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", "eng", map[i18n.Language]string{"eng": "Hi", "spa": "Hola"}, nil, models.NilScheduleID, []*testdb.Contact{testdb.Ann, testdb.Bob, testdb.Cat}, nil)
+	b1 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", "eng", map[i18n.Language]string{"eng": "Hi", "spa": "Hola"}, models.NilScheduleID, []*testdb.Contact{testdb.Ann, testdb.Bob, testdb.Cat}, nil)
 
 	bcast, err := models.GetBroadcastByID(ctx, rt.DB, b1.ID)
 	require.NoError(t, err)
@@ -696,7 +696,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)
 
 	// test skip mode: Ann and Bob have sessions so should be skipped, Cat should receive
-	b2 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401d", "eng", map[i18n.Language]string{"eng": "Skippable"}, nil, models.NilScheduleID, []*testdb.Contact{testdb.Ann, testdb.Bob, testdb.Cat}, nil)
+	b2 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401d", "eng", map[i18n.Language]string{"eng": "Skippable"}, models.NilScheduleID, []*testdb.Contact{testdb.Ann, testdb.Bob, testdb.Cat}, nil)
 	bcast2, err := models.GetBroadcastByID(ctx, rt.DB, b2.ID)
 	require.NoError(t, err)
 
@@ -719,7 +719,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	testsuite.AssertContactInFlow(t, rt, testdb.Bob, testdb.Favorites)
 
 	// test interrupt mode: Ann and Bob have sessions which should be interrupted, all should receive
-	b3 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401e", "eng", map[i18n.Language]string{"eng": "Interrupting"}, nil, models.NilScheduleID, []*testdb.Contact{testdb.Ann, testdb.Bob, testdb.Cat}, nil)
+	b3 := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401e", "eng", map[i18n.Language]string{"eng": "Interrupting"}, models.NilScheduleID, []*testdb.Contact{testdb.Ann, testdb.Bob, testdb.Cat}, nil)
 	bcast3, err := models.GetBroadcastByID(ctx, rt.DB, b3.ID)
 	require.NoError(t, err)
 

--- a/core/tasks/bulk_campaign_trigger.go
+++ b/core/tasks/bulk_campaign_trigger.go
@@ -160,7 +160,7 @@ func (t *BulkCampaignTrigger) triggerFlow(ctx context.Context, rt *runtime.Runti
 }
 
 func (t *BulkCampaignTrigger) triggerBroadcast(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, p *models.CampaignPoint, contactIDs []models.ContactID) ([]models.ContactID, error) {
-	bcast := models.NewBroadcast(oa.OrgID(), p.Translations, i18n.Language(p.BaseLanguage), true, models.NilOptInID, nil, contactIDs, nil, "", models.NoExclusions, models.NilUserID)
+	bcast := models.NewBroadcast(oa.OrgID(), p.Translations, i18n.Language(p.BaseLanguage), true, nil, contactIDs, nil, "", models.NoExclusions, models.NilUserID)
 	bcast.TemplateID = p.TemplateID
 	bcast.TemplateVariables = p.TemplateVariables
 

--- a/core/tasks/send_broadcast_test.go
+++ b/core/tasks/send_broadcast_test.go
@@ -1,7 +1,6 @@
 package tasks_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -179,13 +178,9 @@ func TestSendBroadcastTask(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
-	// add an "Polls" optin and opt-in Bob
-	polls := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
-	rt.DB.MustExec(fmt.Sprintf("UPDATE contacts_contacturn SET auth_tokens = '{\"optin:%d\": \"OPTIN1234\"}' WHERE contact_id = $1", polls.ID), testdb.Bob.ID)
-
 	rt.DB.MustExec(`UPDATE orgs_org SET flow_languages = '{"eng", "spa"}' WHERE id = $1`, testdb.Org1.ID)
 
-	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg|models.RefreshOptIns)
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg)
 	assert.NoError(t, err)
 
 	// add an extra URN for Ann, change Cat's language to Spanish, and mark Bob as seen recently
@@ -199,7 +194,6 @@ func TestSendBroadcastTask(t *testing.T) {
 		translations    core.BroadcastTranslations
 		baseLanguage    i18n.Language
 		expressions     bool
-		optIn           *testdb.OptIn
 		groupIDs        []models.GroupID
 		contactIDs      []models.ContactID
 		URNs            []urns.URN
@@ -216,7 +210,6 @@ func TestSendBroadcastTask(t *testing.T) {
 			},
 			baseLanguage:    "eng",
 			expressions:     false,
-			optIn:           polls,
 			groupIDs:        []models.GroupID{testdb.DoctorsGroup.ID},
 			contactIDs:      []models.ContactID{testdb.Ann.ID, testdb.Bob.ID},
 			exclusions:      models.NoExclusions,
@@ -270,12 +263,7 @@ func TestSendBroadcastTask(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	for i, tc := range tcs {
-		var optInID models.OptInID
-		if tc.optIn != nil {
-			optInID = tc.optIn.ID
-		}
-
-		bcast := models.NewBroadcast(oa.OrgID(), tc.translations, tc.baseLanguage, tc.expressions, optInID, tc.groupIDs, tc.contactIDs, tc.URNs, tc.query, tc.exclusions, tc.createdByID)
+		bcast := models.NewBroadcast(oa.OrgID(), tc.translations, tc.baseLanguage, tc.expressions, tc.groupIDs, tc.contactIDs, tc.URNs, tc.query, tc.exclusions, tc.createdByID)
 		err := models.InsertBroadcast(ctx, rt.DB, bcast)
 		assert.NoError(t, err)
 
@@ -302,10 +290,6 @@ func TestSendBroadcastTask(t *testing.T) {
 		}
 
 		assert.Equal(t, tc.expectedMsgs, actualMsgs, "%d: msg count mismatch", i)
-
-		if tc.optIn != nil {
-			assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE org_id = 1 AND created_on > $1 AND optin_id = $2`, lastNow, optInID)
-		}
 
 		lastNow = time.Now()
 		time.Sleep(5 * time.Millisecond)

--- a/testsuite/testdb/msgs.go
+++ b/testsuite/testdb/msgs.go
@@ -112,21 +112,16 @@ func insertOutgoingMsg(t *testing.T, rt *runtime.Runtime, org *Org, uuid events.
 	return &MsgOut{Msg: Msg{ID: id, UUID: uuid}, FlowMsg: fm}
 }
 
-func InsertBroadcast(t *testing.T, rt *runtime.Runtime, org *Org, uuid core.BroadcastUUID, baseLanguage i18n.Language, text map[i18n.Language]string, optIn *OptIn, schedID models.ScheduleID, contacts []*Contact, groups []*Group) *Broadcast {
+func InsertBroadcast(t *testing.T, rt *runtime.Runtime, org *Org, uuid core.BroadcastUUID, baseLanguage i18n.Language, text map[i18n.Language]string, schedID models.ScheduleID, contacts []*Contact, groups []*Group) *Broadcast {
 	translations := make(core.BroadcastTranslations)
 	for lang, t := range text {
 		translations[lang] = &core.MsgContent{Text: t}
 	}
 
-	var optInID models.OptInID
-	if optIn != nil {
-		optInID = optIn.ID
-	}
-
 	var id models.BroadcastID
 	err := rt.DB.Get(&id,
-		`INSERT INTO msgs_broadcast(uuid, org_id, base_language, translations, optin_id, schedule_id, status, created_on, modified_on, created_by_id, modified_by_id, is_active)
-		VALUES($1, $2, $3, $4, $5, $6, 'P', NOW(), NOW(), 1, 1, TRUE) RETURNING id`, uuid, org.ID, baseLanguage, models.JSONB[core.BroadcastTranslations]{V: translations}, optInID, schedID,
+		`INSERT INTO msgs_broadcast(uuid, org_id, base_language, translations, schedule_id, status, created_on, modified_on, created_by_id, modified_by_id, is_active)
+		VALUES($1, $2, $3, $4, $5, 'P', NOW(), NOW(), 1, 1, TRUE) RETURNING id`, uuid, org.ID, baseLanguage, models.JSONB[core.BroadcastTranslations]{V: translations}, schedID,
 	)
 	require.NoError(t, err)
 

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -82,9 +82,6 @@ func TestBroadcast(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
-	optIn := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
-	require.Equal(t, models.OptInID(30000), optIn.ID)
-
 	createRun := func(org *testdb.Org, contact *testdb.Contact, nodeUUID core.NodeUUID) {
 		sessionUUID := testdb.InsertFlowSession(t, rt, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil, testdb.Favorites)
 		testdb.InsertFlowRun(t, rt, org, sessionUUID, contact, testdb.Favorites, models.RunStatusWaiting, nodeUUID)

--- a/web/msg/broadcast.go
+++ b/web/msg/broadcast.go
@@ -27,7 +27,6 @@ func init() {
 //	  "user_id": 56,
 //	  "translations": {"eng": {"text": "Hello @contact"}, "spa": {"text": "Hola @contact"}},
 //	  "base_language": "eng",
-//	  "optin_id": 456,
 //	  "group_ids": [101, 102],
 //	  "contact_ids": [4646],
 //	  "urns": [4646],
@@ -42,7 +41,6 @@ type broadcastRequest struct {
 	UserID            models.UserID              `json:"user_id"       validate:"required"`
 	Translations      core.BroadcastTranslations `json:"translations"  validate:"required"`
 	BaseLanguage      i18n.Language              `json:"base_language" validate:"required"`
-	OptInID           models.OptInID             `json:"optin_id"`
 	TemplateID        models.TemplateID          `json:"template_id"`
 	TemplateVariables []string                   `json:"template_variables"`
 	GroupIDs          []models.GroupID           `json:"group_ids"`
@@ -81,7 +79,6 @@ func handleBroadcast(ctx context.Context, rt *runtime.Runtime, r *broadcastReque
 		Translations:      r.Translations,
 		BaseLanguage:      r.BaseLanguage,
 		Expressions:       true,
-		OptInID:           r.OptInID,
 		TemplateID:        r.TemplateID,
 		TemplateVariables: r.TemplateVariables,
 		GroupIDs:          r.GroupIDs,

--- a/web/msg/testdata/broadcast.json
+++ b/web/msg/testdata/broadcast.json
@@ -67,7 +67,6 @@
                 "tel:+1234567890"
             ],
             "query": "age > 20",
-            "optin_id": 30000,
             "template_id": 10000,
             "template_variables": [
                 "@contact"
@@ -79,7 +78,7 @@
         },
         "db_assertions": [
             {
-                "query": "SELECT count(*) FROM msgs_broadcast WHERE status = 'P' AND translations-\u003e'eng'-\u003e\u003e'text' = 'Hello' AND base_language = 'eng' AND urns = '{\"tel:+1234567890\"}' AND query = 'age \u003e 20' AND optin_id = 30000 AND template_id = 10000 AND template_variables = '{\"@contact\"}'",
+                "query": "SELECT count(*) FROM msgs_broadcast WHERE status = 'P' AND translations-\u003e'eng'-\u003e\u003e'text' = 'Hello' AND base_language = 'eng' AND urns = '{\"tel:+1234567890\"}' AND query = 'age \u003e 20' AND template_id = 10000 AND template_variables = '{\"@contact\"}'",
                 "returns": 1
             },
             {
@@ -107,7 +106,6 @@
                         },
                         "base_language": "eng",
                         "expressions": true,
-                        "optin_id": 30000,
                         "template_id": 10000,
                         "template_variables": [
                             "@contact"


### PR DESCRIPTION
Since `request_optin` no longer creates messages, the only remaining users of opt-ins on outgoing messages were broadcasts created with an opt-in, and the courier path that swapped in the opt-in's URN auth token when (re)sending those messages. Both go away here.

## What changed

- `Msg.OptInID` field and accessor removed, along with `optin_id` from the msg insert and the two msg select queries
- `Broadcast.OptInID` removed throughout: struct, db struct, `NewBroadcast` signature, insert/select SQL, `InsertChildBroadcast`, `GetBroadcastByID`, and the unfired-schedules query
- Courier no longer overrides `urn_auth` with an opt-in token — outgoing messages use the URN's `default` auth token only
- `optin_id` dropped from the `POST /msg/broadcast` request payload
- `testdb.InsertBroadcast` loses its opt-in parameter

Opt-in assets, `optin`/`optout` channel events and their triggers, and the `optins` channel feature are untouched — those are about channel-level opt-in state, not message sending.

## Notes for reviewers

- The `msgs_msg.optin_id` and `msgs_broadcast.optin_id` columns are simply no longer read or written; dropping them is a separate schema change.
- The broadcast endpoint ignores unknown JSON fields, so a caller still sending `optin_id` won't error — it just has no effect.
- Any opt-in messages already queued or awaiting retry will now be sent with the default URN auth token rather than the per-opt-in one.