### PR TITLE
Give each test binary its own dynamo tables

### DIFF
--- a/core/models/channel_log_test.go
+++ b/core/models/channel_log_test.go
@@ -20,8 +20,6 @@ import (
 func TestChannelLogsOutgoing(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	mocks := httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"http://ivr.com/start":  {httpx.NewMockResponse(200, nil, []byte("OK"))},
 		"http://ivr.com/hangup": {httpx.NewMockResponse(400, nil, []byte("Oops"))},
@@ -58,10 +56,10 @@ func TestChannelLogsOutgoing(t *testing.T) {
 
 	rt.Dynamo.Main.Flush()
 
-	dyntest.AssertCount(t, rt.Dynamo.Main.Client(), "TestMain", 2)
+	dyntest.AssertCount(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table(), 2)
 
 	// read log back from DynamoDB
-	item, err := dynamo.GetItem(ctx, rt.Dynamo.Main.Client(), "TestMain", clog1.DynamoKey())
+	item, err := dynamo.GetItem(ctx, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table(), clog1.DynamoKey())
 	require.NoError(t, err)
 	if assert.NotNil(t, item) {
 		assert.Equal(t, string(models.ChannelLogTypeIVRStart), item.Data["type"])

--- a/core/msgio/courier_test.go
+++ b/core/msgio/courier_test.go
@@ -25,8 +25,6 @@ import (
 func TestNewCourierMsg(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	// create a new contact with a URN with an auth token
 	testFred := testdb.InsertContact(t, rt, testdb.Org1, "fed2d179-73ac-44fd-b838-7f866fef0a3a", "Fred", "eng", models.ContactStatusActive)
 	testdb.InsertContactURN(t, rt, testdb.Org1, testFred, "tel:+593979123456", 1000, map[string]string{"default": "sesame"})

--- a/core/runner/handlers/webhook_called_test.go
+++ b/core/runner/handlers/webhook_called_test.go
@@ -77,7 +77,6 @@ func TestUnhealthyWebhookCalls(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 	defer dates.SetNowFunc(time.Now)
 
 	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2021, 11, 17, 7, 0, 0, 0, time.UTC), time.Second))

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -74,7 +74,7 @@ func TestSessionCreationAndUpdating(t *testing.T) {
 
 	// check events were persisted to DynamoDB
 	rt.Dynamo.History.Flush()
-	dyntest.AssertCount(t, rt.Dynamo.History.Client(), "TestHistory", 6)
+	dyntest.AssertCount(t, rt.Dynamo.History.Client(), rt.Dynamo.History.Table(), 6)
 
 	testsuite.AssertContactFires(t, rt, testdb.Bob.ID, map[string]time.Time{
 		fmt.Sprintf("E:%s", scBob.Session.UUID()): time.Date(2025, 2, 25, 16, 55, 10, 0, time.UTC), // 10 minutes in future
@@ -128,8 +128,6 @@ func TestSessionCreationAndUpdating(t *testing.T) {
 func TestSingleSprintSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	flow := testFlows[1]
 
@@ -160,7 +158,6 @@ func TestSessionWithSubflows(t *testing.T) {
 
 	defer dates.SetNowFunc(time.Now)
 	defer random.SetGenerator(random.DefaultGenerator)
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	parent, child := testFlows[2], testFlows[3]
@@ -260,7 +257,7 @@ func TestBulkCommitPublishesEvents(t *testing.T) {
 			ephemeral++
 		}
 	}
-	dyntest.AssertCount(t, rt.Dynamo.History.Client(), "TestHistory", len(types)-ephemeral)
+	dyntest.AssertCount(t, rt.Dynamo.History.Client(), rt.Dynamo.History.Table(), len(types)-ephemeral)
 
 	// helper returning the contact_flow_changed events published since the last call
 	seen := len(sent)
@@ -345,8 +342,6 @@ func TestBulkCommitPublishesNotifications(t *testing.T) {
 func TestBulkCommitPublishesFlowActivity(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	other, parent, child := testFlows[1], testFlows[2], testFlows[3]
 
@@ -391,10 +386,6 @@ func TestSessionFailedStart(t *testing.T) {
 
 	defer dates.SetNowFunc(time.Now)
 	defer random.SetGenerator(random.DefaultGenerator)
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
-	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
-	testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/ping_pong.json")
 	ping, pong := testFlows[0], testFlows[1]
@@ -431,8 +422,6 @@ func TestFlowStats(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()
 	defer vc.Close()
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	defer random.SetGenerator(random.DefaultGenerator)
 	random.SetGenerator(random.NewSeededGenerator(123))
@@ -541,7 +530,7 @@ func TestFlowStats(t *testing.T) {
 func TestResumeSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetStorage|testsuite.ResetDynamo)
+	defer testsuite.Reset(t, rt, testsuite.ResetStorage)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg)
 	require.NoError(t, err)
@@ -621,11 +610,6 @@ func TestResumeSession(t *testing.T) {
 
 func TestBroadcastWithLock(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
-	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
-	testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)

--- a/core/runner/start_test.go
+++ b/core/runner/start_test.go
@@ -20,8 +20,6 @@ import (
 func TestStartFlowConcurrency(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	// check everything works with big ids
 	rt.DB.MustExec(`ALTER SEQUENCE flows_flowrun_id_seq RESTART WITH 5000000000;`)
 	rt.DB.MustExec(`ALTER SEQUENCE flows_flowsession_id_seq RESTART WITH 5000000000;`)

--- a/core/search/messages_test.go
+++ b/core/search/messages_test.go
@@ -17,8 +17,6 @@ import (
 func TestSearchMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	// pin the clock to just after the message fixtures so they stay within the search's rolling time window
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2025, 12, 16, 0, 0, 0, 0, time.UTC)))

--- a/core/tasks/bulk_wait_expire_test.go
+++ b/core/tasks/bulk_wait_expire_test.go
@@ -14,8 +14,6 @@ import (
 func TestBulkSessionExpire(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))
 

--- a/core/tasks/bulk_wait_timeout_test.go
+++ b/core/tasks/bulk_wait_timeout_test.go
@@ -14,8 +14,6 @@ import (
 func TestBulkSessionTimeout(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	defer dates.SetNowFunc(time.Now)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2024, 11, 15, 13, 59, 0, 0, time.UTC)))
 

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -18,9 +18,6 @@ func TestContactChanged(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	// this test pops tasks without marking them done, inflating the org's active count in the fair queue,
-	// so it needs to reset valkey for the tests which come after it
-
 	type urnRow struct {
 		Identity  string            `db:"identity"`
 		ChannelID *models.ChannelID `db:"channel_id"`

--- a/core/tasks/ctasks/contact_changed_test.go
+++ b/core/tasks/ctasks/contact_changed_test.go
@@ -20,7 +20,6 @@ func TestContactChanged(t *testing.T) {
 
 	// this test pops tasks without marking them done, inflating the org's active count in the fair queue,
 	// so it needs to reset valkey for the tests which come after it
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	type urnRow struct {
 		Identity  string            `db:"identity"`

--- a/core/tasks/ctasks/msg_deleted_test.go
+++ b/core/tasks/ctasks/msg_deleted_test.go
@@ -16,11 +16,6 @@ import (
 func TestMsgDeleted(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
-	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
-	testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	oa := testdb.Org1.Load(t, rt)
 
 	ann, _, _ := testdb.Ann.Load(t, rt, oa)

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -441,7 +441,6 @@ func TestMsgReceivedNewURN(t *testing.T) {
 	defer vc.Close()
 
 	// pops tasks without marking them done, so needs to reset valkey for the tests which come after it
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	dbMsg := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Bob, "", models.MsgStatusPending, "")
 
@@ -613,11 +612,6 @@ func TestMsgReceivedNewURN(t *testing.T) {
 
 func TestMsgReceivedPayload(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
-	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
-	testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	oa := testdb.Org1.Load(t, rt)
 	ann, _, _ := testdb.Ann.Load(t, rt, oa)

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -440,8 +440,6 @@ func TestMsgReceivedNewURN(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	// pops tasks without marking them done, so needs to reset valkey for the tests which come after it
-
 	dbMsg := testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Bob, "", models.MsgStatusPending, "")
 
 	type urnRow struct {

--- a/core/tasks/import_contact_batch_test.go
+++ b/core/tasks/import_contact_batch_test.go
@@ -17,8 +17,6 @@ import (
 func TestImportContactBatch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
 	batch1ID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
 		{"name": "Norbert", "language": "eng", "urns": ["tel:+16055740001"]},
@@ -60,8 +58,6 @@ func TestImportContactBatch(t *testing.T) {
 
 func TestImportContactBatchFailure(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
 

--- a/core/tasks/interrupt_channel_test.go
+++ b/core/tasks/interrupt_channel_test.go
@@ -18,11 +18,6 @@ import (
 func TestInterruptChannel(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
-	// asserts on the entire contents of the shared history table so can't inherit items leaked by other tests
-	testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	// twilio call
 	twilioCall := testdb.InsertCall(t, rt, testdb.Org1, testdb.TwilioChannel, testdb.Dan)
 

--- a/core/tasks/interrupt_flow_test.go
+++ b/core/tasks/interrupt_flow_test.go
@@ -18,8 +18,6 @@ func TestInterruptFlow(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s3UUID := testdb.InsertFlowSession(t, rt, testdb.Cat, models.FlowTypeMessaging, models.SessionStatusCompleted, nil, testdb.Favorites)

--- a/core/tasks/interrupt_session_batch_test.go
+++ b/core/tasks/interrupt_session_batch_test.go
@@ -17,8 +17,6 @@ import (
 func TestInterruptSessionBatch(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s3UUID := testdb.InsertFlowSession(t, rt, testdb.Cat, models.FlowTypeMessaging, models.SessionStatusCompleted, nil, testdb.Favorites)
@@ -47,8 +45,6 @@ func TestInterruptSessionBatchDecrements(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()
 	defer vc.Close()
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)

--- a/testsuite/dbtemplate.go
+++ b/testsuite/dbtemplate.go
@@ -10,6 +10,7 @@ import (
 	"hash/fnv"
 	"os"
 	"os/exec"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -51,6 +52,28 @@ var dbProcID = sync.OnceValue(func() string {
 	b := make([]byte, 4)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+})
+
+// matches a process identifier segment in a per-binary resource name
+var binProcIDRegex = regexp.MustCompile(`^[0-9a-f]{8}$`)
+
+// binKey derives the advisory lock key which marks a binary's per-binary resources - its elastic indexes
+// and dynamo tables - as in use
+func binKey(procID string) int64 {
+	return dbKey("binary_" + procID)
+}
+
+// claimBinary takes the advisory lock which marks this binary's resources as in use, before any of them
+// exist, so they're never visible to another binary's sweep unclaimed. Held for the binary's lifetime.
+var claimBinary = sync.OnceValue(func() error {
+	owner, err := dbOwner()
+	if err != nil {
+		return err
+	}
+	if _, err := owner.ExecContext(context.Background(), `SELECT pg_advisory_lock($1)`, binKey(dbProcID())); err != nil {
+		return fmt.Errorf("error claiming binary resources: %w", err)
+	}
+	return nil
 })
 
 // admin pool is opened once per test binary and left open for its lifetime

--- a/testsuite/dynamo.go
+++ b/testsuite/dynamo.go
@@ -1,7 +1,13 @@
 package testsuite
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +20,128 @@ import (
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/stretchr/testify/require"
 )
+
+// Each test binary gets its own dynamo tables (prefixed with its process identifier), so concurrently
+// running binaries never see each other's items. Within a binary, ClearDynamo runs at the start of every
+// test so each starts with empty tables - assuming sequential tests, as elsewhere. Ownership is the same
+// per-binary advisory lock that marks the elastic indexes (see dbtemplate.go), and setup sweeps away the
+// tables of any run which has died.
+
+// per-binary prefix for dynamo table names, e.g. Testa1b2c3d4 -> Testa1b2c3d4Main
+func dynTablePrefix() string {
+	return "Test" + dbProcID()
+}
+
+var dynSetup sync.Once
+var dynSetupErr error
+
+// ensureDynamo creates this binary's dynamo tables on first use
+func ensureDynamo(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	dynSetup.Do(func() { dynSetupErr = setupDynamo(rt) })
+	require.NoError(t, dynSetupErr, "error setting up dynamo tables")
+}
+
+// setupDynamo claims this binary's tables, creates them, and sweeps those of dead runs
+func setupDynamo(rt *runtime.Runtime) error {
+	ctx := context.Background()
+
+	if err := claimBinary(); err != nil {
+		return err
+	}
+
+	tablesJSON, err := os.ReadFile(testdataPath("dynamo.json"))
+	if err != nil {
+		return err
+	}
+	inputs := []*dynamodb.CreateTableInput{}
+	if err := json.Unmarshal(tablesJSON, &inputs); err != nil {
+		return fmt.Errorf("error unmarshaling dynamo.json: %w", err)
+	}
+
+	client := rt.Dynamo.Main.Client()
+
+	for _, input := range inputs {
+		input.TableName = aws.String(rt.Config.DynamoTablePrefix + *input.TableName)
+
+		if _, err := client.CreateTable(ctx, input); err != nil {
+			return fmt.Errorf("error creating table %s: %w", *input.TableName, err)
+		}
+	}
+
+	return sweepStaleDynamo(ctx, client)
+}
+
+// sweepStaleDynamo deletes the tables of binaries which are no longer running - any process identifier
+// whose per-binary lock we can take ourselves belongs to a run which is no longer around.
+func sweepStaleDynamo(ctx context.Context, client *dynamodb.Client) error {
+	admin, err := dbAdmin()
+	if err != nil {
+		return err
+	}
+	conn, err := admin.DB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	byProcID := make(map[string][]string)
+	var startFrom *string
+	for {
+		resp, err := client.ListTables(ctx, &dynamodb.ListTablesInput{ExclusiveStartTableName: startFrom})
+		if err != nil {
+			return fmt.Errorf("error listing tables: %w", err)
+		}
+		for _, name := range resp.TableNames {
+			rest := strings.TrimPrefix(name, "Test")
+			if len(rest) < 8 {
+				continue
+			}
+			procID := rest[:8]
+			if procID == dbProcID() || !binProcIDRegex.MatchString(procID) {
+				continue // ours, or not a per-binary test table
+			}
+			byProcID[procID] = append(byProcID[procID], name)
+		}
+		if resp.LastEvaluatedTableName == nil {
+			break
+		}
+		startFrom = resp.LastEvaluatedTableName
+	}
+
+	for procID, names := range byProcID {
+		var got bool
+		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
+			return err
+		}
+		if !got {
+			continue // in use by a live run
+		}
+
+		for _, name := range names {
+			if _, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String(name)}); err != nil {
+				return fmt.Errorf("error deleting stale table %s: %w", name, err)
+			}
+		}
+
+		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
+	}
+
+	return nil
+}
+
+// ClearDynamo clears out this binary's dynamo tables. Runs at the start of every test, and can be called
+// mid-test by tests which assert on exact table contents across phases.
+func ClearDynamo(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	rt.Dynamo.Main.Flush()
+	rt.Dynamo.History.Flush()
+
+	dyntest.Truncate(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table())
+	dyntest.Truncate(t, rt.Dynamo.History.Client(), rt.Dynamo.History.Table())
+}
 
 func GetHistoryItems(t *testing.T, rt *runtime.Runtime, clear bool, after time.Time) []*dynamo.Item {
 	t.Helper()

--- a/testsuite/dynamo.go
+++ b/testsuite/dynamo.go
@@ -70,6 +70,14 @@ func setupDynamo(rt *runtime.Runtime) error {
 		}
 	}
 
+	// wait for tables to be usable - localstack creates synchronously but real DynamoDB doesn't
+	waiter := dynamodb.NewTableExistsWaiter(client)
+	for _, input := range inputs {
+		if err := waiter.Wait(ctx, &dynamodb.DescribeTableInput{TableName: input.TableName}, 30*time.Second); err != nil {
+			return fmt.Errorf("error waiting for table %s: %w", *input.TableName, err)
+		}
+	}
+
 	return sweepStaleDynamo(ctx, client)
 }
 

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -43,17 +42,9 @@ const (
 	esMessagesTemplate = "messages-test"
 )
 
-// matches the process identifier segment of a per-binary index name
-var esProcIDRegex = regexp.MustCompile(`^[0-9a-f]{8}$`)
-
 // per-binary index names
 func esContactsIndex() string { return esContactsPrefix + dbProcID() }
 func esMessagesIndex() string { return esMessagesPrefix + dbProcID() }
-
-// esKey derives the advisory lock key which marks a binary's elastic indexes as in use
-func esKey(procID string) int64 {
-	return dbKey("elastic_" + procID)
-}
 
 var esSetup sync.Once
 var esSetupErr error
@@ -70,14 +61,8 @@ func ensureElastic(t *testing.T, rt *runtime.Runtime) {
 func setupElastic(rt *runtime.Runtime) error {
 	ctx := context.Background()
 
-	owner, err := dbOwner()
-	if err != nil {
+	if err := claimBinary(); err != nil {
 		return err
-	}
-
-	// claim our indexes before they exist, so they're never visible to another binary's sweep unclaimed
-	if _, err := owner.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, esKey(dbProcID())); err != nil {
-		return fmt.Errorf("error claiming elastic indexes: %w", err)
 	}
 
 	contactsBody, err := os.ReadFile(testdataPath("es_contacts.json"))
@@ -126,7 +111,7 @@ func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
 		}
 		rest := strings.TrimPrefix(strings.TrimPrefix(*idx.Index, esContactsPrefix), esMessagesPrefix)
 		procID, _, _ := strings.Cut(rest, "-")
-		if procID == dbProcID() || !esProcIDRegex.MatchString(procID) {
+		if procID == dbProcID() || !binProcIDRegex.MatchString(procID) {
 			continue // ours, or not a per-binary test index
 		}
 		byProcID[procID] = append(byProcID[procID], *idx.Index)
@@ -134,7 +119,7 @@ func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
 
 	for procID, names := range byProcID {
 		var got bool
-		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, esKey(procID)).Scan(&got); err != nil {
+		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
 			return err
 		}
 		if !got {
@@ -147,7 +132,7 @@ func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
 			}
 		}
 
-		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, esKey(procID))
+		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
 	}
 
 	return nil

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/gocommon/centrifugo"
 	"github.com/nyaruka/mailroom/v26/core/goflow"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -28,8 +27,8 @@ func testdataPath(file string) string {
 }
 
 // Refresh is our type for the pieces of state we want fresh. Note that there are no flags for the database,
-// valkey or elastic because each test starts with its own clean state (see dbtemplate.go, valkey.go and
-// elastic.go).
+// valkey, elastic or dynamo because each test starts with its own clean state (see dbtemplate.go, valkey.go,
+// elastic.go and dynamo.go).
 type ResetFlag int
 
 // refresh bit masks
@@ -37,16 +36,12 @@ const (
 	ResetNone    = ResetFlag(0)
 	ResetAll     = ResetFlag(^0)
 	ResetStorage = ResetFlag(1 << 0)
-	ResetDynamo  = ResetFlag(1 << 1)
 )
 
 // Reset clears out the state shared between tests
 func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
 	if what&ResetStorage > 0 {
 		resetStorage(t, rt)
-	}
-	if what&ResetDynamo > 0 {
-		resetDynamo(t, rt)
 	}
 }
 
@@ -77,7 +72,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.S3AttachmentsBucket = "test-attachments"
 	cfg.S3PathStyle = true
 	cfg.DynamoEndpoint = "http://localstack:4566"
-	cfg.DynamoTablePrefix = "Test"
+	cfg.DynamoTablePrefix = dynTablePrefix() // this binary's own tables, cleared before every test - see dynamo.go
 	cfg.SpoolDir = absPath("./_test_spool")
 
 	err := cfg.Parse()
@@ -88,9 +83,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 
 	createBucket(t, rt, rt.Config.S3AttachmentsBucket)
 	ensureElastic(t, rt)
-
-	// create Dynamo tables if necessary
-	dyntest.CreateTables(t, rt.Dynamo.Main.Client(), testdataPath("dynamo.json"), false)
+	ensureDynamo(t, rt)
 
 	rt.FCM = &MockFCMClient{ValidTokens: []string{"FCMID3", "FCMID4", "FCMID5"}}
 	rt.Centrifugo = centrifugo.NewService(centrifugo.NewMockClient(), rt.VK)
@@ -100,7 +93,9 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	err = rt.Start()
 	require.NoError(t, err, "error starting runtime")
 
-	ClearElastic(t, rt) // so every test starts with empty indexes (ES writer must be started for its flush)
+	// so every test starts with empty indexes and tables (the writers must be started for their flushes)
+	ClearElastic(t, rt)
+	ClearDynamo(t, rt)
 
 	models.InitCache(rt)
 
@@ -161,15 +156,6 @@ func createBucket(t *testing.T, rt *runtime.Runtime, bucket string) {
 		_, err = rt.S3.Client.CreateBucket(t.Context(), &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 		require.NoError(t, err)
 	}
-}
-
-func resetDynamo(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	rt.Dynamo.Main.Flush()
-	rt.Dynamo.History.Flush()
-
-	dyntest.CreateTables(t, rt.Dynamo.Main.Client(), testdataPath("dynamo.json"), true)
 }
 
 func ReadFile(t *testing.T, path string) []byte {

--- a/web/msg/base_test.go
+++ b/web/msg/base_test.go
@@ -15,8 +15,6 @@ import (
 func TestSend(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	// add an unreachable contact (i.e. no URNs)
 	testdb.InsertContact(t, rt, testdb.Org1, "f5e5c595-0cba-4eb9-b1e6-41d7f7f0add6", "Mr Unreachable", "eng", models.ContactStatusActive)
 
@@ -29,8 +27,6 @@ func TestSend(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "goodbye world", models.MsgStatusPending, "")
@@ -54,8 +50,6 @@ func TestDelete(t *testing.T) {
 func TestHandle(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
-
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusPending, "")
 	testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bb93-ec0f-703e-9b5b-d26d4b6b133c", testdb.TwilioChannel, testdb.Ann, "how can we help", nil, models.MsgStatusSent, false)
@@ -65,8 +59,6 @@ func TestHandle(t *testing.T) {
 
 func TestResend(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "0199bad8-f98d-75a3-b641-2718a25ac3f5", testdb.TwilioChannel, testdb.Ann, "hello", models.MsgStatusHandled, "")
 	testdb.InsertOutgoingMsg(t, rt, testdb.Org1, "0199bad9-9791-770d-a47d-8f4a6ea3ad13", testdb.TwilioChannel, testdb.Ann, "how can we help", nil, models.MsgStatusSent, false)
@@ -79,8 +71,6 @@ func TestResend(t *testing.T) {
 
 func TestBroadcast(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	createRun := func(org *testdb.Org, contact *testdb.Contact, nodeUUID core.NodeUUID) {
 		sessionUUID := testdb.InsertFlowSession(t, rt, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil, testdb.Favorites)
@@ -104,8 +94,6 @@ func TestBroadcastPreview(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetDynamo)
 
 	testdb.InsertIncomingMsg(t, rt, testdb.Org1, "01955193-de00-7000-8000-000000000001", testdb.TwilioChannel, testdb.Ann, "hello world", models.MsgStatusHandled, "")
 

--- a/web/public/ivr_test.go
+++ b/web/public/ivr_test.go
@@ -247,7 +247,7 @@ func getCallLogs(t *testing.T, rt *runtime.Runtime, ch *testdb.Channel) []*httpx
 
 	for _, logUUID := range logUUIDs {
 		key := dynamo.Key{PK: fmt.Sprintf("cha#%s#%s", ch.UUID, logUUID[35:36]), SK: fmt.Sprintf("log#%s", logUUID)}
-		item, err := dynamo.GetItem(t.Context(), rt.Dynamo.Main.Client(), "TestMain", key)
+		item, err := dynamo.GetItem(t.Context(), rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table(), key)
 		require.NoError(t, err)
 		require.NotNil(t, item, "log item not found for key %s", key)
 


### PR DESCRIPTION
## Summary

Extends per-run test isolation to DynamoDB, completing the pattern from the per-test databases (#1186), valkey databases (#1193) and elastic indexes (#1195): each test binary gets its own tables, so concurrently running binaries never see each other's items, and every test starts with empty tables.

## Changes

- **`testsuite/dbtemplate.go`** — the per-binary ownership claim is now shared machinery: `claimBinary()` takes a single advisory lock (`binary_<procid>`) covering all of a binary's per-binary resources, used by both the elastic and dynamo sweeps. The elastic code was refactored onto it, replacing its own `elastic_<procid>` key.
- **`testsuite/dynamo.go`** — each binary's tables are prefixed with its process identifier (`Test<procid>Main`, `Test<procid>History`), created once per binary from `dynamo.json` — with a `TableExistsWaiter` so setup doesn't assume localstack's synchronous creation — and swept when the owning run dies. `ClearDynamo` truncates both tables at the start of every test; truncation rather than drop/recreate, since table creation is the slow part.
- **`testsuite/runtime.go`** — wires the per-binary prefix into each test's config; the `ResetDynamo` flag and `resetDynamo()` are gone, leaving only `ResetStorage`.
- **17 test files** — all 37 `ResetDynamo` usages removed, including five start-of-test resets whose "can't inherit leaked items" rationale no longer applies; four assertions that hardcoded `"TestMain"`/`"TestHistory"` now use `rt.Dynamo.Main.Table()`/`History.Table()`; two comments orphaned by the reset sweeps deleted.

## Notes for reviewers

- Same sequential-tests assumption as the other per-binary schemes, documented in the header.
- Transitional: the elastic ownership key changed (`elastic_<procid>` → `binary_<procid>`), so a run of old code executing concurrently with a run of this branch could have its live elastic indexes swept. One-time hazard during switchover.

## Test plan

- Full suite green with `-p=1` (41 packages) locally and in CI
- Sweep observed working: a follow-up run deleted the finished binary's tables and left only its own
- Dynamo-heavy packages (`core/tasks`, `core/runner`, `core/models`, `web/public`) verified individually