### PR TITLE
Re-index shell contact in Elastic after its URN is reassigned

### DIFF
--- a/core/tasks/ctasks/base.go
+++ b/core/tasks/ctasks/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
 )
 
@@ -94,7 +95,13 @@ func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.
 		if err != nil {
 			return fmt.Errorf("error reassigning URN from shell contact: %w", err)
 		}
-		if ownerID != models.NilContactID && !reassigned {
+		if reassigned {
+			// the shell contact isn't part of this scene so won't be re-indexed by scene events - index it here so
+			// its ES doc no longer includes the URN it just lost
+			if err := indexContact(ctx, rt, oa, ownerID); err != nil {
+				return fmt.Errorf("error indexing shell contact after URN reassignment: %w", err)
+			}
+		} else if ownerID != models.NilContactID {
 			slog.Info("BSUID URN not appended because it belongs to a contact with other URNs", "urn", s.Value, "contact", scene.ContactUUID(), "owner_id", ownerID)
 		}
 	}
@@ -107,6 +114,25 @@ func (s *NewURNSpec) Apply(ctx context.Context, rt *runtime.Runtime, oa *models.
 	mod := modifiers.NewRoutes([]core.Route{{URN: s.Value, Channel: flowCh}}, modifiers.RoutesAppend)
 	if err := scene.ApplyModifier(ctx, rt, oa, mod, models.NilUserID, ""); err != nil {
 		return fmt.Errorf("error applying routes modifier: %w", err)
+	}
+	return nil
+}
+
+// indexContact loads the given contact and queues it for re-indexing in Elastic
+func indexContact(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, contactID models.ContactID) error {
+	mc, err := models.LoadContact(ctx, rt.DB, oa, contactID)
+	if err != nil {
+		return fmt.Errorf("error loading contact: %w", err)
+	}
+
+	contact, err := mc.EngineContact(oa)
+	if err != nil {
+		return fmt.Errorf("error creating engine contact: %w", err)
+	}
+
+	currentFlows := map[models.ContactID]models.FlowID{mc.ID(): mc.CurrentFlowID()}
+	if err := search.IndexContacts(ctx, rt, oa, []*core.Contact{contact}, currentFlows); err != nil {
+		return fmt.Errorf("error indexing contact: %w", err)
 	}
 	return nil
 }

--- a/core/tasks/ctasks/msg_received_test.go
+++ b/core/tasks/ctasks/msg_received_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/mailroom/v26/core/ivr"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
 	"github.com/nyaruka/mailroom/v26/core/tasks/ctasks"
 	"github.com/nyaruka/mailroom/v26/runtime"
@@ -536,6 +537,16 @@ func TestMsgReceivedNewURN(t *testing.T) {
 				assert.True(t, newModifiedOn.After(shellModifiedOn), "shell contact modified_on should be bumped")
 				require.NoError(t, rt.DB.Get(&newModifiedOn, `SELECT modified_on FROM contacts_contact WHERE id = $1`, testdb.Bob.ID))
 				assert.True(t, newModifiedOn.After(bobModifiedOn), "message contact modified_on should be bumped")
+
+				// shell contact isn't part of the scene so must have been explicitly re-indexed without the URN
+				rt.ES.Writer.Flush()
+				resp, err := rt.ES.Client.Get(rt.Config.ElasticContactsIndex, string(shell.UUID)).Routing(fmt.Sprintf("%d", testdb.Org1.ID)).Do(t.Context())
+				require.NoError(t, err)
+				require.True(t, resp.Found, "shell contact doc should be queued to ES writer")
+
+				var doc search.ContactDoc
+				require.NoError(t, json.Unmarshal(resp.Source_, &doc))
+				assert.Empty(t, doc.URNs, "shell contact doc should no longer have any URNs")
 			},
 		},
 		{


### PR DESCRIPTION
When appending a WhatsApp BSUID URN, `NewURNSpec.Apply` may reassign the URN from a URN-less "shell" contact to the contact being handled. Both contacts get `modified_on` bumped, but Elastic indexing is entirely scene driven - the post-commit hook only indexes the scene contact. The shell contact isn't part of the scene, so its ES document kept showing the URN it no longer owns - and being URN-less, nothing was likely to ever touch it again to correct that.

This change re-indexes the shell contact immediately after a successful reassignment. It's done inline rather than via the `IndexContacts` post-commit hook because the reassignment runs directly against the DB (already committed at that point, regardless of whether the scene later commits), and because attaching to the hook from `ctasks` would create an import cycle (`hooks` already imports `ctasks`).

The shell-claim test case now asserts the shell contact's doc is queued to the ES writer with no URNs - it fails without the fix.