### PR TITLE
Remove ResetDB and ResetData flags now that tests get their own databases

### DIFF
--- a/core/crons/end_incidents_test.go
+++ b/core/crons/end_incidents_test.go
@@ -25,7 +25,7 @@ func TestEndIncidents(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa1 := testdb.Org1.Load(t, rt)
 	oa2 := testdb.Org2.Load(t, rt)

--- a/core/crons/fire_contacts_test.go
+++ b/core/crons/fire_contacts_test.go
@@ -26,7 +26,7 @@ func TestFireContacts(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	testdb.InsertContactFire(t, rt, testdb.Org1, testdb.Ann, models.ContactFireTypeWaitTimeout, "", time.Now().Add(3*time.Second), "f72b48df-5f6d-4e4f-955a-f5fb29ccb97b")
 	testdb.InsertContactFire(t, rt, testdb.Org1, testdb.Ann, models.ContactFireTypeWaitExpiration, "", time.Now().Add(-1*time.Second), "f72b48df-5f6d-4e4f-955a-f5fb29ccb97b")
@@ -107,7 +107,7 @@ func TestFireContactsCampaignBatching(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	campaign := testdb.InsertCampaign(t, rt, testdb.Org1, "Test", testdb.DoctorsGroup)
 	flowPoint := testdb.InsertCampaignFlowPoint(t, rt, campaign, testdb.Favorites, testdb.CreatedOnField, 5, "D")

--- a/core/crons/fire_schedules_test.go
+++ b/core/crons/fire_schedules_test.go
@@ -18,7 +18,7 @@ func TestFireSchedules(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	// add a one-time schedule and tie a broadcast to it
 	s1 := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodNever, time.Now().Add(-2*time.Hour))

--- a/core/crons/retry_sending_test.go
+++ b/core/crons/retry_sending_test.go
@@ -17,7 +17,7 @@ func TestRetryErroredMessages(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	// nothing to retry
 	cron := &crons.RetrySendingCron{}

--- a/core/crons/sync_android_channels_test.go
+++ b/core/crons/sync_android_channels_test.go
@@ -14,8 +14,6 @@ func TestSyncAndroidChannels(t *testing.T) {
 
 	rt.Config.AndroidCredentialsFile = `testdata/android.json`
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testChannel1 := testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 1", "123", []string{"tel"}, "SR", map[string]any{"FCM_ID": ""})       // no FCM ID
 	testChannel2 := testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 2", "234", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID2"}) // invalid FCM ID
 	testChannel3 := testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 3", "456", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID3"}) // valid FCM ID

--- a/core/crons/throttle_queue_test.go
+++ b/core/crons/throttle_queue_test.go
@@ -16,7 +16,7 @@ func TestThrottleQueue(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	cron := &crons.ThrottleQueueCron{}
 	res, err := cron.Run(ctx, rt)

--- a/core/models/broadcast_test.go
+++ b/core/models/broadcast_test.go
@@ -22,8 +22,6 @@ import (
 func TestBroadcasts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	bcast := models.NewBroadcast(
 		testdb.Org1.ID,
 		core.BroadcastTranslations{"eng": {Text: "Hi there"}},
@@ -69,8 +67,6 @@ func TestBroadcasts(t *testing.T) {
 func TestInsertChildBroadcast(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	schedID := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodDaily, time.Now())
 	bcast := testdb.InsertBroadcast(t, rt, testdb.Org1, "0199877e-0ed2-790b-b474-35099cea401c", `eng`, map[i18n.Language]string{`eng`: "Hello"}, schedID, []*testdb.Contact{testdb.Bob, testdb.Ann}, nil)
 
@@ -93,9 +89,7 @@ func TestInsertChildBroadcast(t *testing.T) {
 }
 
 func TestNonPersistentBroadcasts(t *testing.T) {
-	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
+	testsuite.Runtime(t) // this test doesn't touch the database but still needs the runtime's global setup
 
 	translations := core.BroadcastTranslations{"eng": {Text: "Hi there"}}
 
@@ -133,7 +127,7 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 func TestBroadcastSend(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOptIns)
 	require.NoError(t, err)

--- a/core/models/campaign_test.go
+++ b/core/models/campaign_test.go
@@ -17,8 +17,6 @@ import (
 func TestLoadCampaigns(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, 1, models.RefreshCampaigns)
 	require.NoError(t, err)
 

--- a/core/models/channel_log_test.go
+++ b/core/models/channel_log_test.go
@@ -20,7 +20,7 @@ import (
 func TestChannelLogsOutgoing(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	mocks := httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"http://ivr.com/start":  {httpx.NewMockResponse(200, nil, []byte("OK"))},

--- a/core/models/channel_test.go
+++ b/core/models/channel_test.go
@@ -123,8 +123,6 @@ func TestGetChannelByID(t *testing.T) {
 func TestGetAndroidChannelsToSync(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testChannel1 := testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 1", "123", []string{"tel"}, "SR", map[string]any{"FCM_ID": ""})
 	testChannel2 := testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 2", "234", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID2"})
 	testChannel3 := testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 3", "456", []string{"tel"}, "SR", map[string]any{"FCM_ID": "FCMID3"})

--- a/core/models/contact_fire_test.go
+++ b/core/models/contact_fire_test.go
@@ -15,8 +15,6 @@ import (
 func TestContactFires(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
@@ -55,8 +53,6 @@ func TestContactFires(t *testing.T) {
 
 func TestSessionContactFires(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	testdb.InsertContactFire(t, rt, testdb.Org1, testdb.Bob, models.ContactFireTypeCampaignPoint, "235", time.Now().Add(2*time.Second), "")
 
@@ -98,8 +94,6 @@ func TestSessionContactFires(t *testing.T) {
 
 func TestCampaignContactFires(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -89,8 +89,6 @@ func TestContacts(t *testing.T) {
 func TestCreateContact(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testdb.InsertContactGroup(t, rt, testdb.Org1, "d636c966-79c1-4417-9f1c-82ad629773a2", "Kinyarwanda", "language = kin")
 
 	// add an orphaned URN
@@ -136,8 +134,6 @@ func TestCreateContact(t *testing.T) {
 func TestCreateContactRace(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	assert.NoError(t, err)
 
@@ -164,8 +160,6 @@ func TestCreateContactRace(t *testing.T) {
 
 func TestGetOrCreateContact(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	testdb.InsertContactGroup(t, rt, testdb.Org1, "dcc16d85-8274-4d19-a3c2-152d4ee99380", "Telegrammer", `telegram = 100001`)
 
@@ -292,8 +286,6 @@ func TestGetOrCreateContact(t *testing.T) {
 func TestGetOrCreateContactRace(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	assert.NoError(t, err)
 
@@ -320,8 +312,6 @@ func TestGetOrCreateContactRace(t *testing.T) {
 
 func TestGetOrCreateContactIDsFromURNs(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	assert.NoError(t, err)
@@ -379,8 +369,6 @@ func TestGetOrCreateContactIDsFromURNs(t *testing.T) {
 
 func TestGetOrCreateContactsFromURNsRace(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	assert.NoError(t, err)

--- a/core/models/counts_test.go
+++ b/core/models/counts_test.go
@@ -15,8 +15,6 @@ import (
 func TestDailyCounts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 

--- a/core/models/import_test.go
+++ b/core/models/import_test.go
@@ -15,8 +15,6 @@ import (
 func TestLoadContactImport(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa := testdb.Org1.Load(t, rt)
 
 	import1ID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)

--- a/core/models/incident_test.go
+++ b/core/models/incident_test.go
@@ -25,8 +25,6 @@ func TestIncidentWebhooksUnhealthy(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa := testdb.Org1.Load(t, rt)
 
 	id1, _, err := models.IncidentWebhooksUnhealthy(ctx, rt.DB, rt.VK, oa, []core.NodeUUID{"5a2e83f1-efa8-40ba-bc0c-8873c525de7d", "aba89043-6f0a-4ccf-ba7f-0e1674b90759"})
@@ -58,8 +56,6 @@ func TestIncidentWebhooksUnhealthy(t *testing.T) {
 
 func TestGetOpenIncidents(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa1 := testdb.Org1.Load(t, rt)
 	oa2 := testdb.Org2.Load(t, rt)

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -55,8 +55,6 @@ func TestLLMs(t *testing.T) {
 func TestLLMRecordCall(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2026, 5, 4, 13, 14, 30, 0, time.UTC)))
 	defer dates.SetNowFunc(time.Now)
 

--- a/core/models/msg_test.go
+++ b/core/models/msg_test.go
@@ -24,7 +24,7 @@ import (
 func TestNewOutgoingFlowMsg(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	blake := testdb.InsertContact(t, rt, testdb.Org1, "79b94a23-6d13-43f4-95fe-c733ee457857", "Blake", i18n.NilLanguage, models.ContactStatusBlocked)
 	blakeURNID := testdb.InsertContactURN(t, rt, testdb.Org1, blake, "tel:+250700000007", 1, nil)
@@ -184,8 +184,6 @@ func TestNewOutgoingFlowMsg(t *testing.T) {
 func TestGetMessagesByUUID(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	msgIn1 := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-d4be-76c7-8a5c-a12caae7aa87", testdb.TwilioChannel, testdb.Ann, "in 1", models.MsgStatusHandled, "")
 	msgOut1 := testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "out 1", []utils.Attachment{"image/jpeg:hi.jpg"}, models.MsgStatusSent, false)
 	msgOut2 := testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "out 2", nil, models.MsgStatusSent, false)
@@ -270,8 +268,6 @@ func TestResendMessages(t *testing.T) {
 func TestFailMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hi", nil, models.MsgStatusPending, false)
 	testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Bob, "hi", nil, models.MsgStatusErrored, false)
 	out3 := testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bb93-ec0f-703e-9b5b-d26d4b6b133c", testdb.TwilioChannel, testdb.Ann, "hi", nil, models.MsgStatusFailed, false)
@@ -291,8 +287,6 @@ func TestFailMessages(t *testing.T) {
 
 func TestDeleteMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	in1 := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hi", models.MsgStatusHandled, "")
 	in1.Label(rt, testdb.ReportingLabel, testdb.TestingLabel)
@@ -392,8 +386,6 @@ func TestNormalizeAttachment(t *testing.T) {
 func TestMarkMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	out1 := testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "Hello", nil, models.MsgStatusQueued, false)
 	msgs, err := models.GetMessagesByUUID(ctx, rt.DB, testdb.Org1.ID, models.DirectionOut, []events.EventUUID{out1.UUID})
 	require.NoError(t, err)
@@ -485,8 +477,6 @@ func TestNewIVRMessages(t *testing.T) {
 func TestCreateMsgOut(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
@@ -559,8 +549,6 @@ func TestCreateMsgOut(t *testing.T) {
 
 func TestMsgTemplating(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa := testdb.Org1.Load(t, rt)
 	mc, _, _ := testdb.Ann.Load(t, rt, oa)

--- a/core/models/notification_test.go
+++ b/core/models/notification_test.go
@@ -19,7 +19,7 @@ import (
 func TestImportNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -61,8 +61,6 @@ func TestImportNotifications(t *testing.T) {
 
 func TestIncidentNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)

--- a/core/models/optin_test.go
+++ b/core/models/optin_test.go
@@ -13,8 +13,6 @@ import (
 func TestOptIns(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	polls := testdb.InsertOptIn(t, rt, testdb.Org1, "45aec4dd-945f-4511-878f-7d8516fbd336", "Polls")
 	offers := testdb.InsertOptIn(t, rt, testdb.Org1, "7fda7c97-4484-445d-8418-66fed031f82d", "Offers")
 

--- a/core/models/org_test.go
+++ b/core/models/org_test.go
@@ -147,8 +147,6 @@ func TestStoreAttachment(t *testing.T) {
 func TestGetOutboxCounts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	rt.DB.MustExec(`INSERT INTO orgs_itemcount(org_id, scope, count, is_squashed) VALUES ($1, 'msgs:folder:O', -1, FALSE)`, testdb.Org1.ID)
 	rt.DB.MustExec(`INSERT INTO orgs_itemcount(org_id, scope, count, is_squashed) VALUES ($1, 'msgs:folder:O', 2, FALSE)`, testdb.Org1.ID)
 	rt.DB.MustExec(`INSERT INTO orgs_itemcount(org_id, scope, count, is_squashed) VALUES ($1, 'msgs:folder:O', 3, FALSE)`, testdb.Org1.ID)

--- a/core/models/resthook_test.go
+++ b/core/models/resthook_test.go
@@ -13,8 +13,6 @@ import (
 func TestResthooks(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	rt.DB.MustExec(`INSERT INTO api_resthook(is_active, created_on, modified_on, slug, created_by_id, modified_by_id, org_id)
 								   VALUES(TRUE, NOW(), NOW(), 'registration', 1, 1, 1);`)
 	rt.DB.MustExec(`INSERT INTO api_resthook(is_active, created_on, modified_on, slug, created_by_id, modified_by_id, org_id)

--- a/core/models/run_test.go
+++ b/core/models/run_test.go
@@ -17,8 +17,6 @@ import (
 func TestInsertAndUpdateRuns(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	sessionUUID := testdb.InsertFlowSession(t, rt, testdb.Ann, models.FlowTypeMessaging, models.SessionStatusWaiting, nil, testdb.Favorites)
 
 	t1 := time.Date(2024, 12, 3, 14, 29, 30, 0, time.UTC)
@@ -80,8 +78,6 @@ func TestInsertAndUpdateRuns(t *testing.T) {
 func TestGetContactIDsAtNode(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	createRun := func(org *testdb.Org, contact *testdb.Contact, nodeUUID core.NodeUUID) {
 		sessionUUID := testdb.InsertFlowSession(t, rt, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil, testdb.Favorites)
 		testdb.InsertFlowRun(t, rt, org, sessionUUID, contact, testdb.Favorites, models.RunStatusWaiting, nodeUUID)
@@ -99,8 +95,6 @@ func TestGetContactIDsAtNode(t *testing.T) {
 
 func TestGetActiveAndWaitingRuns(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	session1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites, testdb.PickANumber)
 	session2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.PickANumber)

--- a/core/models/schedule_test.go
+++ b/core/models/schedule_test.go
@@ -88,8 +88,6 @@ func TestNewSchedule(t *testing.T) {
 func TestGetExpired(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	// add a schedule and tie a broadcast to it
 	s1 := testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodNever, time.Now().Add(-24*time.Hour))
 

--- a/core/models/session_test.go
+++ b/core/models/session_test.go
@@ -27,7 +27,6 @@ func TestInsertSessions(t *testing.T) {
 
 	defer dates.SetNowFunc(time.Now)
 	defer random.SetGenerator(random.DefaultGenerator)
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	flow := testFlows[0]
@@ -104,8 +103,6 @@ func TestInsertSessions(t *testing.T) {
 func TestGetContactWaitingSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	sessionUUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	testdb.InsertFlowSession(t, rt, testdb.Ann, models.FlowTypeMessaging, models.SessionStatusCompleted, nil, testdb.Favorites)
 	testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Cat, models.FlowTypeMessaging, nil, testdb.Favorites)
@@ -121,8 +118,6 @@ func TestGetContactWaitingSession(t *testing.T) {
 
 func TestInterruptContacts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa := testdb.Org1.Load(t, rt)
 

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -114,7 +114,7 @@ func TestNotificationSocket(t *testing.T) {
 func TestPublishNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	vc := rt.VK.Get()
 	defer vc.Close()
@@ -174,7 +174,7 @@ func TestPublishNotifications(t *testing.T) {
 func TestPublishNotificationData(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	vc := rt.VK.Get()
 	defer vc.Close()

--- a/core/models/start_test.go
+++ b/core/models/start_test.go
@@ -21,8 +21,6 @@ import (
 func TestStarts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	startID := testdb.InsertFlowStart(t, rt, testdb.Org1, testdb.Admin, testdb.SingleMessage, []*testdb.Contact{testdb.Ann, testdb.Bob})
 
 	startJSON := fmt.Appendf(nil, `{

--- a/core/models/ticket_test.go
+++ b/core/models/ticket_test.go
@@ -17,8 +17,6 @@ import (
 func TestTickets(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	oa := testdb.Org1.Load(t, rt)
 	favorites := testdb.Favorites.Load(t, rt, oa)
 
@@ -76,8 +74,6 @@ func TestTickets(t *testing.T) {
 func TestUpdateTicketLastActivity(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	now := time.Date(2021, 6, 22, 15, 59, 30, 123456000, time.UTC)
 
 	defer dates.SetNowFunc(time.Now)
@@ -95,8 +91,6 @@ func TestUpdateTicketLastActivity(t *testing.T) {
 
 func TestUpdateTickets(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	ticket1 := testdb.InsertClosedTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.SalesTopic, nil).Load(t, rt, testdb.Org1)
 	ticket2 := testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-725e-be9c-0c6407efd755", testdb.Org1, testdb.Ann, testdb.SalesTopic, time.Now(), nil).Load(t, rt, testdb.Org1)
@@ -134,8 +128,6 @@ func TestUpdateTickets(t *testing.T) {
 
 func TestTicketRecordReply(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)

--- a/core/models/trigger_test.go
+++ b/core/models/trigger_test.go
@@ -254,8 +254,6 @@ func TestFindMatchingIncomingCallTrigger(t *testing.T) {
 func TestFindMatchingMissedCallTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testdb.InsertCatchallTrigger(t, rt, testdb.Org1, testdb.SingleMessage, nil, nil, nil)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshTriggers)
@@ -288,8 +286,6 @@ func TestFindMatchingMissedCallTrigger(t *testing.T) {
 func TestFindMatchingNewConversationTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	twilioTriggerID := testdb.InsertNewConversationTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.TwilioChannel)
 	noChTriggerID := testdb.InsertNewConversationTrigger(t, rt, testdb.Org1, testdb.Favorites, nil)
 
@@ -314,8 +310,6 @@ func TestFindMatchingNewConversationTrigger(t *testing.T) {
 
 func TestFindMatchingReferralTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	fooID := testdb.InsertReferralTrigger(t, rt, testdb.Org1, testdb.Favorites, "foo", testdb.FacebookChannel)
 	barID := testdb.InsertReferralTrigger(t, rt, testdb.Org1, testdb.Favorites, "bar", nil)
@@ -350,8 +344,6 @@ func TestFindMatchingReferralTrigger(t *testing.T) {
 func TestFindMatchingOptInTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	twilioTriggerID := testdb.InsertOptInTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.TwilioChannel)
 	noChTriggerID := testdb.InsertOptInTrigger(t, rt, testdb.Org1, testdb.Favorites, nil)
 
@@ -376,8 +368,6 @@ func TestFindMatchingOptInTrigger(t *testing.T) {
 
 func TestFindMatchingOptOutTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	twilioTriggerID := testdb.InsertOptOutTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.TwilioChannel)
 	noChTriggerID := testdb.InsertOptOutTrigger(t, rt, testdb.Org1, testdb.Favorites, nil)

--- a/core/msgio/android_test.go
+++ b/core/msgio/android_test.go
@@ -14,8 +14,6 @@ import (
 func TestSyncAndroidChannel(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	mockFCM := rt.FCM.(*testsuite.MockFCMClient)
 
 	// create some Android channels

--- a/core/msgio/courier_test.go
+++ b/core/msgio/courier_test.go
@@ -25,7 +25,7 @@ import (
 func TestNewCourierMsg(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	// create a new contact with a URN with an auth token
 	testFred := testdb.InsertContact(t, rt, testdb.Org1, "fed2d179-73ac-44fd-b838-7f866fef0a3a", "Fred", "eng", models.ContactStatusActive)
@@ -236,7 +236,7 @@ func TestQueueCourierMessages(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg|models.RefreshChannels)
 	require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestClearChannelCourierQueue(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg|models.RefreshChannels)
 	require.NoError(t, err)
@@ -341,7 +341,7 @@ func TestPushCourierBatch(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshChannels)
 	require.NoError(t, err)

--- a/core/msgio/send_test.go
+++ b/core/msgio/send_test.go
@@ -52,7 +52,7 @@ func TestQueueMessages(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	mockFCM := rt.FCM.(*testsuite.MockFCMClient)
 

--- a/core/runner/handlers/contact_status_changed_test.go
+++ b/core/runner/handlers/contact_status_changed_test.go
@@ -9,7 +9,5 @@ import (
 func TestContactStatusChanged(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDB)
-
 	runTests(t, rt, "testdata/contact_status_changed.json")
 }

--- a/core/runner/handlers/msg_created_test.go
+++ b/core/runner/handlers/msg_created_test.go
@@ -58,7 +58,7 @@ func TestMsgCreatedNewURN(t *testing.T) {
 func TestMsgCreatedLoop(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	runTests(t, rt, "testdata/msg_created_loop.json")
 }

--- a/core/runner/handlers/webhook_called_test.go
+++ b/core/runner/handlers/webhook_called_test.go
@@ -77,7 +77,7 @@ func TestUnhealthyWebhookCalls(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 	defer dates.SetNowFunc(time.Now)
 
 	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2021, 11, 17, 7, 0, 0, 0, time.UTC), time.Second))

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -128,7 +128,7 @@ func TestSessionCreationAndUpdating(t *testing.T) {
 func TestSingleSprintSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	flow := testFlows[1]
@@ -160,7 +160,7 @@ func TestSessionWithSubflows(t *testing.T) {
 
 	defer dates.SetNowFunc(time.Now)
 	defer random.SetGenerator(random.DefaultGenerator)
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	parent, child := testFlows[2], testFlows[3]
@@ -305,7 +305,7 @@ func TestBulkCommitPublishesEvents(t *testing.T) {
 func TestBulkCommitPublishesNotifications(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
@@ -347,7 +347,7 @@ func TestBulkCommitPublishesNotifications(t *testing.T) {
 func TestBulkCommitPublishesFlowActivity(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	other, parent, child := testFlows[1], testFlows[2], testFlows[3]
@@ -393,7 +393,7 @@ func TestSessionFailedStart(t *testing.T) {
 
 	defer dates.SetNowFunc(time.Now)
 	defer random.SetGenerator(random.DefaultGenerator)
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/ping_pong.json")
 	ping, pong := testFlows[0], testFlows[1]
@@ -431,7 +431,7 @@ func TestFlowStats(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	defer random.SetGenerator(random.DefaultGenerator)
 	random.SetGenerator(random.NewSeededGenerator(123))
@@ -540,7 +540,7 @@ func TestFlowStats(t *testing.T) {
 func TestResumeSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetStorage|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetStorage|testsuite.ResetDynamo)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg)
 	require.NoError(t, err)
@@ -621,7 +621,7 @@ func TestResumeSession(t *testing.T) {
 func TestBroadcastWithLock(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)

--- a/core/runner/start_test.go
+++ b/core/runner/start_test.go
@@ -20,7 +20,7 @@ import (
 func TestStartFlowConcurrency(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
 	// check everything works with big ids
 	rt.DB.MustExec(`ALTER SEQUENCE flows_flowrun_id_seq RESTART WITH 5000000000;`)

--- a/core/search/messages_test.go
+++ b/core/search/messages_test.go
@@ -17,7 +17,7 @@ import (
 func TestSearchMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic|testsuite.ResetDynamo)
 
 	// pin the clock to just after the message fixtures so they stay within the search's rolling time window
 	defer dates.SetNowFunc(time.Now)

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -128,7 +128,7 @@ func TestGetContactUUIDsForQueryPage(t *testing.T) {
 func TestGetContactUUIDsForQuery(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	oa, err := models.GetOrgAssets(ctx, rt, 1)
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestGetContactUUIDsForQuery(t *testing.T) {
 func TestGetContactIDsForQuery(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	oa, err := models.GetOrgAssets(ctx, rt, 1)
 	require.NoError(t, err)

--- a/core/tasks/bulk_wait_expire_test.go
+++ b/core/tasks/bulk_wait_expire_test.go
@@ -14,7 +14,7 @@ import (
 func TestBulkSessionExpire(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))

--- a/core/tasks/bulk_wait_timeout_test.go
+++ b/core/tasks/bulk_wait_timeout_test.go
@@ -14,7 +14,7 @@ import (
 func TestBulkSessionTimeout(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -17,7 +17,7 @@ func TestContactChanged(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	type urnRow struct {
 		Identity  string            `db:"identity"`

--- a/core/tasks/ctasks/msg_deleted_test.go
+++ b/core/tasks/ctasks/msg_deleted_test.go
@@ -16,7 +16,7 @@ import (
 func TestMsgDeleted(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	oa := testdb.Org1.Load(t, rt)
 

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -440,7 +440,7 @@ func TestMsgReceivedNewURN(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	dbMsg := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Bob, "", models.MsgStatusPending, "")
 
@@ -548,7 +548,7 @@ func TestMsgReceivedNewURN(t *testing.T) {
 func TestMsgReceivedPayload(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	oa := testdb.Org1.Load(t, rt)
 	ann, _, _ := testdb.Ann.Load(t, rt, oa)

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -17,7 +17,7 @@ import (
 func TestImportContactBatch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
 	batch1ID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
@@ -61,7 +61,7 @@ func TestImportContactBatch(t *testing.T) {
 func TestImportContactBatchFailure(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
 

--- a/core/tasks/interrupt_channel_test.go
+++ b/core/tasks/interrupt_channel_test.go
@@ -18,7 +18,7 @@ import (
 func TestInterruptChannel(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	// twilio call
 	twilioCall := testdb.InsertCall(t, rt, testdb.Org1, testdb.TwilioChannel, testdb.Dan)

--- a/core/tasks/interrupt_flow_test.go
+++ b/core/tasks/interrupt_flow_test.go
@@ -18,7 +18,7 @@ func TestInterruptFlow(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)

--- a/core/tasks/interrupt_session_batch_test.go
+++ b/core/tasks/interrupt_session_batch_test.go
@@ -17,7 +17,7 @@ import (
 func TestInterruptSessionBatch(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)
@@ -48,7 +48,7 @@ func TestInterruptSessionBatchDecrements(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetDynamo|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)

--- a/core/tasks/start_flow_batch_test.go
+++ b/core/tasks/start_flow_batch_test.go
@@ -18,7 +18,7 @@ import (
 func TestStartFlowBatchTask(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	// create a start
 	start1 := models.NewFlowStart(models.OrgID(1), models.StartTypeManual, testdb.SingleMessage.ID).
@@ -92,7 +92,7 @@ func TestStartFlowBatchTask(t *testing.T) {
 func TestStartFlowBatchTaskNonPersistedStart(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	// create a start
 	start := models.NewFlowStart(models.OrgID(1), models.StartTypeManual, testdb.SingleMessage.ID).

--- a/core/tasks/start_flow_test.go
+++ b/core/tasks/start_flow_test.go
@@ -249,8 +249,6 @@ func TestStartFlowTask(t *testing.T) {
 func TestStartFlowTaskNonPersistedStart(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	// create a start and start it...
 	start := models.NewFlowStart(models.OrgID(1), models.StartTypeManual, testdb.SingleMessage.ID).
 		WithContactIDs([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID})

--- a/services/llm/anthropic/service_test.go
+++ b/services/llm/anthropic/service_test.go
@@ -15,8 +15,6 @@ import (
 func TestService(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "anthropic", "claude", "Bad Config", map[string]any{}, "TF")
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "anthropic", "claude", "Good", map[string]any{"api_key": "sesame"}, "TF")
 

--- a/services/llm/google/service_test.go
+++ b/services/llm/google/service_test.go
@@ -13,8 +13,6 @@ import (
 func TestService(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "google", "gemini", "Bad Config", map[string]any{}, "TF")
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "google", "gemini", "Good", map[string]any{"api_key": "sesame"}, "TF")
 

--- a/services/llm/openai/service_test.go
+++ b/services/llm/openai/service_test.go
@@ -15,8 +15,6 @@ import (
 func TestService(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai", "gpt-4", "Bad Config", map[string]any{}, "TF")
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai", "gpt-4", "Good", map[string]any{"api_key": "sesame"}, "TF")
 

--- a/services/llm/openai_azure/service_test.go
+++ b/services/llm/openai_azure/service_test.go
@@ -15,8 +15,6 @@ import (
 func TestService(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	bad := testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "openai_azure", "gpt-4", "Bad Config", map[string]any{}, "TF")
 	good := testdb.InsertLLM(t, rt, testdb.Org1, "b86966fd-206e-4bdd-a962-06faa3af1182", "openai_azure", "gpt-4", "Good", map[string]any{"endpoint": "http://azure.com/ai", "api_key": "sesame"}, "TF")
 

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -27,22 +27,21 @@ func testdataPath(file string) string {
 	return path.Join(path.Dir(thisFile), "testdata", file)
 }
 
-// Refresh is our type for the pieces of org assets we want fresh (not cached)
+// Refresh is our type for the pieces of state we want fresh. Note that there's no flag for the database
+// because each test gets its own (see dbtemplate.go) which is dropped when it finishes.
 type ResetFlag int
 
 // refresh bit masks
 const (
 	ResetNone    = ResetFlag(0)
 	ResetAll     = ResetFlag(^0)
-	ResetDB      = ResetFlag(1 << 1)
-	ResetData    = ResetFlag(1 << 2)
-	ResetValkey  = ResetFlag(1 << 3)
-	ResetStorage = ResetFlag(1 << 4)
-	ResetDynamo  = ResetFlag(1 << 5)
-	ResetElastic = ResetFlag(1 << 6)
+	ResetValkey  = ResetFlag(1 << 0)
+	ResetStorage = ResetFlag(1 << 1)
+	ResetDynamo  = ResetFlag(1 << 2)
+	ResetElastic = ResetFlag(1 << 3)
 )
 
-// Reset clears out both our database and redis DB
+// Reset clears out the state shared between tests
 func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 	if what&ResetValkey > 0 {
 		resetValkey(t, rt)
@@ -54,10 +53,7 @@ func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 		resetDynamo(t, rt)
 	}
 
-	// ResetDB and ResetData are no-ops - each test gets its own database (see dbtemplate.go) which is
-	// dropped when it finishes, so there's nothing to reset
-
-	// comes after data/db reset so reindexing happens from reset data
+	// comes last so that reindexing happens from reset data
 	if what&ResetElastic > 0 {
 		resetElastic(t, rt)
 	}

--- a/web/android/base_test.go
+++ b/web/android/base_test.go
@@ -10,7 +10,7 @@ import (
 func TestEvent(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	testsuite.RunWebTests(t, rt, "testdata/event.json")
 }
@@ -18,15 +18,13 @@ func TestEvent(t *testing.T) {
 func TestMessage(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	testsuite.RunWebTests(t, rt, "testdata/message.json")
 }
 
 func TestSync(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	testdb.InsertChannel(t, rt, testdb.Org1, "A", "Android 1", "123", []string{"tel"}, "SR", map[string]any{})
 

--- a/web/campaign/base_test.go
+++ b/web/campaign/base_test.go
@@ -9,7 +9,7 @@ import (
 func TestSchedule(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	testsuite.RunWebTests(t, rt, "testdata/schedule.json")
 }

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 func TestDeindex(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	// index Bob and Cat into the v2 contacts index
 	oa := testdb.Org1.Load(t, rt)
@@ -100,7 +100,7 @@ func TestExportPreview(t *testing.T) {
 func TestImport(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	import1ID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
 	testdb.InsertContactImportBatch(t, rt, import1ID, []byte(`[
@@ -120,8 +120,6 @@ func TestImport(t *testing.T) {
 
 func TestInspect(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	// give Ann an unsendable twitterid URN with a display value
 	testdb.InsertContactURN(t, rt, testdb.Org1, testdb.Ann, urns.URN("twitterid:23145325#ann"), 20000, nil)
@@ -164,7 +162,7 @@ func TestModify(t *testing.T) {
 func TestInterrupt(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	var modifiedOn1 time.Time
 	rt.DB.Get(&modifiedOn1, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Ann.ID)
@@ -192,7 +190,7 @@ func TestParseQuery(t *testing.T) {
 func TestPopulateGroup(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetElastic)
 
 	testdb.InsertContactGroup(t, rt, testdb.Org1, "", "Dynamic", "age > 18")
 

--- a/web/flow/base_test.go
+++ b/web/flow/base_test.go
@@ -48,8 +48,8 @@ func TestMigrate(t *testing.T) {
 func TestStart(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	// TODO TestTwilioIVR blows up without full reset so some prior test isn't cleaning up after itself
-	//defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	// TODO TestTwilioIVR blows up without full reset so some prior test isn't cleaning up after itself. Can no
+	// longer be database state, so the culprit is valkey, dynamo or elastic.
 	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	testsuite.RunWebTests(t, rt, "testdata/start.json")

--- a/web/llm/base_test.go
+++ b/web/llm/base_test.go
@@ -10,8 +10,6 @@ import (
 func TestTranslate(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	// LLM without the editing role - id will be 30000
 	testdb.InsertLLM(t, rt, testdb.Org1, "c69723d8-fb37-4cf6-9ec4-bc40cb36f2cc", "test", "gpt-4", "Engine Only", map[string]any{}, "F")
 

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -15,7 +15,7 @@ import (
 func TestSend(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	// add an unreachable contact (i.e. no URNs)
 	testdb.InsertContact(t, rt, testdb.Org1, "f5e5c595-0cba-4eb9-b1e6-41d7f7f0add6", "Mr Unreachable", "eng", models.ContactStatusActive)
@@ -30,7 +30,7 @@ func TestSend(t *testing.T) {
 func TestDelete(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "goodbye world", models.MsgStatusPending, "")
@@ -54,7 +54,7 @@ func TestDelete(t *testing.T) {
 func TestHandle(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusPending, "")
@@ -66,7 +66,7 @@ func TestHandle(t *testing.T) {
 func TestResend(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
 	testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "how can we help", nil, models.MsgStatusSent, false)
@@ -80,7 +80,7 @@ func TestResend(t *testing.T) {
 func TestBroadcast(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	createRun := func(org *testdb.Org, contact *testdb.Contact, nodeUUID core.NodeUUID) {
 		sessionUUID := testdb.InsertFlowSession(t, rt, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil, testdb.Favorites)
@@ -106,7 +106,7 @@ func TestBroadcastPreview(t *testing.T) {
 func TestSearch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetElastic|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetElastic|testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "01955193-de00-7000-8000-000000000001", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
 

--- a/web/simulation/simulation_test.go
+++ b/web/simulation/simulation_test.go
@@ -146,8 +146,6 @@ const (
 func TestServer(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	wg := &sync.WaitGroup{}
 
 	server := web.NewServer(ctx, rt, wg)

--- a/web/socket/publish_test.go
+++ b/web/socket/publish_test.go
@@ -14,8 +14,6 @@ import (
 func TestPublish(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	// a contact with no URNs has no route for typing indicators
 	testdb.InsertContact(t, rt, testdb.Org1, "f5e5c595-0cba-4eb9-b1e6-41d7f7f0add6", "Mr Unreachable", "eng", models.ContactStatusActive)
 

--- a/web/ticket/base_test.go
+++ b/web/ticket/base_test.go
@@ -11,8 +11,6 @@ import (
 func TestTicketAddNote(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.DefaultTopic, time.Now(), testdb.Admin)
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-725e-be9c-0c6407efd755", testdb.Org1, testdb.Ann, testdb.DefaultTopic, time.Now(), testdb.Agent)
 	testdb.InsertClosedTicket(t, rt, "01992f54-5ab6-7498-a7f2-6aa246e45cfe", testdb.Org1, testdb.Ann, testdb.DefaultTopic, nil)
@@ -24,8 +22,6 @@ func TestTicketAddNote(t *testing.T) {
 
 func TestTicketChangeAssignee(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
 
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.DefaultTopic, time.Now(), testdb.Admin)
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-725e-be9c-0c6407efd755", testdb.Org1, testdb.Ann, testdb.DefaultTopic, time.Now(), testdb.Agent)
@@ -40,8 +36,6 @@ func TestTicketChangeAssignee(t *testing.T) {
 func TestTicketChangeTopic(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData)
-
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.DefaultTopic, time.Now(), testdb.Admin)
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-725e-be9c-0c6407efd755", testdb.Org1, testdb.Ann, testdb.SupportTopic, time.Now(), testdb.Agent)
 	testdb.InsertClosedTicket(t, rt, "01992f54-5ab6-7498-a7f2-6aa246e45cfe", testdb.Org1, testdb.Ann, testdb.SalesTopic, nil)
@@ -54,7 +48,7 @@ func TestTicketChangeTopic(t *testing.T) {
 func TestTicketClose(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	// create 2 open tickets and 1 closed one for Ann
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.DefaultTopic, time.Now(), testdb.Admin)
@@ -69,7 +63,7 @@ func TestTicketClose(t *testing.T) {
 func TestTicketReopen(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetData|testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	// we should be able to reopen ticket #1 because Ann has no other tickets open
 	testdb.InsertClosedTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.DefaultTopic, testdb.Admin)


### PR DESCRIPTION
## Summary

Follow-up to #1186, which gave each test its own database cloned from a template and made `ResetDB` and `ResetData` no-ops. This removes the dead flags and strips them from every call site — the mechanical half that was deliberately kept out of that PR to keep its diff reviewable.

## Changes

63 files, +71/−198, almost entirely one-line edits to `testsuite.Reset` calls:

- **62 calls deleted** — they only asked for a database reset, so the whole call is now a no-op.
- **60 calls rewritten** — combined flags like `ResetData|ResetValkey` keep just their live flags.
- **90 calls untouched** — already database-free.
- `ResetDB`/`ResetData` removed from the `ResetFlag` enum, remaining values renumbered, and the type's comment now explains why there's no database flag.

Two edits with any judgment in them:

- `core/models/broadcast_test.go` — deleting the `Reset` call left `rt` unused; `TestNonPersistentBroadcasts` genuinely never touches the database, so it now calls `testsuite.Runtime(t)` without binding the result.
- `web/flow/base_test.go` — a stale commented-out `ResetData` line under a TODO about `TestStart` needing a full reset; the TODO stays but now notes the leaked state can no longer be database state.

## Test plan

- All test packages compile.
- Full suite green with `-p=1` (1m57s).
- Full suite under `-shuffle=7` reproduces exactly the three failures that exist on `main` with that seed (`TestInterrupt`, `TestTicketAddNote`, `TestTicketChangeTopic`) — confirming none of the 62 deleted reset calls was masking hidden state, and no new order dependencies were introduced.