### PR TITLE
Claim WhatsApp BSUID URNs from shell contacts when appending to another contact

### DIFF
--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -914,17 +914,17 @@ func CreateOrClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID C
 	return urn, nil
 }
 
-const sqlDetachShellContactURN = `
+const sqlReassignShellContactURN = `
 UPDATE contacts_contacturn
-   SET contact_id = NULL
+   SET contact_id = $3
  WHERE id = $1 AND contact_id = $2
    AND NOT EXISTS(SELECT 1 FROM contacts_contacturn o WHERE o.contact_id = $2 AND o.id != $1)`
 
-// DetachShellContactURN checks if the given URN identity is owned by a contact other than the given one, and if that
-// owner is a "shell" - a contact with no other URNs - detaches the URN so that it can be claimed by the given contact.
-// The shell contact keeps its history but is left without URNs, and has its modified_on bumped so it's re-indexed.
-// Returns the ID of the owning contact if there is a different owner, and whether the URN was detached from it.
-func DetachShellContactURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (ContactID, bool, error) {
+// ReassignShellContactURN checks if the given URN identity is owned by a contact other than the given one, and if that
+// owner is a "shell" - a contact with no other URNs - reassigns the URN to the given contact. The shell contact keeps
+// its history but is left without URNs, and both contacts have modified_on bumped so they're re-indexed. Returns the
+// ID of the owning contact if there is a different owner, and whether the URN was reassigned from it.
+func ReassignShellContactURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (ContactID, bool, error) {
 	rows, err := db.QueryxContext(ctx, sqlSelectURNByIdentity, u.Identity(), oa.OrgID())
 	if err != nil {
 		return NilContactID, false, fmt.Errorf("error selecting URN by identity: %s", u.Identity())
@@ -943,21 +943,21 @@ func DetachShellContactURN(ctx context.Context, db DBorTx, oa *OrgAssets, contac
 		return NilContactID, false, nil
 	}
 
-	// only detaches if the owner still has no other URNs
-	res, err := db.ExecContext(ctx, sqlDetachShellContactURN, urn.ID, urn.ContactID)
+	// only reassigns if the owner still has no other URNs
+	res, err := db.ExecContext(ctx, sqlReassignShellContactURN, urn.ID, urn.ContactID, contactID)
 	if err != nil {
-		return urn.ContactID, false, fmt.Errorf("error detaching URN from shell contact: %w", err)
+		return urn.ContactID, false, fmt.Errorf("error reassigning URN from shell contact: %w", err)
 	}
-	numDetached, err := res.RowsAffected()
+	numReassigned, err := res.RowsAffected()
 	if err != nil {
-		return urn.ContactID, false, fmt.Errorf("error getting number of detached URNs: %w", err)
+		return urn.ContactID, false, fmt.Errorf("error getting number of reassigned URNs: %w", err)
 	}
-	if numDetached == 0 {
+	if numReassigned == 0 {
 		return urn.ContactID, false, nil
 	}
 
-	if err := UpdateContactModifiedOn(ctx, db, []ContactID{urn.ContactID}); err != nil {
-		return urn.ContactID, true, fmt.Errorf("error updating modified_on for shell contact: %w", err)
+	if err := UpdateContactModifiedOn(ctx, db, []ContactID{urn.ContactID, contactID}); err != nil {
+		return urn.ContactID, true, fmt.Errorf("error updating modified_on for contacts: %w", err)
 	}
 
 	return urn.ContactID, true, nil

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -914,6 +914,55 @@ func CreateOrClaimURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID C
 	return urn, nil
 }
 
+const sqlDetachShellContactURN = `
+UPDATE contacts_contacturn
+   SET contact_id = NULL
+ WHERE id = $1 AND contact_id = $2
+   AND NOT EXISTS(SELECT 1 FROM contacts_contacturn o WHERE o.contact_id = $2 AND o.id != $1)`
+
+// DetachShellContactURN checks if the given URN identity is owned by a contact other than the given one, and if that
+// owner is a "shell" - a contact with no other URNs - detaches the URN so that it can be claimed by the given contact.
+// The shell contact keeps its history but is left without URNs, and has its modified_on bumped so it's re-indexed.
+// Returns the ID of the owning contact if there is a different owner, and whether the URN was detached from it.
+func DetachShellContactURN(ctx context.Context, db DBorTx, oa *OrgAssets, contactID ContactID, u urns.URN) (ContactID, bool, error) {
+	rows, err := db.QueryxContext(ctx, sqlSelectURNByIdentity, u.Identity(), oa.OrgID())
+	if err != nil {
+		return NilContactID, false, fmt.Errorf("error selecting URN by identity: %s", u.Identity())
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return NilContactID, false, nil
+	}
+
+	urn := &ContactURN{}
+	if err := rows.StructScan(urn); err != nil {
+		return NilContactID, false, fmt.Errorf("error scanning contact urn: %w", err)
+	}
+	if urn.ContactID == NilContactID || urn.ContactID == contactID {
+		return NilContactID, false, nil
+	}
+
+	// only detaches if the owner still has no other URNs
+	res, err := db.ExecContext(ctx, sqlDetachShellContactURN, urn.ID, urn.ContactID)
+	if err != nil {
+		return urn.ContactID, false, fmt.Errorf("error detaching URN from shell contact: %w", err)
+	}
+	numDetached, err := res.RowsAffected()
+	if err != nil {
+		return urn.ContactID, false, fmt.Errorf("error getting number of detached URNs: %w", err)
+	}
+	if numDetached == 0 {
+		return urn.ContactID, false, nil
+	}
+
+	if err := UpdateContactModifiedOn(ctx, db, []ContactID{urn.ContactID}); err != nil {
+		return urn.ContactID, true, fmt.Errorf("error updating modified_on for shell contact: %w", err)
+	}
+
+	return urn.ContactID, true, nil
+}
+
 // CalculateDynamicGroups recalculates all the dynamic groups for the passed in contact, recalculating
 // campaigns as necessary based on those group changes.
 func CalculateDynamicGroups(ctx context.Context, db DBorTx, oa *OrgAssets, contacts []*core.Contact) error {

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -632,7 +632,7 @@ func TestUpdateContactURNs(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn`).Returns(numInitialURNs + 3)
 }
 
-func TestDetachShellContactURN(t *testing.T) {
+func TestReassignShellContactURN(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
 	defer testsuite.Reset(t, rt, testsuite.ResetData)
@@ -648,39 +648,42 @@ func TestDetachShellContactURN(t *testing.T) {
 	testdb.InsertContactURN(t, rt, testdb.Org1, other, "tel:+16055747777", 1000, nil)
 	otherURNID := testdb.InsertContactURN(t, rt, testdb.Org1, other, "whatsapp:US.D4E5F6", 999, nil)
 
-	var shellModifiedOn time.Time
+	var shellModifiedOn, annModifiedOn time.Time
 	require.NoError(t, rt.DB.Get(&shellModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
+	require.NoError(t, rt.DB.Get(&annModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Ann.ID))
 
 	// noop if URN doesn't exist
-	ownerID, detached, err := models.DetachShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.XXXXXX")
+	ownerID, reassigned, err := models.ReassignShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.XXXXXX")
 	assert.NoError(t, err)
 	assert.Equal(t, models.NilContactID, ownerID)
-	assert.False(t, detached)
+	assert.False(t, reassigned)
 
 	// noop if URN is already owned by the given contact
-	ownerID, detached, err = models.DetachShellContactURN(ctx, rt.DB, oa, shell.ID, "whatsapp:US.A1B2C3")
+	ownerID, reassigned, err = models.ReassignShellContactURN(ctx, rt.DB, oa, shell.ID, "whatsapp:US.A1B2C3")
 	assert.NoError(t, err)
 	assert.Equal(t, models.NilContactID, ownerID)
-	assert.False(t, detached)
+	assert.False(t, reassigned)
 
-	// URN owned by a contact with other URNs isn't detached
-	ownerID, detached, err = models.DetachShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.D4E5F6")
+	// URN owned by a contact with other URNs isn't reassigned
+	ownerID, reassigned, err = models.ReassignShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.D4E5F6")
 	assert.NoError(t, err)
 	assert.Equal(t, other.ID, ownerID)
-	assert.False(t, detached)
+	assert.False(t, reassigned)
 	assertdb.Query(t, rt.DB, `SELECT contact_id FROM contacts_contacturn WHERE id = $1`, otherURNID).Returns(int64(other.ID))
 
-	// URN owned by a shell contact is detached and the shell's modified_on is bumped
-	ownerID, detached, err = models.DetachShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.A1B2C3")
+	// URN owned by a shell contact is reassigned and both contacts have modified_on bumped
+	ownerID, reassigned, err = models.ReassignShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.A1B2C3")
 	assert.NoError(t, err)
 	assert.Equal(t, shell.ID, ownerID)
-	assert.True(t, detached)
-	assertdb.Query(t, rt.DB, `SELECT contact_id FROM contacts_contacturn WHERE id = $1`, shellURNID).Returns(nil)
+	assert.True(t, reassigned)
+	assertdb.Query(t, rt.DB, `SELECT contact_id FROM contacts_contacturn WHERE id = $1`, shellURNID).Returns(int64(testdb.Ann.ID))
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, shell.ID).Returns(0)
 
-	var newShellModifiedOn time.Time
-	require.NoError(t, rt.DB.Get(&newShellModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
-	assert.True(t, newShellModifiedOn.After(shellModifiedOn))
+	var newModifiedOn time.Time
+	require.NoError(t, rt.DB.Get(&newModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
+	assert.True(t, newModifiedOn.After(shellModifiedOn))
+	require.NoError(t, rt.DB.Get(&newModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Ann.ID))
+	assert.True(t, newModifiedOn.After(annModifiedOn))
 }
 
 func TestLoadContactURNs(t *testing.T) {

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -632,6 +632,57 @@ func TestUpdateContactURNs(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn`).Returns(numInitialURNs + 3)
 }
 
+func TestDetachShellContactURN(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.Reset(t, rt, testsuite.ResetData)
+
+	oa := testdb.Org1.Load(t, rt)
+
+	// create a shell contact with only a WhatsApp BSUID URN
+	shell := testdb.InsertContact(t, rt, testdb.Org1, "8b2b8b4c-8e6e-4c96-9e9c-bf6b56a04e37", "Shell", "eng", models.ContactStatusActive)
+	shellURNID := testdb.InsertContactURN(t, rt, testdb.Org1, shell, "whatsapp:US.A1B2C3", 1000, nil)
+
+	// and a contact with a BSUID URN as well as a phone URN
+	other := testdb.InsertContact(t, rt, testdb.Org1, "a5b62498-f593-4dd2-a390-e2ff5b6d3c5b", "Other", "eng", models.ContactStatusActive)
+	testdb.InsertContactURN(t, rt, testdb.Org1, other, "tel:+16055747777", 1000, nil)
+	otherURNID := testdb.InsertContactURN(t, rt, testdb.Org1, other, "whatsapp:US.D4E5F6", 999, nil)
+
+	var shellModifiedOn time.Time
+	require.NoError(t, rt.DB.Get(&shellModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
+
+	// noop if URN doesn't exist
+	ownerID, detached, err := models.DetachShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.XXXXXX")
+	assert.NoError(t, err)
+	assert.Equal(t, models.NilContactID, ownerID)
+	assert.False(t, detached)
+
+	// noop if URN is already owned by the given contact
+	ownerID, detached, err = models.DetachShellContactURN(ctx, rt.DB, oa, shell.ID, "whatsapp:US.A1B2C3")
+	assert.NoError(t, err)
+	assert.Equal(t, models.NilContactID, ownerID)
+	assert.False(t, detached)
+
+	// URN owned by a contact with other URNs isn't detached
+	ownerID, detached, err = models.DetachShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.D4E5F6")
+	assert.NoError(t, err)
+	assert.Equal(t, other.ID, ownerID)
+	assert.False(t, detached)
+	assertdb.Query(t, rt.DB, `SELECT contact_id FROM contacts_contacturn WHERE id = $1`, otherURNID).Returns(int64(other.ID))
+
+	// URN owned by a shell contact is detached and the shell's modified_on is bumped
+	ownerID, detached, err = models.DetachShellContactURN(ctx, rt.DB, oa, testdb.Ann.ID, "whatsapp:US.A1B2C3")
+	assert.NoError(t, err)
+	assert.Equal(t, shell.ID, ownerID)
+	assert.True(t, detached)
+	assertdb.Query(t, rt.DB, `SELECT contact_id FROM contacts_contacturn WHERE id = $1`, shellURNID).Returns(nil)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, shell.ID).Returns(0)
+
+	var newShellModifiedOn time.Time
+	require.NoError(t, rt.DB.Get(&newShellModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
+	assert.True(t, newShellModifiedOn.After(shellModifiedOn))
+}
+
 func TestLoadContactURNs(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/core/tasks/ctasks/base.go
+++ b/core/tasks/ctasks/base.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	valkey "github.com/gomodule/redigo/redis"
@@ -85,6 +86,19 @@ type NewURNSpec struct {
 
 // Apply appends the new URN to the contact, recording channel affinity for the given channel if set.
 func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, scene *runner.Scene, channel *models.Channel) error {
+	// as WhatsApp identity transitions from phone numbers to BSUIDs, a BSUID being appended here may already be owned
+	// by a duplicate contact created from messages received with only that BSUID - if that contact has no other URNs
+	// we detach the URN from it so that it can be claimed by this contact
+	if urns.IsWhatsAppBSUID(s.Value) {
+		ownerID, detached, err := models.DetachShellContactURN(ctx, rt.DB, oa, scene.ContactID(), s.Value)
+		if err != nil {
+			return fmt.Errorf("error detaching URN from shell contact: %w", err)
+		}
+		if ownerID != models.NilContactID && !detached {
+			slog.Info("BSUID URN not appended because it belongs to a contact with other URNs", "urn", s.Value, "contact", scene.ContactUUID(), "owner_id", ownerID)
+		}
+	}
+
 	var flowCh *core.Channel
 	if channel != nil {
 		flowCh = oa.SessionAssets().Channels().Get(channel.UUID())

--- a/core/tasks/ctasks/base.go
+++ b/core/tasks/ctasks/base.go
@@ -88,13 +88,13 @@ type NewURNSpec struct {
 func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, scene *runner.Scene, channel *models.Channel) error {
 	// as WhatsApp identity transitions from phone numbers to BSUIDs, a BSUID being appended here may already be owned
 	// by a duplicate contact created from messages received with only that BSUID - if that contact has no other URNs
-	// we detach the URN from it so that it can be claimed by this contact
+	// we reassign the URN to this contact, which lets the append below proceed and set priority and channel affinity
 	if urns.IsWhatsAppBSUID(s.Value) {
-		ownerID, detached, err := models.DetachShellContactURN(ctx, rt.DB, oa, scene.ContactID(), s.Value)
+		ownerID, reassigned, err := models.ReassignShellContactURN(ctx, rt.DB, oa, scene.ContactID(), s.Value)
 		if err != nil {
-			return fmt.Errorf("error detaching URN from shell contact: %w", err)
+			return fmt.Errorf("error reassigning URN from shell contact: %w", err)
 		}
-		if ownerID != models.NilContactID && !detached {
+		if ownerID != models.NilContactID && !reassigned {
 			slog.Info("BSUID URN not appended because it belongs to a contact with other URNs", "urn", s.Value, "contact", scene.ContactUUID(), "owner_id", ownerID)
 		}
 	}

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -3,6 +3,7 @@ package ctasks_test
 import (
 	"testing"
 
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
 	"github.com/nyaruka/mailroom/v26/core/tasks/ctasks"
@@ -24,9 +25,12 @@ func TestContactChanged(t *testing.T) {
 		ChannelID *models.ChannelID `db:"channel_id"`
 	}
 
+	var shell *testdb.Contact
+
 	tcs := []struct {
 		label       string
 		preHook     func()
+		postHook    func(t *testing.T)
 		contact     *testdb.Contact
 		channel     *testdb.Channel
 		newURN      *ctasks.NewURNSpec
@@ -63,6 +67,30 @@ func TestContactChanged(t *testing.T) {
 				{Identity: "telegram:98765", ChannelID: nil},
 			},
 		},
+		{
+			label: "append WhatsApp BSUID URN owned by URN-less shell contact claims it",
+			preHook: func() {
+				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme != 'tel'`, testdb.Bob.ID)
+
+				// create a shell contact whose only URN is the BSUID
+				shell = testdb.InsertContact(t, rt, testdb.Org1, "778cb7bb-e6ef-4786-b8d0-a7e29e7cd7cd", "Shell", "eng", models.ContactStatusActive)
+				testdb.InsertContactURN(t, rt, testdb.Org1, shell, "whatsapp:US.SHELL1", 1000, nil)
+			},
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "whatsapp:US.SHELL1",
+				Action: "append",
+			},
+			expectedURN: []urnRow{
+				{Identity: "tel:+16055742222", ChannelID: nil},
+				{Identity: "whatsapp:US.SHELL1", ChannelID: &testdb.TwilioChannel.ID},
+			},
+			postHook: func(t *testing.T) {
+				// shell contact is left without URNs
+				assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, shell.ID).Returns(0)
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -92,6 +120,10 @@ func TestContactChanged(t *testing.T) {
 			err = rt.DB.Select(&urnRows, `SELECT identity, channel_id FROM contacts_contacturn WHERE contact_id = $1 ORDER BY priority DESC`, tc.contact.ID)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedURN, urnRows)
+
+			if tc.postHook != nil {
+				tc.postHook(t)
+			}
 		})
 	}
 }

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -449,9 +449,13 @@ func TestMsgReceivedNewURN(t *testing.T) {
 		ChannelID *models.ChannelID `db:"channel_id"`
 	}
 
+	var shell, other *testdb.Contact
+	var shellModifiedOn, bobModifiedOn time.Time
+
 	tcs := []struct {
 		label       string
 		preHook     func()
+		postHook    func(t *testing.T)
 		contact     *testdb.Contact
 		channel     *testdb.Channel
 		newURN      *ctasks.NewURNSpec
@@ -505,6 +509,63 @@ func TestMsgReceivedNewURN(t *testing.T) {
 				{Identity: "telegram:98765", ChannelID: nil},
 			},
 		},
+		{
+			label: "append WhatsApp BSUID URN owned by URN-less shell contact claims it",
+			preHook: func() {
+				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme != 'tel'`, testdb.Bob.ID)
+
+				// create a shell contact whose only URN is the BSUID
+				shell = testdb.InsertContact(t, rt, testdb.Org1, "778cb7bb-e6ef-4786-b8d0-a7e29e7cd7cd", "Shell", "eng", models.ContactStatusActive)
+				testdb.InsertContactURN(t, rt, testdb.Org1, shell, "whatsapp:US.SHELL1", 1000, nil)
+
+				require.NoError(t, rt.DB.Get(&shellModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
+				require.NoError(t, rt.DB.Get(&bobModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Bob.ID))
+			},
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "whatsapp:US.SHELL1",
+				Action: "append",
+			},
+			expectedURN: []urnRow{
+				{Identity: "tel:+16055742222", ChannelID: &testdb.TwilioChannel.ID},
+				{Identity: "whatsapp:US.SHELL1", ChannelID: &testdb.TwilioChannel.ID},
+			},
+			postHook: func(t *testing.T) {
+				// shell contact is left without URNs and both contacts have modified_on bumped for re-indexing
+				assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, shell.ID).Returns(0)
+
+				var newModifiedOn time.Time
+				require.NoError(t, rt.DB.Get(&newModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, shell.ID))
+				assert.True(t, newModifiedOn.After(shellModifiedOn), "shell contact modified_on should be bumped")
+				require.NoError(t, rt.DB.Get(&newModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Bob.ID))
+				assert.True(t, newModifiedOn.After(bobModifiedOn), "message contact modified_on should be bumped")
+			},
+		},
+		{
+			label: "append WhatsApp BSUID URN owned by contact with other URNs isn't claimed",
+			preHook: func() {
+				rt.DB.MustExec(`DELETE FROM contacts_contacturn WHERE contact_id = $1 AND scheme != 'tel'`, testdb.Bob.ID)
+
+				// create a contact that owns the BSUID but also has a phone URN
+				other = testdb.InsertContact(t, rt, testdb.Org1, "d0d1a352-6e05-4a4c-9e07-2266a0dcfae7", "Other", "eng", models.ContactStatusActive)
+				testdb.InsertContactURN(t, rt, testdb.Org1, other, "tel:+16055749999", 1000, nil)
+				testdb.InsertContactURN(t, rt, testdb.Org1, other, "whatsapp:US.OTHER1", 999, nil)
+			},
+			contact: testdb.Bob,
+			channel: testdb.TwilioChannel,
+			newURN: &ctasks.NewURNSpec{
+				Value:  "whatsapp:US.OTHER1",
+				Action: "append",
+			},
+			expectedURN: []urnRow{
+				{Identity: "tel:+16055742222", ChannelID: &testdb.TwilioChannel.ID},
+			},
+			postHook: func(t *testing.T) {
+				// owning contact keeps both its URNs
+				assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE contact_id = $1`, other.ID).Returns(2)
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -541,6 +602,10 @@ func TestMsgReceivedNewURN(t *testing.T) {
 			err = rt.DB.Select(&urnRows, `SELECT identity, channel_id FROM contacts_contacturn WHERE contact_id = $1 ORDER BY priority DESC`, tc.contact.ID)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedURN, urnRows)
+
+			if tc.postHook != nil {
+				tc.postHook(t)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

As WhatsApp transitions user identity from phone numbers to business-scoped user IDs (BSUIDs), a user whose phone number is hidden may have messaged in with only their BSUID, creating a duplicate contact whose only URN is that BSUID. When a later message arrives carrying both the phone number and the BSUID, the message is handled for the original phone-number contact, but appending the BSUID URN was silently skipped because the URN was owned by the duplicate — leaving the user's identity split across two contacts indefinitely, with messages flapping between them depending on which identifiers each one carried.

This adds a narrow rule to the new-URN append path used when handling incoming messages and contact-changed events: if the URN being appended is a WhatsApp BSUID owned by a different contact that has *no other URNs* (a shell created from BSUID-only messages), the URN is reassigned to the contact being appended to. This is not a full merge — the shell contact keeps its message history but is left without URNs, and no messages, groups or fields are moved.

If the owning contact has other URNs, the existing no-steal behavior is kept and the collision is logged for manual reconciliation. Other URN update paths (flow modifiers, contact API updates, imports) are unchanged.

## Changes

- New `models.ReassignShellContactURN` looks up the owner of a URN identity and, when the owner is a different contact with no other URNs, reassigns the URN row directly to the target contact and bumps `modified_on` on both contacts so search re-indexes them. The reassign SQL is guarded so it only fires while the owner still has exactly that one URN.
- `NewURNSpec.Apply` (the ctasks new-URN append path) calls it before applying the append, only for WhatsApp BSUID URNs. The normal append then proceeds: the URN claim check passes because the target now owns the URN, and the standard URN update logic sets priority and channel affinity on commit.
- The reassignment is a single immediate write to the intended end state, so a task failure between it and the final commit can't leave the URN orphaned — retries of the append are idempotent.

## Behavior

- Message arrives with phone + BSUID, BSUID owned by a URN-only shell contact → the phone contact ends up with phone as primary URN and the BSUID as secondary with channel affinity; the shell is left URN-less; both contacts get `modified_on` bumped.
- Message arrives with phone + BSUID, BSUID owned by a contact that has other URNs → no change, collision logged.
- Non-BSUID URN appends behave exactly as before.

## Test plan

- `TestReassignShellContactURN` (models): no existing owner, self-owned, non-shell owner (not reassigned), and shell owner (reassigned, both `modified_on` bumped).
- `TestMsgReceivedNewURN` (ctasks): shell-claim and non-shell-collision cases, plus existing telegram/non-WhatsApp-BSUID cases verifying unchanged behavior.
- `TestContactChanged` (ctasks): shell-claim case on the contact-changed path.
- Full `./core/models/...` and `./core/tasks/ctasks/...` suites pass; CI green.