### PR TITLE
Remove support for opt-in and opt-out triggers

### DIFF
--- a/core/models/trigger.go
+++ b/core/models/trigger.go
@@ -35,8 +35,6 @@ const (
 	IncomingCallTriggerType    = TriggerType("V")
 	ScheduleTriggerType        = TriggerType("S")
 	TicketClosedTriggerType    = TriggerType("T")
-	OptInTriggerType           = TriggerType("I")
-	OptOutTriggerType          = TriggerType("O")
 )
 
 // match type constants
@@ -170,20 +168,6 @@ func FindMatchingMissedCallTrigger(oa *OrgAssets, channel *Channel) *Trigger {
 // FindMatchingNewConversationTrigger finds the best match trigger for new conversation channel events
 func FindMatchingNewConversationTrigger(oa *OrgAssets, channel *Channel) *Trigger {
 	candidates := findTriggerCandidates(oa, NewConversationTriggerType, nil)
-
-	return findBestTriggerMatch(candidates, channel, nil)
-}
-
-// FindMatchingOptInTrigger finds the best match trigger for optin channel events
-func FindMatchingOptInTrigger(oa *OrgAssets, channel *Channel) *Trigger {
-	candidates := findTriggerCandidates(oa, OptInTriggerType, nil)
-
-	return findBestTriggerMatch(candidates, channel, nil)
-}
-
-// FindMatchingOptOutTrigger finds the best match trigger for optout channel events
-func FindMatchingOptOutTrigger(oa *OrgAssets, channel *Channel) *Trigger {
-	candidates := findTriggerCandidates(oa, OptOutTriggerType, nil)
 
 	return findBestTriggerMatch(candidates, channel, nil)
 }

--- a/core/models/trigger_test.go
+++ b/core/models/trigger_test.go
@@ -347,60 +347,6 @@ func TestFindMatchingReferralTrigger(t *testing.T) {
 	}
 }
 
-func TestFindMatchingOptInTrigger(t *testing.T) {
-	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
-	twilioTriggerID := testdb.InsertOptInTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.TwilioChannel)
-	noChTriggerID := testdb.InsertOptInTrigger(t, rt, testdb.Org1, testdb.Favorites, nil)
-
-	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshTriggers)
-	require.NoError(t, err)
-
-	tcs := []struct {
-		channelID         models.ChannelID
-		expectedTriggerID models.TriggerID
-	}{
-		{testdb.TwilioChannel.ID, twilioTriggerID},
-		{testdb.VonageChannel.ID, noChTriggerID},
-	}
-
-	for i, tc := range tcs {
-		channel := oa.ChannelByID(tc.channelID)
-		trigger := models.FindMatchingOptInTrigger(oa, channel)
-
-		assertTrigger(t, tc.expectedTriggerID, trigger, "trigger mismatch in test case #%d", i)
-	}
-}
-
-func TestFindMatchingOptOutTrigger(t *testing.T) {
-	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
-	twilioTriggerID := testdb.InsertOptOutTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.TwilioChannel)
-	noChTriggerID := testdb.InsertOptOutTrigger(t, rt, testdb.Org1, testdb.Favorites, nil)
-
-	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshTriggers)
-	require.NoError(t, err)
-
-	tcs := []struct {
-		channelID         models.ChannelID
-		expectedTriggerID models.TriggerID
-	}{
-		{testdb.TwilioChannel.ID, twilioTriggerID},
-		{testdb.VonageChannel.ID, noChTriggerID},
-	}
-
-	for i, tc := range tcs {
-		channel := oa.ChannelByID(tc.channelID)
-		trigger := models.FindMatchingOptOutTrigger(oa, channel)
-
-		assertTrigger(t, tc.expectedTriggerID, trigger, "trigger mismatch in test case #%d", i)
-	}
-}
-
 func TestArchiveContactTriggers(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/core/tasks/ctasks/event_received.go
+++ b/core/tasks/ctasks/event_received.go
@@ -118,7 +118,7 @@ func (t *EventReceived) handle(ctx context.Context, rt *runtime.Runtime, oa *mod
 			return nil, fmt.Errorf("error adding channel event to scene: %w", err)
 		}
 
-		trig, flowType, err := findEventTrigger(oa, event, channel, contact, flowOptIn)
+		trig, flowType, err := findEventTrigger(oa, event, channel, contact)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +187,7 @@ func (t *EventReceived) toEvent(ch *models.Channel, call *core.Call, optIn *core
 	return nil
 }
 
-func findEventTrigger(oa *models.OrgAssets, evt events.Event, ch *models.Channel, c *core.Contact, optIn *core.OptIn) (flows.Trigger, models.FlowType, error) {
+func findEventTrigger(oa *models.OrgAssets, evt events.Event, ch *models.Channel, c *core.Contact) (flows.Trigger, models.FlowType, error) {
 	var mtrig *models.Trigger
 
 	switch typed := evt.(type) {
@@ -201,10 +201,8 @@ func findEventTrigger(oa *models.OrgAssets, evt events.Event, ch *models.Channel
 		} else {
 			mtrig = models.FindMatchingNewConversationTrigger(oa, ch)
 		}
-	case *events.OptInStarted:
-		mtrig = models.FindMatchingOptInTrigger(oa, ch)
-	case *events.OptInStopped:
-		mtrig = models.FindMatchingOptOutTrigger(oa, ch)
+	case *events.OptInStarted, *events.OptInStopped:
+		return nil, "", nil // no trigger types for these events
 	default:
 		panic(fmt.Sprintf("unknown event type: %T", evt))
 	}
@@ -235,10 +233,6 @@ func findEventTrigger(oa *models.OrgAssets, evt events.Event, ch *models.Channel
 		trig = tb.CallReceived(typed).Build()
 	case *events.ChatStarted:
 		trig = tb.ChatStarted(typed).Build()
-	case *events.OptInStarted:
-		trig = tb.OptInStarted(typed, optIn).Build()
-	case *events.OptInStopped:
-		trig = tb.OptInStopped(typed, optIn).Build()
 	default:
 		panic(fmt.Sprintf("unknown event type: %T", evt))
 	}

--- a/core/tasks/ctasks/event_received_test.go
+++ b/core/tasks/ctasks/event_received_test.go
@@ -47,8 +47,6 @@ func TestEventReceived(t *testing.T) {
 	// add some channel event triggers
 	testdb.InsertNewConversationTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.FacebookChannel)
 	testdb.InsertReferralTrigger(t, rt, testdb.Org1, testdb.PickANumber, "", testdb.VonageChannel)
-	testdb.InsertOptInTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.VonageChannel)
-	testdb.InsertOptOutTrigger(t, rt, testdb.Org1, testdb.PickANumber, testdb.VonageChannel)
 
 	testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
 

--- a/core/tasks/ctasks/testdata/event_received.json
+++ b/core/tasks/ctasks/testdata/event_received.json
@@ -312,54 +312,6 @@
                     },
                     "type": "optin_started"
                 }
-            },
-            {
-                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b48-900b-76f8-838e-7d5caf016400",
-                "OrgID": 1,
-                "Data": {
-                    "created_on": "2025-05-04T12:32:27.123456789Z",
-                    "flow": {
-                        "name": "Pick a Number",
-                        "uuid": "5890fe3a-f204-4661-b74d-025be4ee019c"
-                    },
-                    "run_uuid": "01969b48-1adb-76f8-ab7b-b7ab5b0dc119",
-                    "status": "interrupted",
-                    "type": "run_ended"
-                }
-            },
-            {
-                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b48-a77b-76f8-a150-3428ae2cd5bf",
-                "OrgID": 1,
-                "Data": {
-                    "created_on": "2025-05-04T12:32:33.123456789Z",
-                    "flow": {
-                        "name": "Favorites",
-                        "revision": 1,
-                        "uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85"
-                    },
-                    "run_uuid": "01969b48-a393-76f8-9170-73aa5f656389",
-                    "type": "run_started"
-                }
-            },
-            {
-                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b48-b71b-76f8-a284-24686e628a7b",
-                "OrgID": 1,
-                "Data": {
-                    "created_on": "2025-05-04T12:32:37.123456789Z",
-                    "msg": {
-                        "channel": {
-                            "name": "Vonage",
-                            "uuid": "19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
-                        },
-                        "locale": "und-US",
-                        "text": "What is your favorite color?",
-                        "urn": "tel:+16055741111"
-                    },
-                    "type": "msg_created"
-                }
             }
         ]
     },
@@ -381,67 +333,19 @@
         "expected_history": [
             {
                 "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-0153-76f8-a014-bfd905bd3906",
+                "SK": "evt#01969b48-900b-76f8-8e47-34e3393ba6d0",
                 "OrgID": 1,
                 "Data": {
                     "channel": {
                         "name": "Vonage",
                         "uuid": "19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
                     },
-                    "created_on": "2025-05-04T12:32:56.123456789Z",
+                    "created_on": "2025-05-04T12:32:27.123456789Z",
                     "optin": {
                         "name": "Polls",
                         "uuid": "45aec4dd-945f-4511-878f-7d8516fbd336"
                     },
                     "type": "optin_stopped"
-                }
-            },
-            {
-                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-1cab-76f8-85e2-056da0a5692a",
-                "OrgID": 1,
-                "Data": {
-                    "created_on": "2025-05-04T12:33:03.123456789Z",
-                    "flow": {
-                        "name": "Favorites",
-                        "uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85"
-                    },
-                    "run_uuid": "01969b48-a393-76f8-9170-73aa5f656389",
-                    "status": "interrupted",
-                    "type": "run_ended"
-                }
-            },
-            {
-                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-341b-76f8-8d77-6c3d50b7bc5a",
-                "OrgID": 1,
-                "Data": {
-                    "created_on": "2025-05-04T12:33:09.123456789Z",
-                    "flow": {
-                        "name": "Pick a Number",
-                        "revision": 1,
-                        "uuid": "5890fe3a-f204-4661-b74d-025be4ee019c"
-                    },
-                    "run_uuid": "01969b49-3033-76f8-8ddf-439f8a7762e5",
-                    "type": "run_started"
-                }
-            },
-            {
-                "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-43bb-76f8-bb6f-b873752f885a",
-                "OrgID": 1,
-                "Data": {
-                    "created_on": "2025-05-04T12:33:13.123456789Z",
-                    "msg": {
-                        "channel": {
-                            "name": "Vonage",
-                            "uuid": "19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
-                        },
-                        "locale": "und-US",
-                        "text": "Pick a number between 1-10.",
-                        "urn": "tel:+16055741111"
-                    },
-                    "type": "msg_created"
                 }
             }
         ]
@@ -463,14 +367,14 @@
         "expected_history": [
             {
                 "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-8a0b-76f8-b967-8af4e55f3a3f",
+                "SK": "evt#01969b48-ab63-76f8-b806-699460e5ca92",
                 "OrgID": 1,
                 "Data": {
                     "channel": {
                         "name": "Vonage",
                         "uuid": "19012bfd-3ce3-4cae-9bb9-76cf92c73d49"
                     },
-                    "created_on": "2025-05-04T12:33:31.123456789Z",
+                    "created_on": "2025-05-04T12:32:34.123456789Z",
                     "type": "call_missed"
                 }
             }
@@ -499,21 +403,21 @@
         "expected_history": [
             {
                 "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-a563-76f8-97ad-3aa8fbd702eb",
+                "SK": "evt#01969b48-c6bb-76f8-9170-73aa5f656389",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:33:38.123456789Z",
+                    "created_on": "2025-05-04T12:32:41.123456789Z",
                     "status": "stopped",
                     "type": "contact_status_changed"
                 }
             },
             {
                 "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b49-ad33-76f8-93bd-ee89de0c94c7",
+                "SK": "evt#01969b48-ce8b-76f8-a150-3428ae2cd5bf",
                 "OrgID": 1,
-                "TTL": "2026-05-04T12:33:40Z",
+                "TTL": "2026-05-04T12:32:43Z",
                 "Data": {
-                    "created_on": "2025-05-04T12:33:40.123456789Z",
+                    "created_on": "2025-05-04T12:32:43.123456789Z",
                     "groups_removed": [
                         {
                             "name": "Doctors",
@@ -561,21 +465,21 @@
         "expected_history": [
             {
                 "PK": "con#b699a406-7e44-49be-9f01-1a82893e8a10",
-                "SK": "evt#01969b49-d05b-76f8-bbab-41ae7be90048",
+                "SK": "evt#01969b48-f1b3-76f8-a284-24686e628a7b",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:33:49.123456789Z",
+                    "created_on": "2025-05-04T12:32:52.123456789Z",
                     "status": "active",
                     "type": "contact_status_changed"
                 }
             },
             {
                 "PK": "con#b699a406-7e44-49be-9f01-1a82893e8a10",
-                "SK": "evt#01969b49-d82b-76f8-a0c4-2314fb7af950",
+                "SK": "evt#01969b48-f983-76f8-9ad1-04953223c01c",
                 "OrgID": 1,
-                "TTL": "2026-05-04T12:33:51Z",
+                "TTL": "2026-05-04T12:32:54Z",
                 "Data": {
-                    "created_on": "2025-05-04T12:33:51.123456789Z",
+                    "created_on": "2025-05-04T12:32:54.123456789Z",
                     "type": "contact_urns_changed",
                     "urns": [
                         "facebook:1000000000002?channel=0f661e8b-ea9d-4bd3-9953-d368340acf91",
@@ -586,38 +490,38 @@
             },
             {
                 "PK": "con#b699a406-7e44-49be-9f01-1a82893e8a10",
-                "SK": "evt#01969b49-dffb-76f8-b605-56ed66c7447b",
+                "SK": "evt#01969b49-0153-76f8-9e32-5b7ee54bb315",
                 "OrgID": 1,
                 "Data": {
                     "channel": {
                         "name": "Facebook",
                         "uuid": "0f661e8b-ea9d-4bd3-9953-d368340acf91"
                     },
-                    "created_on": "2025-05-04T12:33:53.123456789Z",
+                    "created_on": "2025-05-04T12:32:56.123456789Z",
                     "type": "chat_started"
                 }
             },
             {
                 "PK": "con#b699a406-7e44-49be-9f01-1a82893e8a10",
-                "SK": "evt#01969b49-fb53-76f8-9cba-6ead9640c23d",
+                "SK": "evt#01969b49-1cab-76f8-a014-bfd905bd3906",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:34:00.123456789Z",
+                    "created_on": "2025-05-04T12:33:03.123456789Z",
                     "flow": {
                         "name": "Favorites",
                         "revision": 1,
                         "uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85"
                     },
-                    "run_uuid": "01969b49-f76b-76f8-92e7-6bb1f58ce1eb",
+                    "run_uuid": "01969b49-18c3-76f8-8876-bd2f7154ab08",
                     "type": "run_started"
                 }
             },
             {
                 "PK": "con#b699a406-7e44-49be-9f01-1a82893e8a10",
-                "SK": "evt#01969b4a-0af3-76f8-b358-5a0ea4ce79b4",
+                "SK": "evt#01969b49-2c4b-76f8-9455-dca0efc034b0",
                 "OrgID": 1,
                 "Data": {
-                    "created_on": "2025-05-04T12:34:04.123456789Z",
+                    "created_on": "2025-05-04T12:33:07.123456789Z",
                     "msg": {
                         "channel": {
                             "name": "Facebook",

--- a/testsuite/testdb/triggers.go
+++ b/testsuite/testdb/triggers.go
@@ -25,14 +25,6 @@ func InsertNewConversationTrigger(t *testing.T, rt *runtime.Runtime, org *Org, f
 	return insertTrigger(t, rt, org, models.NewConversationTriggerType, flow, nil, "", models.NilScheduleID, nil, nil, nil, "", channel)
 }
 
-func InsertOptInTrigger(t *testing.T, rt *runtime.Runtime, org *Org, flow *Flow, channel *Channel) models.TriggerID {
-	return insertTrigger(t, rt, org, models.OptInTriggerType, flow, nil, "", models.NilScheduleID, nil, nil, nil, "", channel)
-}
-
-func InsertOptOutTrigger(t *testing.T, rt *runtime.Runtime, org *Org, flow *Flow, channel *Channel) models.TriggerID {
-	return insertTrigger(t, rt, org, models.OptOutTriggerType, flow, nil, "", models.NilScheduleID, nil, nil, nil, "", channel)
-}
-
 func InsertReferralTrigger(t *testing.T, rt *runtime.Runtime, org *Org, flow *Flow, referrerID string, channel *Channel) models.TriggerID {
 	return insertTrigger(t, rt, org, models.ReferralTriggerType, flow, nil, "", models.NilScheduleID, nil, nil, nil, referrerID, channel)
 }


### PR DESCRIPTION
## Summary

Opt-in and opt-out trigger types have been removed upstream (existing triggers released by data migration), so this removes their handling here. Opt-in and opt-out channel events are still converted to `optin_started` / `optin_stopped` contact history events — they just no longer trigger flows.

## Changes

- `core/models/trigger.go`: removed the `OptInTriggerType` / `OptOutTriggerType` constants and the `FindMatchingOptInTrigger` / `FindMatchingOptOutTrigger` functions
- `core/tasks/ctasks/event_received.go`: `findEventTrigger` no longer looks up or builds triggers for `OptInStarted` / `OptInStopped` events, and no longer needs the opt-in asset passed in
- `testsuite/testdb/triggers.go`: removed the `InsertOptInTrigger` / `InsertOptOutTrigger` helpers
- Removed the `FindMatchingOptInTrigger` / `FindMatchingOptOutTrigger` tests and regenerated the `event_received` snapshots — the optin/optout cases now record only the history event instead of also starting a flow session

## Test plan

- [x] `go vet ./...` passes
- [x] Full test suite passes (`go test -p=1 ./...`)