### PR TITLE
Set Elasticsearch disk watermarks in CI so test indexes can allocate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
         env:
           discovery.type: single-node
           xpack.security.enabled: false
+          # test indexes are created as the tests run and hold almost no data, but by then the runner's
+          # disk is past the default 90% high watermark, which leaves their primaries permanently
+          # unassigned and every search against them failing with a 503. Watermarks as free space rather
+          # than percentages keep allocation working on an otherwise full disk. (disk.threshold_enabled
+          # would be more direct but is only honoured via the cluster settings API, not from config.)
+          cluster.routing.allocation.disk.watermark.low: 1gb
+          cluster.routing.allocation.disk.watermark.high: 1gb
+          cluster.routing.allocation.disk.watermark.flood_stage: 1gb
         options: --health-cmd "curl http://localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 5
       localstack:
         image: localstack/localstack:4.14


### PR DESCRIPTION
Preventive: this hasn't broken CI here yet, but it has downstream, in a repo that consumes `testsuite` with the same Elasticsearch service config.

Since the testsuite moved to per-binary indexes, they're created as the tests run rather than up front — which means they're created after the runner's disk has passed Elasticsearch's default 90% high watermark, reached during the build steps. The `disk_threshold` allocation decider then refuses to place their primaries, so the indexes exist with no shards, the cluster goes red, and every search or delete-by-query against them fails after a long wait with:

```
status: 503, failed: [search_phase_execution_exception], reason:
```

Reproduced against the same image: with the node over the high watermark, creating an index leaves `unassigned_primary_shards: 1` and `_delete_by_query` returns exactly that error; with the watermarks below, the cluster stays green and the same request returns 200.

Expressing the watermarks as free space rather than percentages keeps allocation working on an otherwise full disk, which is all a test cluster holding a few kilobytes of documents needs. `disk.threshold_enabled` would be more direct, but it is only honoured through the cluster settings API — set in the container config it is accepted and ignored, so this needs no extra step.