### PR TITLE
Use dynamodb-local instead of localstack for DynamoDB in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,13 @@ jobs:
       localstack:
         image: localstack/localstack:4.14
         env:
-          SERVICES: s3,dynamodb,cloudwatch
+          SERVICES: s3,cloudwatch
         ports:
           - 4566:4566
+      dynamodb:
+        image: amazon/dynamodb-local:3.3.1
+        ports:
+          - 8000:8000
 
     steps:
       - name: Checkout code

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -47,7 +47,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.ElasticContactsIndex = esContactsIndex() // this binary's own indexes, cleared before every test
 	cfg.ElasticMessagesIndex = esMessagesIndex() // - see elastic.go
 
-	// AWS SDK default chain reads these — used by the localstack S3/Dynamo/Cloudwatch clients
+	// AWS SDK default chain reads these — used by the S3/Dynamo/Cloudwatch clients
 	t.Setenv("AWS_ACCESS_KEY_ID", "root")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "tembatemba")
 	t.Setenv("AWS_REGION", "us-east-1")
@@ -55,7 +55,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.S3Endpoint = "http://localstack:4566"
 	cfg.S3AttachmentsBucket = s3AttachmentsBucket() // this binary's own bucket, emptied before every test - see storage.go
 	cfg.S3PathStyle = true
-	cfg.DynamoEndpoint = "http://localstack:4566"
+	cfg.DynamoEndpoint = "http://dynamodb:8000"
 	cfg.DynamoTablePrefix = dynTablePrefix() // this binary's own tables, cleared before every test - see dynamo.go
 	cfg.SpoolDir = t.TempDir()
 


### PR DESCRIPTION
Points the test suite at a dedicated `amazon/dynamodb-local` service (`http://dynamodb:8000`) instead of localstack's DynamoDB, and adds that service to CI (localstack there now provides S3/CloudWatch only).

dynamodb-local is the same engine localstack wraps for DynamoDB, so behavior is unchanged — but it is officially maintained, much lighter, and supports persistence, which localstack's Community edition license-gated. The shared dev services stack now runs it alongside localstack, so devcontainer test runs reach it on the same hostname CI uses.