### PR TITLE
Consolidate per-binary test resource setup and sweeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ coverage.text
 /mrindex
 /docs
 /_spool
-/_test_spool

--- a/testsuite/binary.go
+++ b/testsuite/binary.go
@@ -1,0 +1,111 @@
+package testsuite
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+// Some resources are per-binary rather than per-test: the elastic indexes, dynamo tables and attachments
+// bucket are namespaced with a random process identifier and created on first use - see elastic.go,
+// dynamo.go and storage.go. Ownership is marked with a Postgres advisory lock held for the binary's
+// lifetime, so it evaporates when the run that owns it dies - and setup sweeps away the resources of any
+// run which has died.
+
+// random per-binary identifier used in per-binary resource names. Can't use the pid because binaries run
+// in per-worktree containers which share the backing services, so pids are neither unique nor observable
+// across them.
+var binProcID = sync.OnceValue(func() string {
+	b := make([]byte, 4)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+})
+
+// matches a process identifier segment in a per-binary resource name
+var binProcIDRegex = regexp.MustCompile(`^[0-9a-f]{8}$`)
+
+// binKey derives the advisory lock key which marks a binary's per-binary resources as in use
+func binKey(procID string) int64 {
+	return dbKey("binary_" + procID)
+}
+
+var binSetup sync.Once
+var binSetupErr error
+
+// ensureBinaryResources creates this binary's per-binary resources on first use
+func ensureBinaryResources(t *testing.T, rt *runtime.Runtime) {
+	t.Helper()
+
+	binSetup.Do(func() { binSetupErr = setupBinaryResources(rt) })
+	require.NoError(t, binSetupErr, "error setting up per-binary resources")
+}
+
+// setupBinaryResources claims this binary's resources, creates them, and sweeps those of dead runs
+func setupBinaryResources(rt *runtime.Runtime) error {
+	ctx := context.Background()
+
+	owner, err := dbOwner()
+	if err != nil {
+		return err
+	}
+
+	// claim before any of the resources exist, so they're never visible to another binary's sweep unclaimed
+	if _, err := owner.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, binKey(binProcID())); err != nil {
+		return fmt.Errorf("error claiming binary resources: %w", err)
+	}
+
+	if err := setupStorage(ctx, rt); err != nil {
+		return err
+	}
+	if err := setupElastic(ctx, rt); err != nil {
+		return err
+	}
+	return setupDynamo(ctx, rt)
+}
+
+// sweepDeadBinaries deletes per-binary resources, given as names grouped by process identifier, belonging
+// to runs which are no longer around. A resource still in use is protected by its owner's advisory lock,
+// so any process identifier we can lock ourselves belongs to a dead run. Our own identifier, and anything
+// that doesn't look like one, is ignored.
+func sweepDeadBinaries(ctx context.Context, byProcID map[string][]string, del func(name string) error) error {
+	admin, err := dbAdmin()
+	if err != nil {
+		return err
+	}
+	conn, err := admin.DB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	for procID, names := range byProcID {
+		if procID == binProcID() || !binProcIDRegex.MatchString(procID) {
+			continue // ours, or not a per-binary test resource
+		}
+
+		var got bool
+		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
+			return err
+		}
+		if !got {
+			continue // in use by a live run
+		}
+
+		for _, name := range names {
+			if err := del(name); err != nil {
+				return err
+			}
+		}
+
+		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
+	}
+
+	return nil
+}

--- a/testsuite/dbtemplate.go
+++ b/testsuite/dbtemplate.go
@@ -2,15 +2,12 @@ package testsuite
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"os/exec"
-	"regexp"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -45,36 +42,6 @@ const (
 )
 
 var dbCounter atomic.Int64
-
-// random per-binary identifier used in test database names. Can't use the pid because binaries run in
-// per-worktree containers which share a Postgres, so pids are neither unique nor observable across them.
-var dbProcID = sync.OnceValue(func() string {
-	b := make([]byte, 4)
-	rand.Read(b)
-	return hex.EncodeToString(b)
-})
-
-// matches a process identifier segment in a per-binary resource name
-var binProcIDRegex = regexp.MustCompile(`^[0-9a-f]{8}$`)
-
-// binKey derives the advisory lock key which marks a binary's per-binary resources - its elastic indexes,
-// dynamo tables and attachments bucket - as in use
-func binKey(procID string) int64 {
-	return dbKey("binary_" + procID)
-}
-
-// claimBinary takes the advisory lock which marks this binary's resources as in use, before any of them
-// exist, so they're never visible to another binary's sweep unclaimed. Held for the binary's lifetime.
-var claimBinary = sync.OnceValue(func() error {
-	owner, err := dbOwner()
-	if err != nil {
-		return err
-	}
-	if _, err := owner.ExecContext(context.Background(), `SELECT pg_advisory_lock($1)`, binKey(dbProcID())); err != nil {
-		return fmt.Errorf("error claiming binary resources: %w", err)
-	}
-	return nil
-})
 
 // admin pool is opened once per test binary and left open for its lifetime
 var dbAdmin = sync.OnceValues(func() (*sqlx.DB, error) {
@@ -274,7 +241,7 @@ func createTestDB(t *testing.T) string {
 	owner, err := dbOwner()
 	require.NoError(t, err)
 
-	name := fmt.Sprintf("%s%s_%d", dbTestPrefix, dbProcID(), dbCounter.Add(1))
+	name := fmt.Sprintf("%s%s_%d", dbTestPrefix, binProcID(), dbCounter.Add(1))
 
 	// claim the database before it exists, so that it's never visible to another binary's sweep unclaimed
 	_, err = owner.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, dbKey(name))

--- a/testsuite/dynamo.go
+++ b/testsuite/dynamo.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -24,34 +23,18 @@ import (
 
 // Each test binary gets its own dynamo tables (prefixed with its process identifier), so concurrently
 // running binaries never see each other's items. Within a binary, ClearDynamo runs at the start of every
-// test so each starts with empty tables - assuming sequential tests, as elsewhere. Ownership is the same
-// per-binary advisory lock that marks the elastic indexes (see dbtemplate.go), and setup sweeps away the
-// tables of any run which has died.
+// test so each starts with empty tables - assuming sequential tests, as elsewhere. Ownership and sweeping
+// of dead runs' tables works as for all per-binary resources - see binary.go.
+
+const dynTestPrefix = "Test"
 
 // per-binary prefix for dynamo table names, e.g. Testa1b2c3d4 -> Testa1b2c3d4Main
 func dynTablePrefix() string {
-	return "Test" + dbProcID()
+	return dynTestPrefix + binProcID()
 }
 
-var dynSetup sync.Once
-var dynSetupErr error
-
-// ensureDynamo creates this binary's dynamo tables on first use
-func ensureDynamo(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	dynSetup.Do(func() { dynSetupErr = setupDynamo(rt) })
-	require.NoError(t, dynSetupErr, "error setting up dynamo tables")
-}
-
-// setupDynamo claims this binary's tables, creates them, and sweeps those of dead runs
-func setupDynamo(rt *runtime.Runtime) error {
-	ctx := context.Background()
-
-	if err := claimBinary(); err != nil {
-		return err
-	}
-
+// setupDynamo creates this binary's tables and sweeps those of dead runs
+func setupDynamo(ctx context.Context, rt *runtime.Runtime) error {
 	tablesJSON, err := os.ReadFile(testdataPath("dynamo.json"))
 	if err != nil {
 		return err
@@ -82,19 +65,8 @@ func setupDynamo(rt *runtime.Runtime) error {
 	return sweepStaleDynamo(ctx, client)
 }
 
-// sweepStaleDynamo deletes the tables of binaries which are no longer running - any process identifier
-// whose per-binary lock we can take ourselves belongs to a run which is no longer around.
+// sweepStaleDynamo deletes the tables of binaries which are no longer running
 func sweepStaleDynamo(ctx context.Context, client *dynamodb.Client) error {
-	admin, err := dbAdmin()
-	if err != nil {
-		return err
-	}
-	conn, err := admin.DB.Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	byProcID := make(map[string][]string)
 	var startFrom *string
 	for {
@@ -103,15 +75,10 @@ func sweepStaleDynamo(ctx context.Context, client *dynamodb.Client) error {
 			return fmt.Errorf("error listing tables: %w", err)
 		}
 		for _, name := range resp.TableNames {
-			rest := strings.TrimPrefix(name, "Test")
-			if len(rest) < 8 {
-				continue
+			rest := strings.TrimPrefix(name, dynTestPrefix)
+			if len(rest) >= 8 {
+				byProcID[rest[:8]] = append(byProcID[rest[:8]], name)
 			}
-			procID := rest[:8]
-			if procID == dbProcID() || !binProcIDRegex.MatchString(procID) {
-				continue // ours, or not a per-binary test table
-			}
-			byProcID[procID] = append(byProcID[procID], name)
 		}
 		if resp.LastEvaluatedTableName == nil {
 			break
@@ -119,27 +86,14 @@ func sweepStaleDynamo(ctx context.Context, client *dynamodb.Client) error {
 		startFrom = resp.LastEvaluatedTableName
 	}
 
-	for procID, names := range byProcID {
-		var got bool
-		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
-			return err
+	return sweepDeadBinaries(ctx, byProcID, func(name string) error {
+		// not found is fine - another live binary's sweep can get there first
+		var notFound *dbtypes.ResourceNotFoundException
+		if _, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String(name)}); err != nil && !errors.As(err, &notFound) {
+			return fmt.Errorf("error deleting stale table %s: %w", name, err)
 		}
-		if !got {
-			continue // in use by a live run
-		}
-
-		for _, name := range names {
-			// not found is fine - another live binary's sweep can get there first
-			var notFound *dbtypes.ResourceNotFoundException
-			if _, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String(name)}); err != nil && !errors.As(err, &notFound) {
-				return fmt.Errorf("error deleting stale table %s: %w", name, err)
-			}
-		}
-
-		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // ClearDynamo clears out this binary's dynamo tables. Runs at the start of every test, and can be called

--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -30,8 +29,8 @@ import (
 // running binaries - including other worktrees sharing an Elasticsearch - never see each other's documents.
 // Within a binary, ClearElastic runs at the start of every test so each starts with empty indexes - which
 // assumes tests run sequentially, as a t.Parallel() test would have its documents cleared by the next test
-// to start. As with the per-test databases, ownership is marked with a Postgres advisory lock held for the
-// binary's lifetime, and setup sweeps away the indexes of any run which has died.
+// to start. Ownership and sweeping of dead runs' indexes works as for all per-binary resources - see
+// binary.go.
 
 const (
 	esContactsPrefix = "contacts-test-"
@@ -43,28 +42,11 @@ const (
 )
 
 // per-binary index names
-func esContactsIndex() string { return esContactsPrefix + dbProcID() }
-func esMessagesIndex() string { return esMessagesPrefix + dbProcID() }
+func esContactsIndex() string { return esContactsPrefix + binProcID() }
+func esMessagesIndex() string { return esMessagesPrefix + binProcID() }
 
-var esSetup sync.Once
-var esSetupErr error
-
-// ensureElastic creates this binary's elastic indexes on first use
-func ensureElastic(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	esSetup.Do(func() { esSetupErr = setupElastic(rt) })
-	require.NoError(t, esSetupErr, "error setting up elastic indexes")
-}
-
-// setupElastic claims this binary's indexes, creates them, and sweeps those of dead runs
-func setupElastic(rt *runtime.Runtime) error {
-	ctx := context.Background()
-
-	if err := claimBinary(); err != nil {
-		return err
-	}
-
+// setupElastic creates this binary's indexes and sweeps those of dead runs
+func setupElastic(ctx context.Context, rt *runtime.Runtime) error {
 	contactsBody, err := os.ReadFile(testdataPath("es_contacts.json"))
 	if err != nil {
 		return err
@@ -85,20 +67,8 @@ func setupElastic(rt *runtime.Runtime) error {
 	return sweepStaleElastic(ctx, rt)
 }
 
-// sweepStaleElastic deletes the indexes of binaries which are no longer running. An index still in use is
-// protected by its owner's advisory lock, so any process identifier we can lock ourselves belongs to a run
-// which is no longer around.
+// sweepStaleElastic deletes the indexes of binaries which are no longer running
 func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
-	admin, err := dbAdmin()
-	if err != nil {
-		return err
-	}
-	conn, err := admin.DB.Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	indexes, err := rt.ES.Client.Cat.Indices().Index(esContactsPrefix + "*," + esMessagesPrefix + "*").Do(ctx)
 	if err != nil {
 		return fmt.Errorf("error listing test indexes: %w", err)
@@ -111,32 +81,16 @@ func sweepStaleElastic(ctx context.Context, rt *runtime.Runtime) error {
 		}
 		rest := strings.TrimPrefix(strings.TrimPrefix(*idx.Index, esContactsPrefix), esMessagesPrefix)
 		procID, _, _ := strings.Cut(rest, "-")
-		if procID == dbProcID() || !binProcIDRegex.MatchString(procID) {
-			continue // ours, or not a per-binary test index
-		}
 		byProcID[procID] = append(byProcID[procID], *idx.Index)
 	}
 
-	for procID, names := range byProcID {
-		var got bool
-		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
-			return err
+	return sweepDeadBinaries(ctx, byProcID, func(name string) error {
+		// unavailable is fine - another live binary's sweep can get there first
+		if _, err := rt.ES.Client.Indices.Delete(name).IgnoreUnavailable(true).Do(ctx); err != nil {
+			return fmt.Errorf("error deleting stale index %s: %w", name, err)
 		}
-		if !got {
-			continue // in use by a live run
-		}
-
-		for _, name := range names {
-			// unavailable is fine - another live binary's sweep can get there first
-			if _, err := rt.ES.Client.Indices.Delete(name).IgnoreUnavailable(true).Do(ctx); err != nil {
-				return fmt.Errorf("error deleting stale index %s: %w", name, err)
-			}
-		}
-
-		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // ClearElastic clears out this binary's elastic indexes: all documents from the contacts index, and the
@@ -320,12 +274,7 @@ func GetIndexedMessages(t *testing.T, rt *runtime.Runtime, clear bool) []Indexed
 	slices.SortFunc(msgs, func(a, b IndexedMessage) int { return strings.Compare(a.ID, b.ID) })
 
 	if clear {
-		for _, idx := range indexes {
-			if idx.Index != nil {
-				_, err := rt.ES.Client.Indices.Delete(*idx.Index).Do(t.Context())
-				require.NoError(t, err)
-			}
-		}
+		clearElasticMessages(t, rt)
 	}
 
 	return msgs

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -57,7 +57,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.S3PathStyle = true
 	cfg.DynamoEndpoint = "http://localstack:4566"
 	cfg.DynamoTablePrefix = dynTablePrefix() // this binary's own tables, cleared before every test - see dynamo.go
-	cfg.SpoolDir = absPath("./_test_spool/" + dbProcID())
+	cfg.SpoolDir = t.TempDir()
 
 	err := cfg.Parse()
 	require.NoError(t, err)
@@ -65,9 +65,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	rt, err := runtime.NewRuntime(cfg)
 	require.NoError(t, err)
 
-	ensureStorage(t, rt)
-	ensureElastic(t, rt)
-	ensureDynamo(t, rt)
+	ensureBinaryResources(t, rt) // creates those on first use and sweeps dead runs' - see binary.go
 
 	rt.FCM = &MockFCMClient{ValidTokens: []string{"FCMID3", "FCMID4", "FCMID5"}}
 	rt.Centrifugo = centrifugo.NewService(centrifugo.NewMockClient(), rt.VK)
@@ -98,20 +96,6 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	})
 
 	return t.Context(), rt
-}
-
-// Converts a project root relative path to an absolute path usable in any test. This is needed because go tests
-// are run with a working directory set to the current module being tested.
-func absPath(p string) string {
-	// start in working directory and go up until we are in a directory containing go.mod
-	dir, _ := os.Getwd()
-	for dir != "/" {
-		if _, err := os.Stat(path.Join(dir, "go.mod")); err == nil {
-			break
-		}
-		dir = path.Dir(dir)
-	}
-	return path.Join(dir, p)
 }
 
 // CentrifugoHistory returns the JSON payloads published to the given Centrifugo channel, oldest first. The runtime's

--- a/testsuite/storage.go
+++ b/testsuite/storage.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,44 +14,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// isNoSuchBucket returns whether the given error is S3 telling us the bucket doesn't exist
-func isNoSuchBucket(err error) bool {
-	var ae smithy.APIError
-	return errors.As(err, &ae) && ae.ErrorCode() == "NoSuchBucket"
-}
-
 // Each test binary gets its own attachments bucket (suffixed with its process identifier), so concurrently
 // running binaries never see each other's files. Within a binary, clearStorage runs at the start of every
-// test so each starts with an empty bucket - assuming sequential tests, as elsewhere. Ownership is the same
-// per-binary advisory lock that marks the elastic indexes and dynamo tables (see dbtemplate.go), and setup
-// sweeps away the buckets of any run which has died.
+// test so each starts with an empty bucket - assuming sequential tests, as elsewhere. Ownership and
+// sweeping of dead runs' buckets works as for all per-binary resources - see binary.go.
 
 const s3TestPrefix = "test-attachments-"
 
 // per-binary bucket name
 func s3AttachmentsBucket() string {
-	return s3TestPrefix + dbProcID()
+	return s3TestPrefix + binProcID()
 }
 
-var s3Setup sync.Once
-var s3SetupErr error
-
-// ensureStorage creates this binary's attachments bucket on first use
-func ensureStorage(t *testing.T, rt *runtime.Runtime) {
-	t.Helper()
-
-	s3Setup.Do(func() { s3SetupErr = setupStorage(rt) })
-	require.NoError(t, s3SetupErr, "error setting up storage")
-}
-
-// setupStorage claims this binary's bucket, creates it, and sweeps those of dead runs
-func setupStorage(rt *runtime.Runtime) error {
-	ctx := context.Background()
-
-	if err := claimBinary(); err != nil {
-		return err
-	}
-
+// setupStorage creates this binary's attachments bucket and sweeps the buckets of dead runs
+func setupStorage(ctx context.Context, rt *runtime.Runtime) error {
 	if _, err := rt.S3.Client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(s3AttachmentsBucket())}); err != nil {
 		return fmt.Errorf("error creating attachments bucket: %w", err)
 	}
@@ -60,39 +35,20 @@ func setupStorage(rt *runtime.Runtime) error {
 	return sweepStaleStorage(ctx, rt)
 }
 
-// sweepStaleStorage deletes the buckets of binaries which are no longer running - any process identifier
-// whose per-binary lock we can take ourselves belongs to a run which is no longer around.
+// sweepStaleStorage deletes the buckets of binaries which are no longer running
 func sweepStaleStorage(ctx context.Context, rt *runtime.Runtime) error {
-	admin, err := dbAdmin()
-	if err != nil {
-		return err
-	}
-	conn, err := admin.DB.Conn(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	resp, err := rt.S3.Client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return fmt.Errorf("error listing buckets: %w", err)
 	}
 
+	byProcID := make(map[string][]string)
 	for _, b := range resp.Buckets {
 		name := aws.ToString(b.Name)
-		procID := strings.TrimPrefix(name, s3TestPrefix)
-		if procID == dbProcID() || !binProcIDRegex.MatchString(procID) {
-			continue // ours, or not a per-binary test bucket
-		}
+		byProcID[strings.TrimPrefix(name, s3TestPrefix)] = []string{name}
+	}
 
-		var got bool
-		if err := conn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, binKey(procID)).Scan(&got); err != nil {
-			return err
-		}
-		if !got {
-			continue // in use by a live run
-		}
-
+	return sweepDeadBinaries(ctx, byProcID, func(name string) error {
 		// not found is fine - another live binary's sweep can get there first
 		if err := rt.S3.EmptyBucket(ctx, name); err != nil && !isNoSuchBucket(err) {
 			return fmt.Errorf("error emptying stale bucket %s: %w", name, err)
@@ -100,11 +56,14 @@ func sweepStaleStorage(ctx context.Context, rt *runtime.Runtime) error {
 		if _, err := rt.S3.Client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(name)}); err != nil && !isNoSuchBucket(err) {
 			return fmt.Errorf("error deleting stale bucket %s: %w", name, err)
 		}
+		return nil
+	})
+}
 
-		conn.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, binKey(procID))
-	}
-
-	return nil
+// isNoSuchBucket returns whether the given error is S3 telling us the bucket doesn't exist
+func isNoSuchBucket(err error) bool {
+	var ae smithy.APIError
+	return errors.As(err, &ae) && ae.ErrorCode() == "NoSuchBucket"
 }
 
 // clearStorage empties this binary's attachments bucket - runs at the start of every test


### PR DESCRIPTION
The test parallelization work left elastic, dynamo and S3 each with their own copy of the per-binary resource lifecycle: a `sync.Once` + error pair, a claim of the binary advisory lock, and near-identical sweep plumbing (open an admin connection, filter process identifiers, try-lock, delete, unlock).

This consolidates the shared machinery into a new `testsuite/binary.go`:

- `ensureBinaryResources` claims the binary lock once and runs the three backend setups, replacing the three ensure/once pairs and `claimBinary`.
- `sweepDeadBinaries` holds the shared lock-and-delete loop, including the own/invalid procID filtering, so each backend's sweeper is now just list + group + a delete callback with its backend-specific error handling.
- The process identity machinery (`binProcID`, `binProcIDRegex`, `binKey`) moves out of `dbtemplate.go`, which is now purely about the postgres template/clone flow.

Adding a per-binary resource type in future only requires a name scheme, a create and a delete callback.

Also:

- The spool dir is now `t.TempDir()` instead of a per-binary dir in the project root - this removes the `absPath` helper and its gitignore entry, and improves isolation since a spool file left by a failed write can no longer be retried into a later test's state.
- `GetIndexedMessages` reuses `clearElasticMessages` instead of duplicating its delete loop.
- The dynamo table prefix literal is now a single const shared by naming and sweep parsing.

No behavior change intended; full suite passes.