### PR TITLE
Fix tests that leaked or inherited shared state between test binaries

### DIFF
--- a/core/models/broadcast_test.go
+++ b/core/models/broadcast_test.go
@@ -132,7 +132,7 @@ func TestBroadcastSend(t *testing.T) {
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOptIns)
 	require.NoError(t, err)
 
-	test.MockUniverse()
+	defer test.MockUniverse()()
 
 	tcs := []struct {
 		contactLanguage   i18n.Language

--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -106,7 +106,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	assert.NoError(t, err)
 
-	test.MockUniverse()
+	defer test.MockUniverse()()
 
 	for i, tc := range tcs {
 		scenes := make([]*runner.Scene, 4)

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -395,6 +395,9 @@ func TestSessionFailedStart(t *testing.T) {
 	defer random.SetGenerator(random.DefaultGenerator)
 	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
 
+	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
+	testsuite.Reset(t, rt, testsuite.ResetDynamo)
+
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/ping_pong.json")
 	ping, pong := testFlows[0], testFlows[1]
 
@@ -432,6 +435,10 @@ func TestFlowStats(t *testing.T) {
 	defer vc.Close()
 
 	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo)
+
+	// this test asserts the exact set of recent contacts keys in valkey, and other tests in this package run
+	// flows without resetting valkey, so start from a clean slate
+	testsuite.Reset(t, rt, testsuite.ResetValkey)
 
 	defer random.SetGenerator(random.DefaultGenerator)
 	random.SetGenerator(random.NewSeededGenerator(123))
@@ -623,6 +630,9 @@ func TestBroadcastWithLock(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
+	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
+	testsuite.Reset(t, rt, testsuite.ResetDynamo)
+
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
@@ -631,7 +641,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast, err := models.GetBroadcastByID(ctx, rt.DB, b1.ID)
 	require.NoError(t, err)
 
-	test.MockUniverse()
+	defer test.MockUniverse()()
 
 	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID})
 	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID})

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -18,7 +18,9 @@ func TestContactChanged(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	// this test pops tasks without marking them done, inflating the org's active count in the fair queue,
+	// so it needs to reset valkey for the tests which come after it
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	type urnRow struct {
 		Identity  string            `db:"identity"`

--- a/core/tasks/ctasks/msg_deleted_test.go
+++ b/core/tasks/ctasks/msg_deleted_test.go
@@ -18,6 +18,9 @@ func TestMsgDeleted(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
 
+	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
+	testsuite.Reset(t, rt, testsuite.ResetDynamo)
+
 	oa := testdb.Org1.Load(t, rt)
 
 	ann, _, _ := testdb.Ann.Load(t, rt, oa)

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -440,7 +440,8 @@ func TestMsgReceivedNewURN(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	// pops tasks without marking them done, so needs to reset valkey for the tests which come after it
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey|testsuite.ResetDynamo|testsuite.ResetElastic)
 
 	dbMsg := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Bob, "", models.MsgStatusPending, "")
 
@@ -614,6 +615,9 @@ func TestMsgReceivedPayload(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
 	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+
+	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
+	testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	oa := testdb.Org1.Load(t, rt)
 	ann, _, _ := testdb.Ann.Load(t, rt, oa)

--- a/core/tasks/interrupt_channel_test.go
+++ b/core/tasks/interrupt_channel_test.go
@@ -20,6 +20,9 @@ func TestInterruptChannel(t *testing.T) {
 
 	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetValkey)
 
+	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
+	testsuite.Reset(t, rt, testsuite.ResetDynamo)
+
 	// twilio call
 	twilioCall := testdb.InsertCall(t, rt, testdb.Org1, testdb.TwilioChannel, testdb.Dan)
 

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -23,18 +23,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// IndexContacts indexes all contacts for the test orgs into Elasticsearch.
+// IndexContacts indexes all contacts for the test orgs into Elasticsearch. The index is cleared first because
+// it's shared state - a test calling this is about to assert on index contents and can't inherit docs leaked
+// by tests in other binaries whose async indexing completed after their own elastic reset.
 func IndexContacts(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
+
+	clearElasticContacts(t, rt)
 
 	indexOrgContacts(t, rt, testdb.Org1)
 	indexOrgContacts(t, rt, testdb.Org2)
 }
 
 // IndexMessages indexes all indexable messages from the database into Elasticsearch, then refreshes
-// the index so they're immediately searchable.
+// the index so they're immediately searchable. The message indexes are cleared first for the same reason
+// IndexContacts clears the contacts index.
 func IndexMessages(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
+
+	clearElasticMessages(t, rt)
 
 	ctx := t.Context()
 
@@ -204,7 +211,14 @@ type SearchAssertion struct {
 func clearElasticIndexes(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
 
-	// clear contacts
+	clearElasticContacts(t, rt)
+	clearElasticMessages(t, rt)
+}
+
+// removes all documents from the contacts index
+func clearElasticContacts(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
 	_, err := rt.ES.Client.DeleteByQuery(rt.Config.ElasticContactsIndex).
 		Conflicts(conflicts.Proceed).
 		Raw(strings.NewReader(`{"query": {"match_all": {}}}`)).Do(t.Context())
@@ -212,8 +226,12 @@ func clearElasticIndexes(t *testing.T, rt *runtime.Runtime) {
 
 	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(t.Context())
 	require.NoError(t, err)
+}
 
-	// clear messages
+// deletes all message indexes
+func clearElasticMessages(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
 	pattern := rt.Config.ElasticMessagesIndex + "-*"
 
 	indexes, err := rt.ES.Client.Cat.Indices().Index(pattern).Do(t.Context())

--- a/testsuite/web.go
+++ b/testsuite/web.go
@@ -62,7 +62,7 @@ func RunWebTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 	jsonx.MustUnmarshal(tcJSON, &tcs)
 	var err error
 
-	test.MockUniverse()
+	defer test.MockUniverse()()
 
 	// track which messages were already indexed before each test case so we only report new ones
 	prevIndexedIDs := make(map[string]bool)

--- a/utils/crons/cron_test.go
+++ b/utils/crons/cron_test.go
@@ -17,6 +17,10 @@ func TestCron(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
+	// cron locks and last-fire times live in the shared valkey, so start clean and leave clean
+	testsuite.Reset(t, rt, testsuite.ResetValkey)
+	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
 	align := func() {
 		untilNextSecond := time.Nanosecond * time.Duration(1_000_000_000-time.Now().Nanosecond()) // time until next second boundary
 		time.Sleep(untilNextSecond)                                                               // wait until after second boundary

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner/clocks"
 	_ "github.com/nyaruka/mailroom/v26/core/runner/handlers"
@@ -163,6 +164,9 @@ func TestInterrupt(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
 	defer testsuite.Reset(t, rt, testsuite.ResetValkey)
+
+	// mock the universe before inserting sessions so their generated UUIDs are deterministic
+	defer test.MockUniverse()()
 
 	var modifiedOn1 time.Time
 	rt.DB.Get(&modifiedOn1, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Ann.ID)

--- a/web/contact/testdata/interrupt.json
+++ b/web/contact/testdata/interrupt.json
@@ -34,7 +34,7 @@
                         "uuid": "01969b47-1523-76f8-95cf-9fca95f1c30a",
                         "type": "run_ended",
                         "created_on": "2025-05-04T12:30:50.123456789Z",
-                        "run_uuid": "01969b48-2e63-76f8-8e47-34e3393ba6d0",
+                        "run_uuid": "01969b47-0d53-76f8-b20c-e3cb6203e029",
                         "flow": {
                             "uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85",
                             "name": "Favorites"
@@ -64,7 +64,7 @@
                 "query": "SELECT current_session_uuid::text, current_flow_id FROM contacts_contact WHERE uuid = 'b699a406-7e44-49be-9f01-1a82893e8a10'",
                 "columns": {
                     "current_flow_id": 10001,
-                    "current_session_uuid": "01969b48-324b-76f8-838e-7d5caf016400"
+                    "current_session_uuid": "01969b47-113b-76f8-b774-0a98171a0712"
                 }
             }
         ],
@@ -79,7 +79,7 @@
                         "name": "Favorites",
                         "uuid": "9de3663f-c5c5-4c92-9f45-ecbc09abcc85"
                     },
-                    "run_uuid": "01969b48-2e63-76f8-8e47-34e3393ba6d0",
+                    "run_uuid": "01969b47-0d53-76f8-b20c-e3cb6203e029",
                     "status": "interrupted",
                     "type": "run_ended"
                 }

--- a/web/ticket/testdata/change_assignee.json
+++ b/web/ticket/testdata/change_assignee.json
@@ -31,14 +31,10 @@
                             "name": "Andy Admin"
                         },
                         "_via": "api",
-                        "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
+                        "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
                         "assignee": {
                             "uuid": "aee44553-ab35-482b-a4d4-6f000ec611ab",
                             "name": "Ann D'Agent"
-                        },
-                        "previous": {
-                            "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25",
-                            "name": "Andy Admin"
                         }
                     },
                     {
@@ -50,10 +46,14 @@
                             "name": "Andy Admin"
                         },
                         "_via": "api",
-                        "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
+                        "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
                         "assignee": {
                             "uuid": "aee44553-ab35-482b-a4d4-6f000ec611ab",
                             "name": "Ann D'Agent"
+                        },
+                        "previous": {
+                            "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25",
+                            "name": "Andy Admin"
                         }
                     }
                 ]
@@ -81,11 +81,7 @@
                         "uuid": "aee44553-ab35-482b-a4d4-6f000ec611ab"
                     },
                     "created_on": "2025-05-04T12:30:46.123456789Z",
-                    "previous": {
-                        "name": "Andy Admin",
-                        "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
-                    },
-                    "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
+                    "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
                     "type": "ticket_assignee_changed"
                 }
             },
@@ -104,7 +100,11 @@
                         "uuid": "aee44553-ab35-482b-a4d4-6f000ec611ab"
                     },
                     "created_on": "2025-05-04T12:30:48.123456789Z",
-                    "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
+                    "previous": {
+                        "name": "Andy Admin",
+                        "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25"
+                    },
+                    "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
                     "type": "ticket_assignee_changed"
                 }
             }

--- a/web/ticket/testdata/change_topic.json
+++ b/web/ticket/testdata/change_topic.json
@@ -48,7 +48,7 @@
                             "name": "Andy Admin"
                         },
                         "_via": "ui",
-                        "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
+                        "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
                         "topic": {
                             "uuid": "0a8f2e00-fef6-402c-bd79-d789446ec0e0",
                             "name": "Support"
@@ -63,7 +63,7 @@
                             "name": "Andy Admin"
                         },
                         "_via": "ui",
-                        "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
+                        "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
                         "topic": {
                             "uuid": "0a8f2e00-fef6-402c-bd79-d789446ec0e0",
                             "name": "Support"
@@ -90,7 +90,7 @@
                     },
                     "_via": "ui",
                     "created_on": "2025-05-04T12:30:46.123456789Z",
-                    "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
+                    "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
                     "topic": {
                         "name": "Support",
                         "uuid": "0a8f2e00-fef6-402c-bd79-d789446ec0e0"
@@ -109,7 +109,7 @@
                     },
                     "_via": "ui",
                     "created_on": "2025-05-04T12:30:49.123456789Z",
-                    "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
+                    "ticket_uuid": "01992f54-5ab6-717a-a39e-e8ca91fb7262",
                     "topic": {
                         "name": "Support",
                         "uuid": "0a8f2e00-fef6-402c-bd79-d789446ec0e0"


### PR DESCRIPTION
## Summary

Follow-up to #1186/#1190: with the database now isolated per test, the remaining test-order dependencies all flow through the state tests still share — the process-global mocked clock, and the valkey / Elasticsearch / DynamoDB backends. This tracks each observed shuffle failure to its mechanism and fixes the class, not just the instance. The full suite now passes under `-shuffle` (verified with seeds 1, 2, 7, 11, 23), and tests that previously couldn't even run alone with `-run` now can.

## The mocked clock leak

The most surprising finding: the `web/ticket` fixture failures were **never inter-test pollution** — `TestTicketChangeTopic` failed when run entirely alone. The chain:

- `RunWebTests` (and three other call sites) called `test.MockUniverse()` and discarded its restore function, so the mocked sequential clock and seeded UUID generator stayed active for every later test in the binary.
- `testdb.insertTicket` stamps a closed ticket's `opened_on` with the mockable `dates.Now()` while the tests pass real `time.Now()` for open tickets. On a cold binary the closed ticket is newest; under a leaked clock (stuck in the mock epoch) it's oldest.
- `LoadTickets` orders by `opened_on DESC`, so ticket processing order — and which generated event lands on which ticket — differed between the first test in a binary and every subsequent one. Each fixture had baked in whichever ordering was live when it was recorded.

Restore is now always deferred, and the three stale fixtures are regenerated. `TestInterrupt` additionally mocks the universe *before* inserting sessions, so their UUIDs are seeded rather than real-time (a regenerated fixture would otherwise embed values that change every run).

## Shared-backend leaks

- **Fair queue accounting (valkey).** `FairV2.Pop` increments the owner's active count and only `Done` decrements it. Tests that pop and then call `Perform` directly never call `Done`, so org 1's count ratchets up across tests until it hits the per-owner limit — after which `Pop` returns nil for whoever runs next (surfacing as a nil-task panic in `TestEventReceived`). The popping tests now declare `ResetValkey`.
- **Elasticsearch (crosses binary runs).** A test's deferred elastic reset runs *before* `Runtime`'s cleanup stops the async workers, so an in-flight indexing task can land after the index was cleared — reset-after-test structurally can't win that race, and the orphan survives into future runs. Rather than patching each victim, `testsuite.IndexContacts` / `IndexMessages` now clear their own index first: calling them is precisely the declaration that a test is about to assert on index contents. This armors all 21 call sites.
- **DynamoDB history.** Five tests assert on the *entire* contents of the shared history table; they now reset it up front instead of only cleaning up afterwards.
- **`TestCron`** had no reset at all despite cron locks and last-fire times living in valkey; it now starts and leaves clean.

## Test plan

- Full suite green in default order and at shuffle seeds 1, 2, 7, 11, 23.
- The previously order-dependent tests (`TestTicketChangeTopic`, `TestTicketAddNote`, `TestTicketChangeAssignee`, `TestInterrupt`, `TestEventReceived`, `TestMsgDeleted`, `TestFlowStats`, `TestDeindexDeletedOrgsCron`) pass with `-run` in isolation on a cold binary.
- `TestInterrupt` verified stable across consecutive clean runs (its fixture previously recorded real-time UUIDs).

## Notes for review

- The fixture diffs in `web/ticket/testdata/` are pure event↔ticket reassignments (same events, same times); `web/contact/testdata/interrupt.json` swaps real-time UUIDs for seeded ones.
- Concurrent test binaries (plain `go test ./...` without `-p=1`) still contend on valkey/Elastic/Dynamo — this PR fixes sequential order-dependence, not parallel safety.