### PR TITLE
Give each test binary its own elastic indexes

### DIFF
--- a/core/crons/deindex_deleted_orgs_test.go
+++ b/core/crons/deindex_deleted_orgs_test.go
@@ -16,8 +16,6 @@ func TestDeindexDeletedOrgsCron(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
-
 	cron := &crons.DeindexDeletedOrgsCron{}
 
 	assertRun := func(expected map[string]any) {

--- a/core/runner/handlers/base_test.go
+++ b/core/runner/handlers/base_test.go
@@ -236,7 +236,7 @@ func runTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 			tcs[i] = actual
 		}
 
-		testsuite.Reset(t, rt, testsuite.ResetElastic)
+		testsuite.ClearElastic(t, rt)
 	}
 
 	// update if we are meant to

--- a/core/search/messages_test.go
+++ b/core/search/messages_test.go
@@ -17,7 +17,7 @@ import (
 func TestSearchMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	// pin the clock to just after the message fixtures so they stay within the search's rolling time window
 	defer dates.SetNowFunc(time.Now)

--- a/core/search/search_test.go
+++ b/core/search/search_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestGetContactTotal(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 
@@ -60,7 +59,6 @@ func TestGetContactTotal(t *testing.T) {
 
 func TestGetContactUUIDsForQueryPage(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 
@@ -127,8 +125,6 @@ func TestGetContactUUIDsForQueryPage(t *testing.T) {
 
 func TestGetContactUUIDsForQuery(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	oa, err := models.GetOrgAssets(ctx, rt, 1)
 	require.NoError(t, err)
@@ -255,8 +251,6 @@ func TestGetContactUUIDsForQuery(t *testing.T) {
 
 func TestGetContactIDsForQuery(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	oa, err := models.GetOrgAssets(ctx, rt, 1)
 	require.NoError(t, err)

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -20,7 +20,7 @@ func TestContactChanged(t *testing.T) {
 
 	// this test pops tasks without marking them done, inflating the org's active count in the fair queue,
 	// so it needs to reset valkey for the tests which come after it
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	type urnRow struct {
 		Identity  string            `db:"identity"`

--- a/core/tasks/ctasks/msg_deleted_test.go
+++ b/core/tasks/ctasks/msg_deleted_test.go
@@ -16,7 +16,7 @@ import (
 func TestMsgDeleted(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
 	testsuite.Reset(t, rt, testsuite.ResetDynamo)

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -441,7 +441,7 @@ func TestMsgReceivedNewURN(t *testing.T) {
 	defer vc.Close()
 
 	// pops tasks without marking them done, so needs to reset valkey for the tests which come after it
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	dbMsg := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Bob, "", models.MsgStatusPending, "")
 
@@ -614,7 +614,7 @@ func TestMsgReceivedNewURN(t *testing.T) {
 func TestMsgReceivedPayload(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
 	testsuite.Reset(t, rt, testsuite.ResetDynamo)

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -2,10 +2,14 @@ package testsuite
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,9 +27,150 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// IndexContacts indexes all contacts for the test orgs into Elasticsearch. The index is cleared first because
-// it's shared state - a test calling this is about to assert on index contents and can't inherit docs leaked
-// by tests in other binaries whose async indexing completed after their own elastic reset.
+// Each test binary gets its own elastic indexes (suffixed with its process identifier), so concurrently
+// running binaries - including other worktrees sharing an Elasticsearch - never see each other's documents.
+// Within a binary, ClearElastic runs at the start of every test so each starts with empty indexes - which
+// assumes tests run sequentially, as a t.Parallel() test would have its documents cleared by the next test
+// to start. As with the per-test databases, ownership is marked with a Postgres advisory lock held for the
+// binary's lifetime, and setup sweeps away the indexes of any run which has died.
+
+const (
+	esContactsPrefix = "contacts-test-"
+	esMessagesPrefix = "messages-test-"
+
+	// name and index pattern base of the shared message index template, which covers the per-binary
+	// message indexes of every binary
+	esMessagesTemplate = "messages-test"
+)
+
+// matches the process identifier segment of a per-binary index name
+var esProcIDRegex = regexp.MustCompile(`^[0-9a-f]{8}$`)
+
+// per-binary index names
+func esContactsIndex() string { return esContactsPrefix + dbProcID() }
+func esMessagesIndex() string { return esMessagesPrefix + dbProcID() }
+
+// esKey derives the advisory lock key which marks a binary's elastic indexes as in use
+func esKey(procID string) int64 {
+	return dbKey("elastic_" + procID)
+}
+
+var esSetup sync.Once
+var esSetupErr error
+
+// ensureElastic creates this binary's elastic indexes on first use
+func ensureElastic(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	esSetup.Do(func() { esSetupErr = setupElastic(rt) })
+	require.NoError(t, esSetupErr, "error setting up elastic indexes")
+}
+
+// setupElastic claims this binary's indexes, creates them, and sweeps those of dead runs
+func setupElastic(rt *runtime.Runtime) error {
+	ctx := context.Background()
+
+	owner, err := dbOwner()
+	if err != nil {
+		return err
+	}
+
+	// claim our indexes before they exist, so they're never visible to another binary's sweep unclaimed
+	if _, err := owner.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, esKey(dbProcID())); err != nil {
+		return fmt.Errorf("error claiming elastic indexes: %w", err)
+	}
+
+	contactsBody, err := os.ReadFile(testdataPath("es_contacts.json"))
+	if err != nil {
+		return err
+	}
+	if _, err := rt.ES.Client.Indices.Create(esContactsIndex()).Raw(bytes.NewReader(contactsBody)).Do(ctx); err != nil {
+		return fmt.Errorf("error creating contacts index: %w", err)
+	}
+
+	messagesBody, err := os.ReadFile(testdataPath("es_messages.json"))
+	if err != nil {
+		return err
+	}
+	messagesBody = bytes.ReplaceAll(messagesBody, []byte("{{INDEX}}"), []byte(esMessagesTemplate))
+	if _, err := rt.ES.Client.Indices.PutIndexTemplate(esMessagesTemplate).Raw(bytes.NewReader(messagesBody)).Do(ctx); err != nil {
+		return fmt.Errorf("error creating messages index template: %w", err)
+	}
+
+	return sweepStaleElastic(ctx, rt)
+}
+
+// sweepStaleElastic deletes the indexes of binaries which are no longer running. An index still in use is
+// protected by its owner's advisory lock, so any process identifier we can lock ourselves belongs to a run
+// which is no longer around.
+func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
+	admin, err := dbAdmin()
+	if err != nil {
+		return err
+	}
+	conn, err := admin.DB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	indexes, err := rt.ES.Client.Cat.Indices().Index(esContactsPrefix + "*," + esMessagesPrefix + "*").Do(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing test indexes: %w", err)
+	}
+
+	byProcID := make(map[string][]string)
+	for _, idx := range indexes {
+		if idx.Index == nil {
+			continue
+		}
+		rest := strings.TrimPrefix(strings.TrimPrefix(*idx.Index, esContactsPrefix), esMessagesPrefix)
+		procID, _, _ := strings.Cut(rest, "-")
+		if procID == dbProcID() || !esProcIDRegex.MatchString(procID) {
+			continue // ours, or not a per-binary test index
+		}
+		byProcID[procID] = append(byProcID[procID], *idx.Index)
+	}
+
+	for procID, names := range byProcID {
+		var got bool
+		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, esKey(procID)).Scan(&got); err != nil {
+			return err
+		}
+		if !got {
+			continue // in use by a live run
+		}
+
+		for _, name := range names {
+			if _, err := rt.ES.Client.Indices.Delete(name).Do(ctx); err != nil {
+				return fmt.Errorf("error deleting stale index %s: %w", name, err)
+			}
+		}
+
+		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, esKey(procID))
+	}
+
+	return nil
+}
+
+// ClearElastic clears out this binary's elastic indexes: all documents from the contacts index, and the
+// message indexes entirely. Runs at the start of every test, and can be called mid-test by tests which
+// assert on exact index contents across phases.
+func ClearElastic(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	rt.ES.Writer.Flush()
+
+	// refresh so that recently written documents are visible to the delete query
+	_, err := rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(t.Context())
+	require.NoError(t, err)
+
+	clearElasticContacts(t, rt)
+	clearElasticMessages(t, rt)
+}
+
+// IndexContacts indexes all contacts for the test orgs into Elasticsearch. The index is cleared first so
+// the result is exactly the indexable contacts in the database, regardless of what the test indexed before.
 func IndexContacts(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
 
@@ -206,15 +351,6 @@ type SearchAssertion struct {
 	Contacts []core.ContactUUID `json:"contacts"`
 }
 
-// removes all documents from the contacts index and deletes all message indexes.
-// Callers should flush the ES writer first if there may be buffered writes.
-func clearElasticIndexes(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	clearElasticContacts(t, rt)
-	clearElasticMessages(t, rt)
-}
-
 // removes all documents from the contacts index
 func clearElasticContacts(t *testing.T, rt *runtime.Runtime) {
 	t.Helper()
@@ -243,33 +379,6 @@ func clearElasticMessages(t *testing.T, rt *runtime.Runtime) {
 			require.NoError(t, err)
 		}
 	}
-}
-
-// setupElasticContacts creates the contacts index in Elastic if it doesn't already exist
-func setupElasticContacts(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	exists, err := rt.ES.Client.Indices.Exists(rt.Config.ElasticContactsIndex).IsSuccess(t.Context())
-	require.NoError(t, err)
-
-	if !exists {
-		contactsBody := ReadFile(t, testdataPath("es_contacts.json"))
-		_, err = rt.ES.Client.Indices.Create(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(contactsBody)).Do(t.Context())
-		require.NoError(t, err)
-	}
-}
-
-// setupElasticMessages creates the index template for messages in Elastic
-func setupElasticMessages(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	messagesBody := ReadFile(t, testdataPath("es_messages.json"))
-
-	// replace placeholder with actual index name for test
-	body := bytes.ReplaceAll(messagesBody, []byte("{{INDEX}}"), []byte(rt.Config.ElasticMessagesIndex))
-
-	_, err := rt.ES.Client.Indices.PutIndexTemplate(rt.Config.ElasticMessagesIndex).Raw(bytes.NewReader(body)).Do(t.Context())
-	require.NoError(t, err)
 }
 
 // indexes all active contacts for the given org into Elastic and refreshes the index so they're immediately searchable

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -27,8 +27,9 @@ func testdataPath(file string) string {
 	return path.Join(path.Dir(thisFile), "testdata", file)
 }
 
-// Refresh is our type for the pieces of state we want fresh. Note that there are no flags for the database
-// or valkey because each test gets its own (see dbtemplate.go and valkey.go).
+// Refresh is our type for the pieces of state we want fresh. Note that there are no flags for the database,
+// valkey or elastic because each test starts with its own clean state (see dbtemplate.go, valkey.go and
+// elastic.go).
 type ResetFlag int
 
 // refresh bit masks
@@ -37,7 +38,6 @@ const (
 	ResetAll     = ResetFlag(^0)
 	ResetStorage = ResetFlag(1 << 0)
 	ResetDynamo  = ResetFlag(1 << 1)
-	ResetElastic = ResetFlag(1 << 2)
 )
 
 // Reset clears out the state shared between tests
@@ -47,11 +47,6 @@ func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 	}
 	if what&ResetDynamo > 0 {
 		resetDynamo(t, rt)
-	}
-
-	// comes last so that reindexing happens from reset data
-	if what&ResetElastic > 0 {
-		resetElastic(t, rt)
 	}
 }
 
@@ -70,6 +65,8 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.InternalPort = 8191
 	cfg.DB = fmt.Sprintf(dbTestDSNFormat, dbName)
 	cfg.Valkey = fmt.Sprintf(vkTestDSNFormat, vkDB)
+	cfg.ElasticContactsIndex = esContactsIndex() // this binary's own indexes, cleared before every test
+	cfg.ElasticMessagesIndex = esMessagesIndex() // - see elastic.go
 
 	// AWS SDK default chain reads these — used by the localstack S3/Dynamo/Cloudwatch clients
 	t.Setenv("AWS_ACCESS_KEY_ID", "root")
@@ -81,8 +78,6 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.S3PathStyle = true
 	cfg.DynamoEndpoint = "http://localstack:4566"
 	cfg.DynamoTablePrefix = "Test"
-	cfg.ElasticContactsIndex = "contacts-test"
-	cfg.ElasticMessagesIndex = "messages-test"
 	cfg.SpoolDir = absPath("./_test_spool")
 
 	err := cfg.Parse()
@@ -92,8 +87,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	require.NoError(t, err)
 
 	createBucket(t, rt, rt.Config.S3AttachmentsBucket)
-	setupElasticContacts(t, rt)
-	setupElasticMessages(t, rt)
+	ensureElastic(t, rt)
 
 	// create Dynamo tables if necessary
 	dyntest.CreateTables(t, rt.Dynamo.Main.Client(), testdataPath("dynamo.json"), false)
@@ -105,6 +99,8 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 
 	err = rt.Start()
 	require.NoError(t, err, "error starting runtime")
+
+	ClearElastic(t, rt) // so every test starts with empty indexes (ES writer must be started for its flush)
 
 	models.InitCache(rt)
 
@@ -165,13 +161,6 @@ func createBucket(t *testing.T, rt *runtime.Runtime, bucket string) {
 		_, err = rt.S3.Client.CreateBucket(t.Context(), &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 		require.NoError(t, err)
 	}
-}
-
-func resetElastic(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	rt.ES.Writer.Flush()
-	clearElasticIndexes(t, rt)
 }
 
 func resetDynamo(t *testing.T, rt *runtime.Runtime) {

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -35,8 +35,6 @@ func TestCreate(t *testing.T) {
 func TestDeindex(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
-
 	// index Bob and Cat into the v2 contacts index
 	oa := testdb.Org1.Load(t, rt)
 	mcs, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{testdb.Bob.ID, testdb.Cat.ID})
@@ -75,14 +73,11 @@ func TestDeindex(t *testing.T) {
 func TestReindex(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
-
 	testsuite.RunWebTests(t, rt, "testdata/reindex.json")
 }
 
 func TestExport(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 
@@ -91,7 +86,6 @@ func TestExport(t *testing.T) {
 
 func TestExportPreview(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 
@@ -190,8 +184,6 @@ func TestParseQuery(t *testing.T) {
 func TestPopulateGroup(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
-
 	testdb.InsertContactGroup(t, rt, testdb.Org1, "", "Dynamic", "age > 18")
 
 	testsuite.RunWebTests(t, rt, "testdata/populate_group.json")
@@ -199,7 +191,6 @@ func TestPopulateGroup(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 

--- a/web/flow/base_test.go
+++ b/web/flow/base_test.go
@@ -55,7 +55,6 @@ func TestStart(t *testing.T) {
 
 func TestStartPreview(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -15,7 +15,7 @@ import (
 func TestSend(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	// add an unreachable contact (i.e. no URNs)
 	testdb.InsertContact(t, rt, testdb.Org1, "f5e5c595-0cba-4eb9-b1e6-41d7f7f0add6", "Mr Unreachable", "eng", models.ContactStatusActive)
@@ -30,7 +30,7 @@ func TestSend(t *testing.T) {
 func TestDelete(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "goodbye world", models.MsgStatusPending, "")
@@ -54,7 +54,7 @@ func TestDelete(t *testing.T) {
 func TestHandle(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusPending, "")
@@ -66,7 +66,7 @@ func TestHandle(t *testing.T) {
 func TestResend(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
 	testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "how can we help", nil, models.MsgStatusSent, false)
@@ -80,7 +80,7 @@ func TestResend(t *testing.T) {
 func TestBroadcast(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo|testsuite.ResetElastic)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	createRun := func(org *testdb.Org, contact *testdb.Contact, nodeUUID core.NodeUUID) {
 		sessionUUID := testdb.InsertFlowSession(t, rt, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil, testdb.Favorites)
@@ -96,7 +96,6 @@ func TestBroadcast(t *testing.T) {
 
 func TestBroadcastPreview(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
 
 	testsuite.IndexContacts(t, rt)
 
@@ -106,7 +105,7 @@ func TestBroadcastPreview(t *testing.T) {
 func TestSearch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "01955193-de00-7000-8000-000000000001", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
 

--- a/web/org/base_test.go
+++ b/web/org/base_test.go
@@ -37,8 +37,6 @@ func TestDeindex(t *testing.T) {
 
 	rt.DB.MustExec(`UPDATE orgs_org SET is_active = false WHERE id = $1`, testdb.Org1.ID)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetElastic)
-
 	testsuite.RunWebTests(t, rt, "testdata/deindex.json")
 
 	vc := rt.VK.Get()


### PR DESCRIPTION
## Summary

Extends per-run test isolation to Elasticsearch, following the per-test databases (#1186) and per-test valkey databases (#1193): each test binary gets its own indexes, so concurrently running binaries — including other checkouts sharing an Elasticsearch — never see each other's documents, and every test starts with empty indexes.

## Changes

- **`testsuite/elastic.go`** — each binary's indexes are suffixed with its process identifier (`contacts-test-<procid>`, monthly message indexes under `messages-test-<procid>-`). Isolation is per-binary rather than per-test because index creation costs ~0.3–1s — too slow to do hundreds of times — and binaries are the unit of `go test -p` parallelism anyway; tests within a binary run sequentially.
- Within a binary, `ClearElastic` runs at the start of every test (delete-by-query on contacts plus dropping message indexes, ~tens of ms), so tests always start empty.
- Ownership follows the dbtemplate pattern: each binary holds a Postgres advisory lock on its process identifier for its lifetime, and setup sweeps away indexes whose owning run has died. The message index template stays shared (`messages-test` matching `messages-test-*`) — it's pure mapping config, safe for every binary, so there's no template churn to sweep.
- **`testsuite/runtime.go`** — wires the per-binary index names into each test's config and clears indexes after the runtime starts (the ES writer's flush needs its batcher running); the `ResetElastic` flag and `resetElastic()` are gone, and remaining flags were renumbered.
- **11 test files** — all 26 `ResetElastic` usages removed; the one mid-test reset (handlers web tests, which assert exact index contents per case) now uses the exported `testsuite.ClearElastic`.

## Notes for reviewers

- The scheme assumes tests within a binary run sequentially — a `t.Parallel()` test would have its documents cleared by the next test to start. Documented in the header, same caveat as the valkey claims.
- This also eliminates the cross-run flake where another checkout's test run could land documents in the shared index mid-assertion.

## Test plan

- Full suite green with `-p=1` (41 packages)
- Sweep observed working: after a full run only the final binary's index remains, and a subsequent run sweeps that one too
- Elastic-heavy packages (`core/search`, `web/contact`, `web/msg`, `core/crons`) verified individually