### PR TITLE
Give each test binary its own attachments bucket

### DIFF
--- a/core/crons/retry_calls_test.go
+++ b/core/crons/retry_calls_test.go
@@ -17,8 +17,6 @@ import (
 func TestRetryCalls(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// register our mock client
 	ivr.RegisterService(models.ChannelType("ZZ"), testsuite.NewIVRServiceFactory)
 

--- a/core/imports/contacts_test.go
+++ b/core/imports/contacts_test.go
@@ -32,8 +32,6 @@ func TestContactImports(t *testing.T) {
 	reset := test.MockUniverse()
 	defer reset()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// start with no contacts or URNs
 	rt.DB.MustExec(`DELETE FROM contacts_contacturn`)
 	rt.DB.MustExec(`DELETE FROM contacts_contactgroup_contacts`)

--- a/core/models/channel_test.go
+++ b/core/models/channel_test.go
@@ -14,8 +14,6 @@ import (
 func TestChannels(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// add some tel specific config to channel 2
 	rt.DB.MustExec(`UPDATE channels_channel SET config = '{"matching_prefixes": ["250", "251"], "allow_international": true}' WHERE id = $1`, testdb.VonageChannel.ID)
 

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -24,8 +24,6 @@ import (
 func TestContacts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// for now it's still possible to have more than one open ticket in the database
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-717a-a39e-e8ca91fb7262", testdb.Org1, testdb.Ann, testdb.SupportTopic, time.Now(), testdb.Agent)
 	testdb.InsertOpenTicket(t, rt, "01992f54-5ab6-725e-be9c-0c6407efd755", testdb.Org1, testdb.Ann, testdb.SalesTopic, time.Now(), nil)
@@ -457,8 +455,6 @@ func TestGetContactIDsPage(t *testing.T) {
 func TestUpdateContactLastSeenAndModifiedOn(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
@@ -491,8 +487,6 @@ func TestUpdateContactLastSeenAndModifiedOn(t *testing.T) {
 func TestUpdateContactStatus(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	err := models.UpdateContactStatus(ctx, rt.DB, []*models.ContactStatusChange{})
 	assert.NoError(t, err)
 
@@ -521,8 +515,6 @@ func TestUpdateContactStatus(t *testing.T) {
 
 func TestUpdateContactURNs(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	assert.NoError(t, err)

--- a/core/models/flow_test.go
+++ b/core/models/flow_test.go
@@ -17,8 +17,6 @@ import (
 func TestLoadFlows(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	rt.DB.MustExec(`UPDATE flows_flow SET ivr_retry = 30 WHERE id = $1`, testdb.IVRFlow.ID)
 	rt.DB.MustExec(`UPDATE flows_flow SET expires_after_minutes = 720 WHERE id = $1`, testdb.Favorites.ID)
 	rt.DB.MustExec(`UPDATE flows_flow SET expires_after_minutes = 1 WHERE id = $1`, testdb.PickANumber.ID)          // too small for messaging

--- a/core/models/msg_test.go
+++ b/core/models/msg_test.go
@@ -210,8 +210,6 @@ func TestGetMessagesByUUID(t *testing.T) {
 func TestResendMessages(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 

--- a/core/models/org_test.go
+++ b/core/models/org_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -19,8 +20,6 @@ import (
 
 func TestLoadOrg(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	tz, _ := time.LoadLocation("America/Los_Angeles")
 
@@ -66,8 +65,6 @@ func TestLoadOrg(t *testing.T) {
 func TestGetOrgIDFromUUID(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// mark org 2 deleted
 	rt.DB.MustExec(`UPDATE orgs_org SET is_active = FALSE WHERE id = $1`, testdb.Org2.ID)
 
@@ -83,8 +80,6 @@ func TestGetOrgIDFromUUID(t *testing.T) {
 
 func TestEmailService(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	// make org 2 a child of org 1
 	rt.DB.MustExec(`UPDATE orgs_org SET parent_id = $2 WHERE id = $1`, testdb.Org2.ID, testdb.Org1.ID)
@@ -126,8 +121,6 @@ func TestEmailService(t *testing.T) {
 func TestStoreAttachment(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetStorage)
-
 	image, err := os.Open("testdata/test.jpg")
 	require.NoError(t, err)
 
@@ -137,7 +130,8 @@ func TestStoreAttachment(t *testing.T) {
 	attachment, err := org.StoreAttachment(context.Background(), rt, "668383ba-387c-49bc-b164-1213ac0ea7aa.jpg", "image/jpeg", image)
 	require.NoError(t, err)
 
-	assert.Equal(t, utils.Attachment("image/jpeg:http://localstack:4566/test-attachments/attachments/1/6683/83ba/668383ba-387c-49bc-b164-1213ac0ea7aa.jpg"), attachment)
+	expectedURL := fmt.Sprintf("http://localstack:4566/%s/attachments/1/6683/83ba/668383ba-387c-49bc-b164-1213ac0ea7aa.jpg", rt.Config.S3AttachmentsBucket)
+	assert.Equal(t, utils.Attachment("image/jpeg:"+expectedURL), attachment)
 
 	// err trying to read from same reader again
 	_, err = org.StoreAttachment(context.Background(), rt, "668383ba-387c-49bc-b164-1213ac0ea7aa.jpg", "image/jpeg", image)

--- a/core/models/trigger_test.go
+++ b/core/models/trigger_test.go
@@ -17,8 +17,6 @@ import (
 func TestLoadTriggers(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	rt.DB.MustExec(`DELETE FROM triggers_trigger`)
 	farmersGroup := testdb.InsertContactGroup(t, rt, testdb.Org1, assets.GroupUUID(uuids.NewV4()), "Farmers", "")
 
@@ -137,8 +135,6 @@ func TestLoadTriggers(t *testing.T) {
 func TestFindMatchingMsgTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	rt.DB.MustExec(`DELETE FROM triggers_trigger`)
 
 	joinID := testdb.InsertKeywordTrigger(t, rt, testdb.Org1, testdb.Favorites, []string{"join"}, models.MatchFirst, nil, nil, nil)
@@ -208,8 +204,6 @@ func TestFindMatchingMsgTrigger(t *testing.T) {
 
 func TestFindMatchingIncomingCallTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	doctorsAndNotTestersTriggerID := testdb.InsertIncomingCallTrigger(t, rt, testdb.Org1, testdb.Favorites, []*testdb.Group{testdb.DoctorsGroup}, []*testdb.Group{testdb.TestersGroup}, nil)
 	doctorsTriggerID := testdb.InsertIncomingCallTrigger(t, rt, testdb.Org1, testdb.Favorites, []*testdb.Group{testdb.DoctorsGroup}, nil, nil)
@@ -343,8 +337,6 @@ func TestFindMatchingReferralTrigger(t *testing.T) {
 
 func TestArchiveContactTriggers(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	everybodyID := testdb.InsertKeywordTrigger(t, rt, testdb.Org1, testdb.Favorites, []string{"join"}, models.MatchFirst, nil, nil, nil)
 	annOnly1ID := testdb.InsertScheduledTrigger(t, rt, testdb.Org1, testdb.Favorites, testdb.InsertSchedule(t, rt, testdb.Org1, models.RepeatPeriodMonthly, time.Now()), nil, nil, []*testdb.Contact{testdb.Ann})

--- a/core/runner/handlers/airtime_created_test.go
+++ b/core/runner/handlers/airtime_created_test.go
@@ -26,8 +26,6 @@ func TestAirtimeCreated(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 	rt.Config.Domain = "mailroom.example.com"
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// the in-sprint Create resolves the operator + product and submits the unconfirmed transaction; the
 	// post-commit hook then POSTs to /confirm with the provider id. HTTP logs surfaced inside the event are
 	// test data only and don't make real calls.

--- a/core/runner/handlers/broadcast_created_test.go
+++ b/core/runner/handlers/broadcast_created_test.go
@@ -9,7 +9,5 @@ import (
 func TestBroadcastCreated(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/broadcast_created.json")
 }

--- a/core/runner/handlers/campaigns_test.go
+++ b/core/runner/handlers/campaigns_test.go
@@ -10,8 +10,6 @@ import (
 func TestCampaigns(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// insert an event on our campaign that is based on created_on
 	testdb.InsertCampaignFlowPoint(t, rt, testdb.RemindersCampaign, testdb.Favorites, testdb.CreatedOnField, 1000, "W")
 

--- a/core/runner/handlers/contact_field_changed_test.go
+++ b/core/runner/handlers/contact_field_changed_test.go
@@ -10,8 +10,6 @@ import (
 func TestContactFieldChanged(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// populate some field values on Dan
 	rt.DB.MustExec(`UPDATE contacts_contact SET fields = '{"903f51da-2717-47c7-a0d3-f2f32877013d": {"text":"34"}, "3a5891e4-756e-4dc9-8e12-b7a766168824": {"text":"female"}}' WHERE id = $1`, testdb.Dan.ID)
 

--- a/core/runner/handlers/contact_groups_changed_test.go
+++ b/core/runner/handlers/contact_groups_changed_test.go
@@ -9,7 +9,5 @@ import (
 func TestContactGroupsChanged(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/contact_groups_changed.json")
 }

--- a/core/runner/handlers/contact_language_changed_test.go
+++ b/core/runner/handlers/contact_language_changed_test.go
@@ -9,7 +9,5 @@ import (
 func TestContactLanguageChanged(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/contact_language_changed.json")
 }

--- a/core/runner/handlers/contact_name_changed_test.go
+++ b/core/runner/handlers/contact_name_changed_test.go
@@ -9,7 +9,5 @@ import (
 func TestContactNameChanged(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/contact_name_changed.json")
 }

--- a/core/runner/handlers/contact_urns_changed_test.go
+++ b/core/runner/handlers/contact_urns_changed_test.go
@@ -9,7 +9,5 @@ import (
 func TestContactURNsChanged(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/contact_urns_changed.json")
 }

--- a/core/runner/handlers/input_labels_added_test.go
+++ b/core/runner/handlers/input_labels_added_test.go
@@ -9,7 +9,5 @@ import (
 func TestInputLabelsAdded(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/input_labels_added.json")
 }

--- a/core/runner/handlers/msg_created_test.go
+++ b/core/runner/handlers/msg_created_test.go
@@ -15,8 +15,6 @@ import (
 func TestMsgCreated(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	rt.Config.AttachmentDomain = "foo.bar.com"
 	defer func() { rt.Config.AttachmentDomain = "" }()
 
@@ -46,8 +44,6 @@ func TestMsgCreated(t *testing.T) {
 
 func TestMsgCreatedNewURN(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	// switch our twitter channel to telegram
 	rt.DB.MustExec(`UPDATE channels_channel SET channel_type = 'TG', name = 'Telegram', schemes = ARRAY['telegram'] WHERE uuid = $1`, testdb.FacebookChannel.UUID)

--- a/core/runner/handlers/msg_received_test.go
+++ b/core/runner/handlers/msg_received_test.go
@@ -9,7 +9,5 @@ import (
 func TestMsgReceived(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/msg_received.json")
 }

--- a/core/runner/handlers/run_started_test.go
+++ b/core/runner/handlers/run_started_test.go
@@ -9,7 +9,5 @@ import (
 func TestRunStarted(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/run_started.json")
 }

--- a/core/runner/handlers/session_triggered_test.go
+++ b/core/runner/handlers/session_triggered_test.go
@@ -10,8 +10,6 @@ import (
 func TestSessionTriggered(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	reset := test.MockUniverse()
 	defer reset()
 
@@ -20,8 +18,6 @@ func TestSessionTriggered(t *testing.T) {
 
 func TestSessionTriggeredByQuery(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	runTests(t, rt, "testdata/session_triggered_by_query.json")
 }

--- a/core/runner/handlers/ticket_opened_test.go
+++ b/core/runner/handlers/ticket_opened_test.go
@@ -9,7 +9,5 @@ import (
 func TestTicketOpened(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	runTests(t, rt, "testdata/ticket_opened.json")
 }

--- a/core/runner/handlers/webhook_called_test.go
+++ b/core/runner/handlers/webhook_called_test.go
@@ -27,8 +27,6 @@ import (
 func TestWebhookCalled(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	rt.HTTP.Engine.Transport = httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"http://rapidpro.io/": {
 			httpx.NewMockResponse(200, nil, []byte("OK")),

--- a/core/runner/hooks/confirm_airtime_transfers_test.go
+++ b/core/runner/hooks/confirm_airtime_transfers_test.go
@@ -25,8 +25,6 @@ func TestConfirmAirtimeTransfers(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	rt.Config.Domain = "mailroom.example.com"
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	rt.DB.MustExec(`UPDATE orgs_org SET config = '{"dtone_key": "key123", "dtone_secret": "sesame"}'::jsonb WHERE id = $1`, testdb.Org1.ID)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -38,7 +38,6 @@ func TestSessionCreationAndUpdating(t *testing.T) {
 
 	defer dates.SetNowFunc(time.Now)
 	defer random.SetGenerator(random.DefaultGenerator)
-	defer testsuite.Reset(t, rt, testsuite.ResetAll) // modifies contacts
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	flow := testFlows[0]
@@ -219,8 +218,6 @@ func TestSessionWithSubflows(t *testing.T) {
 
 func TestBulkCommitPublishesEvents(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll) // modifies contacts
 
 	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
 	flow := testFlows[0]
@@ -529,8 +526,6 @@ func TestFlowStats(t *testing.T) {
 
 func TestResumeSession(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetStorage)
 
 	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshOrg)
 	require.NoError(t, err)

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -116,8 +116,6 @@ func TestNewContactDoc(t *testing.T) {
 func TestDeindexContacts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	testsuite.IndexContacts(t, rt)
 
 	refreshV2 := func() {

--- a/core/search/resolve_test.go
+++ b/core/search/resolve_test.go
@@ -15,8 +15,6 @@ import (
 func TestResolveRecipients(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	group1 := testdb.InsertContactGroup(t, rt, testdb.Org1, "a85acec9-3895-4ffd-87c1-c69a25781a85", "Group 1", "", testdb.Cat, testdb.Dan)
 	group2 := testdb.InsertContactGroup(t, rt, testdb.Org1, "eb578345-595e-4e36-a68b-6941e242cdbb", "Group 2", "", testdb.Cat)
 

--- a/core/tasks/bulk_campaign_trigger_test.go
+++ b/core/tasks/bulk_campaign_trigger_test.go
@@ -17,8 +17,6 @@ import (
 func TestBulkCampaignTrigger(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	defer random.SetGenerator(random.DefaultGenerator)
 	random.SetGenerator(random.NewSeededGenerator(123))
 
@@ -135,8 +133,6 @@ func TestBulkCampaignTrigger(t *testing.T) {
 
 func TestBulkCampaignTriggerModes(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	// create waiting messaging sessions for Ann and Bob, Cat and Dan have no session
 	testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)

--- a/core/tasks/ctasks/base_test.go
+++ b/core/tasks/ctasks/base_test.go
@@ -42,8 +42,6 @@ func TestTimedEvents(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// create some keyword triggers
 	testdb.InsertKeywordTrigger(t, rt, testdb.Org1, testdb.Favorites, []string{"start"}, models.MatchOnly, nil, nil, nil)
 	testdb.InsertKeywordTrigger(t, rt, testdb.Org1, testdb.PickANumber, []string{"pick"}, models.MatchOnly, nil, nil, nil)

--- a/core/tasks/ctasks/event_received_test.go
+++ b/core/tasks/ctasks/event_received_test.go
@@ -26,8 +26,6 @@ func TestEventReceived(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	oa := testdb.Org1.Load(t, rt)
 
 	// stop Bob so we can test that he gets un-stopped on new conversation

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -23,8 +23,6 @@ func TestMsgReceivedTask(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	ivr.RegisterService(models.ChannelType("T"), testsuite.NewIVRServiceFactory)
 
 	// create a disabled channel

--- a/core/tasks/ctasks/ticket_closed_test.go
+++ b/core/tasks/ctasks/ticket_closed_test.go
@@ -18,8 +18,6 @@ func TestTicketClosed(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// add a ticket closed trigger
 	testdb.InsertTicketClosedTrigger(t, rt, testdb.Org1, testdb.Favorites)
 

--- a/core/tasks/interrupt_contacts_test.go
+++ b/core/tasks/interrupt_contacts_test.go
@@ -14,8 +14,6 @@ import (
 func TestInterruptContacts(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	s1UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Ann, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s2UUID := testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Bob, models.FlowTypeMessaging, nil, testdb.Favorites)
 	s3UUID := testdb.InsertFlowSession(t, rt, testdb.Cat, models.FlowTypeMessaging, models.SessionStatusCompleted, nil, testdb.Favorites)

--- a/core/tasks/populate_group_test.go
+++ b/core/tasks/populate_group_test.go
@@ -17,8 +17,6 @@ import (
 func TestPopulateGroupTask(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	group1 := testdb.InsertContactGroup(t, rt, testdb.Org1, "e52fee05-2f95-4445-aef6-2fe7dac2fd56", "Women", "gender = F")
 	group2 := testdb.InsertContactGroup(t, rt, testdb.Org1, "8d1c25ff-d9b3-43c4-9abe-7ef3d2fc6c1a", "Invalid", "!!!", testdb.Bob)
 

--- a/core/tasks/process_contact_queue_test.go
+++ b/core/tasks/process_contact_queue_test.go
@@ -17,8 +17,6 @@ import (
 func TestProcessContactQueue(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	vc := rt.VK.Get()
 	defer vc.Close()
 

--- a/core/tasks/schedule_campaign_point_test.go
+++ b/core/tasks/schedule_campaign_point_test.go
@@ -13,8 +13,6 @@ import (
 func TestScheduleCampaignPoint(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// set campaign point status to (S)CHEDULING (done by RP)
 	rt.DB.MustExec(`UPDATE campaigns_campaignevent SET status = 'S' WHERE id = $1`, testdb.RemindersPoint1.ID)
 

--- a/core/tasks/send_broadcast_test.go
+++ b/core/tasks/send_broadcast_test.go
@@ -23,8 +23,6 @@ import (
 func TestBroadcastsFromEvents(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
 	require.NoError(t, err)
 
@@ -175,8 +173,6 @@ func TestSendBroadcastTask(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()
 	defer vc.Close()
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	rt.DB.MustExec(`UPDATE orgs_org SET flow_languages = '{"eng", "spa"}' WHERE id = $1`, testdb.Org1.ID)
 

--- a/core/tasks/start_flow_test.go
+++ b/core/tasks/start_flow_test.go
@@ -16,8 +16,6 @@ import (
 func TestStartFlowTask(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	testdb.InsertWaitingSession(t, rt, testdb.Org1, testdb.Cat, models.FlowTypeMessaging, nil, testdb.Favorites)
 
 	tcs := []struct {

--- a/services/ivr/vonage/service_test.go
+++ b/services/ivr/vonage/service_test.go
@@ -29,8 +29,6 @@ func TestResponseForSprint(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	client, mockVonage := test.MockedHTTP(map[string][]*httpx.MockResponse{
 		"https://api.nexmo.com/v1/calls": {
 			httpx.NewMockResponse(201, nil, []byte(`{"uuid": "63f61863-4a51-4f6b-86e1-46edebcf9356", "status": "started", "direction": "outbound"}`)),

--- a/testsuite/dynamo.go
+++ b/testsuite/dynamo.go
@@ -3,6 +3,7 @@ package testsuite
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -128,7 +129,9 @@ func sweepStaleDynamo(ctx context.Context, client *dynamodb.Client) error {
 		}
 
 		for _, name := range names {
-			if _, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String(name)}); err != nil {
+			// not found is fine - another live binary's sweep can get there first
+			var notFound *dbtypes.ResourceNotFoundException
+			if _, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String(name)}); err != nil && !errors.As(err, &notFound) {
 				return fmt.Errorf("error deleting stale table %s: %w", name, err)
 			}
 		}

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -127,7 +127,8 @@ func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
 		}
 
 		for _, name := range names {
-			if _, err := rt.ES.Client.Indices.Delete(name).Do(ctx); err != nil {
+			// unavailable is fine - another live binary's sweep can get there first
+			if _, err := rt.ES.Client.Indices.Delete(name).IgnoreUnavailable(true).Do(ctx); err != nil {
 				return fmt.Errorf("error deleting stale index %s: %w", name, err)
 			}
 		}

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -10,8 +10,6 @@ import (
 	goruntime "runtime"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/nyaruka/gocommon/centrifugo"
 	"github.com/nyaruka/mailroom/v26/core/goflow"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -24,25 +22,6 @@ import (
 func testdataPath(file string) string {
 	_, thisFile, _, _ := goruntime.Caller(0)
 	return path.Join(path.Dir(thisFile), "testdata", file)
-}
-
-// Refresh is our type for the pieces of state we want fresh. Note that there are no flags for the database,
-// valkey, elastic or dynamo because each test starts with its own clean state (see dbtemplate.go, valkey.go,
-// elastic.go and dynamo.go).
-type ResetFlag int
-
-// refresh bit masks
-const (
-	ResetNone    = ResetFlag(0)
-	ResetAll     = ResetFlag(^0)
-	ResetStorage = ResetFlag(1 << 0)
-)
-
-// Reset clears out the state shared between tests
-func Reset(t *testing.T, rt *runtime.Runtime, what ResetFlag) {
-	if what&ResetStorage > 0 {
-		resetStorage(t, rt)
-	}
 }
 
 // Runtime returns the various runtime things a test might need
@@ -69,7 +48,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	t.Setenv("AWS_REGION", "us-east-1")
 
 	cfg.S3Endpoint = "http://localstack:4566"
-	cfg.S3AttachmentsBucket = "test-attachments"
+	cfg.S3AttachmentsBucket = s3AttachmentsBucket() // this binary's own bucket, emptied before every test - see storage.go
 	cfg.S3PathStyle = true
 	cfg.DynamoEndpoint = "http://localstack:4566"
 	cfg.DynamoTablePrefix = dynTablePrefix() // this binary's own tables, cleared before every test - see dynamo.go
@@ -81,7 +60,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	rt, err := runtime.NewRuntime(cfg)
 	require.NoError(t, err)
 
-	createBucket(t, rt, rt.Config.S3AttachmentsBucket)
+	ensureStorage(t, rt)
 	ensureElastic(t, rt)
 	ensureDynamo(t, rt)
 
@@ -93,9 +72,10 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	err = rt.Start()
 	require.NoError(t, err, "error starting runtime")
 
-	// so every test starts with empty indexes and tables (the writers must be started for their flushes)
+	// so every test starts with empty indexes, tables and storage (writers must be started for their flushes)
 	ClearElastic(t, rt)
 	ClearDynamo(t, rt)
+	clearStorage(t, rt)
 
 	models.InitCache(rt)
 
@@ -127,13 +107,6 @@ func absPath(p string) string {
 	return path.Join(dir, p)
 }
 
-func resetStorage(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	err := rt.S3.EmptyBucket(t.Context(), rt.Config.S3AttachmentsBucket)
-	require.NoError(t, err)
-}
-
 // CentrifugoHistory returns the JSON payloads published to the given Centrifugo channel, oldest first. The runtime's
 // Centrifugo client is a mock so this reads back what the test published rather than hitting a real server.
 func CentrifugoHistory(t *testing.T, rt *runtime.Runtime, channel string) []json.RawMessage {
@@ -146,16 +119,6 @@ func CentrifugoHistory(t *testing.T, rt *runtime.Runtime, channel string) []json
 		}
 	}
 	return history
-}
-
-func createBucket(t *testing.T, rt *runtime.Runtime, bucket string) {
-	t.Helper()
-
-	err := rt.S3.Test(t.Context(), bucket)
-	if err != nil {
-		_, err = rt.S3.Client.CreateBucket(t.Context(), &s3.CreateBucketInput{Bucket: aws.String(bucket)})
-		require.NoError(t, err)
-	}
 }
 
 func ReadFile(t *testing.T, path string) []byte {

--- a/testsuite/storage.go
+++ b/testsuite/storage.go
@@ -2,6 +2,7 @@ package testsuite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -9,9 +10,16 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/stretchr/testify/require"
 )
+
+// isNoSuchBucket returns whether the given error is S3 telling us the bucket doesn't exist
+func isNoSuchBucket(err error) bool {
+	var ae smithy.APIError
+	return errors.As(err, &ae) && ae.ErrorCode() == "NoSuchBucket"
+}
 
 // Each test binary gets its own attachments bucket (suffixed with its process identifier), so concurrently
 // running binaries never see each other's files. Within a binary, clearStorage runs at the start of every
@@ -85,10 +93,11 @@ func sweepStaleStorage(ctx context.Context, rt *runtime.Runtime) error {
 			continue // in use by a live run
 		}
 
-		if err := rt.S3.EmptyBucket(ctx, name); err != nil {
+		// not found is fine - another live binary's sweep can get there first
+		if err := rt.S3.EmptyBucket(ctx, name); err != nil && !isNoSuchBucket(err) {
 			return fmt.Errorf("error emptying stale bucket %s: %w", name, err)
 		}
-		if _, err := rt.S3.Client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(name)}); err != nil {
+		if _, err := rt.S3.Client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(name)}); err != nil && !isNoSuchBucket(err) {
 			return fmt.Errorf("error deleting stale bucket %s: %w", name, err)
 		}
 

--- a/testsuite/storage.go
+++ b/testsuite/storage.go
@@ -1,0 +1,107 @@
+package testsuite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+// Each test binary gets its own attachments bucket (suffixed with its process identifier), so concurrently
+// running binaries never see each other's files. Within a binary, clearStorage runs at the start of every
+// test so each starts with an empty bucket - assuming sequential tests, as elsewhere. Ownership is the same
+// per-binary advisory lock that marks the elastic indexes and dynamo tables (see dbtemplate.go), and setup
+// sweeps away the buckets of any run which has died.
+
+const s3TestPrefix = "test-attachments-"
+
+// per-binary bucket name
+func s3AttachmentsBucket() string {
+	return s3TestPrefix + dbProcID()
+}
+
+var s3Setup sync.Once
+var s3SetupErr error
+
+// ensureStorage creates this binary's attachments bucket on first use
+func ensureStorage(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	s3Setup.Do(func() { s3SetupErr = setupStorage(rt) })
+	require.NoError(t, s3SetupErr, "error setting up storage")
+}
+
+// setupStorage claims this binary's bucket, creates it, and sweeps those of dead runs
+func setupStorage(rt *runtime.Runtime) error {
+	ctx := context.Background()
+
+	if err := claimBinary(); err != nil {
+		return err
+	}
+
+	if _, err := rt.S3.Client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(s3AttachmentsBucket())}); err != nil {
+		return fmt.Errorf("error creating attachments bucket: %w", err)
+	}
+
+	return sweepStaleStorage(ctx, rt)
+}
+
+// sweepStaleStorage deletes the buckets of binaries which are no longer running - any process identifier
+// whose per-binary lock we can take ourselves belongs to a run which is no longer around.
+func sweepStaleStorage(ctx context.Context, rt *runtime.Runtime) error {
+	admin, err := dbAdmin()
+	if err != nil {
+		return err
+	}
+	conn, err := admin.DB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	resp, err := rt.S3.Client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		return fmt.Errorf("error listing buckets: %w", err)
+	}
+
+	for _, b := range resp.Buckets {
+		name := aws.ToString(b.Name)
+		procID := strings.TrimPrefix(name, s3TestPrefix)
+		if procID == dbProcID() || !binProcIDRegex.MatchString(procID) {
+			continue // ours, or not a per-binary test bucket
+		}
+
+		var got bool
+		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
+			return err
+		}
+		if !got {
+			continue // in use by a live run
+		}
+
+		if err := rt.S3.EmptyBucket(ctx, name); err != nil {
+			return fmt.Errorf("error emptying stale bucket %s: %w", name, err)
+		}
+		if _, err := rt.S3.Client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(name)}); err != nil {
+			return fmt.Errorf("error deleting stale bucket %s: %w", name, err)
+		}
+
+		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
+	}
+
+	return nil
+}
+
+// clearStorage empties this binary's attachments bucket - runs at the start of every test
+func clearStorage(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	err := rt.S3.EmptyBucket(t.Context(), rt.Config.S3AttachmentsBucket)
+	require.NoError(t, err)
+}

--- a/testsuite/web.go
+++ b/testsuite/web.go
@@ -127,6 +127,10 @@ func RunWebTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 		// some timestamps come from db NOW() which we can't mock, so we replace them with $recent_timestamp$
 		actual.actualResponse = overwriteRecentTimestamps(actual.actualResponse)
 
+		// attachment URLs contain this binary's own bucket name, so rewrite to the stable name snapshots use
+		actual.actualResponse = overwriteTestBucket(rt, actual.actualResponse)
+		actual.ExpectedHistory = overwriteTestBucketJSON(rt, actual.ExpectedHistory)
+
 		ClearTasks(t, rt)
 
 		if tc.ResponseFile != "" {
@@ -209,6 +213,19 @@ func RunWebTests(t *testing.T, rt *runtime.Runtime, truthFile string) {
 		err = os.WriteFile(truthFile, truth, 0644)
 		require.NoError(t, err, "failed to update truth file")
 	}
+}
+
+// overwriteTestBucket rewrites this binary's per-binary bucket name (see storage.go) to the stable
+// "test-attachments" so that snapshots don't vary by binary
+func overwriteTestBucket(rt *runtime.Runtime, b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte(rt.Config.S3AttachmentsBucket), []byte("test-attachments"))
+}
+
+// overwriteTestBucketJSON is overwriteTestBucket applied through a JSON round trip of the given value
+func overwriteTestBucketJSON[T any](rt *runtime.Runtime, v T) T {
+	var out T
+	jsonx.MustUnmarshal(overwriteTestBucket(rt, jsonx.MustMarshal(v)), &out)
+	return out
 }
 
 var isoTimestampRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,9}Z`)

--- a/web/channel/base_test.go
+++ b/web/channel/base_test.go
@@ -9,7 +9,5 @@ import (
 func TestInterrupt(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	testsuite.RunWebTests(t, rt, "testdata/interrupt.json")
 }

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -24,8 +24,6 @@ import (
 func TestCreate(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// detach Ann's tel URN
 	rt.DB.MustExec(`UPDATE contacts_contacturn SET contact_id = NULL WHERE contact_id = $1`, testdb.Ann.ID)
 
@@ -122,8 +120,6 @@ func TestInspect(t *testing.T) {
 
 func TestModify(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	oa := testdb.Org1.Load(t, rt)
 

--- a/web/flow/base_test.go
+++ b/web/flow/base_test.go
@@ -48,7 +48,6 @@ func TestStart(t *testing.T) {
 
 	// TODO TestTwilioIVR blows up without full reset so some prior test isn't cleaning up after itself. Can no
 	// longer be database state, so the culprit is valkey, dynamo or elastic.
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	testsuite.RunWebTests(t, rt, "testdata/start.json")
 }

--- a/web/flow/base_test.go
+++ b/web/flow/base_test.go
@@ -46,9 +46,6 @@ func TestMigrate(t *testing.T) {
 func TestStart(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	// TODO TestTwilioIVR blows up without full reset so some prior test isn't cleaning up after itself. Can no
-	// longer be database state, so the culprit is valkey, dynamo or elastic.
-
 	testsuite.RunWebTests(t, rt, "testdata/start.json")
 }
 

--- a/web/public/airtime_test.go
+++ b/web/public/airtime_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestDTOneStatusCallback(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	wg := &sync.WaitGroup{}
 	server := web.NewServer(ctx, rt, wg)

--- a/web/public/base_test.go
+++ b/web/public/base_test.go
@@ -23,8 +23,6 @@ func TestDocs(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	promToken := "2d26a50841ff48237238bbdd021150f6a33a4196"
 	rt.DB.MustExec(`UPDATE orgs_org SET prometheus_token = $1 WHERE id = $2`, promToken, testdb.Org1.ID)
 

--- a/web/public/ivr_test.go
+++ b/web/public/ivr_test.go
@@ -55,8 +55,6 @@ func mockTwilioHandler(w http.ResponseWriter, r *http.Request) {
 func TestTwilioIVR(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
-
 	// start mocked API server
 	mockTwilio := test.NewHTTPServer(50001, http.HandlerFunc(mockTwilioHandler))
 	defer mockTwilio.Close()
@@ -167,8 +165,6 @@ func TestVonageIVR(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()
 	defer vc.Close()
-
-	defer testsuite.Reset(t, rt, testsuite.ResetAll)
 
 	// deactivate our twilio channel
 	rt.DB.MustExec(`UPDATE channels_channel SET is_active = FALSE WHERE id = $1`, testdb.TwilioChannel.ID)


### PR DESCRIPTION
## Summary

Extends per-run test isolation to S3, completing the set: databases (#1186), valkey (#1193), elastic (#1195), dynamo (#1196), and now storage. Each test binary gets its own attachments bucket, so concurrently running binaries never see each other's files, and every test starts with an empty bucket. With every piece of test state now automatically clean, the `Reset` flag apparatus is gone entirely.

## Changes

- **`testsuite/storage.go`** — each binary's bucket is suffixed with its process identifier (`test-attachments-<procid>`), created once per binary under the same per-binary ownership lock as the elastic indexes and dynamo tables, swept when the owning run dies, and emptied at the start of every test.
- **`testsuite/runtime.go`** — `Reset`, `ResetFlag` and all its constants are deleted; nothing needs opt-in cleanup any more.
- **~46 test files** — every remaining `defer testsuite.Reset(...)` removed (all were deferred cleanup; none mid-test), plus a stale TODO about mystery test contamination whose cause this series eliminated.
- **`testsuite/web.go`** — attachment URLs in web-test snapshots pass through `overwriteTestBucket`, rewriting the per-binary bucket back to the stable `test-attachments` (same pattern as `overwriteRecentTimestamps`, applied at capture so snapshot-update mode also writes stable names).
- **`core/models/org_test.go`** — the `StoreAttachment` assertion builds its expected URL from `rt.Config.S3AttachmentsBucket` instead of a hardcoded bucket name.
- **All three sweeps** (elastic, dynamo, S3) now tolerate not-found on deletion: two live binaries can both list a dead run's resources, and losing that race must not fail the loser's setup.

## Notes for reviewers

- Same sequential-tests assumption as the other per-binary schemes.
- This is the last isolation piece: what remains before dropping `-p=1` is mechanical (dynamic web test ports, per-binary spool dir, valkey claim retry-on-exhaustion, CI postgres `max_connections`).

## Test plan

- Full suite green with `-p=1` (41 packages) locally and in CI
- Sweep observed working: a follow-up run deleted the finished binary's bucket and left only its own
- Storage-heavy packages (`core/models`, `web/public`) verified individually, including the vonage IVR snapshot tests that assert attachment URLs