### PR TITLE
Require an embeddings service rather than treating it as optional

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -70,6 +70,14 @@ func testConnections(ctx context.Context, rt *runtime.Runtime) error {
 		log.Info("centrifugo ok")
 	}
 
+	// embedding something trivial checks both that the service is reachable and that it serves the model we're
+	// configured for - a mismatch there wouldn't show up until the first thing we tried to index
+	if _, err := rt.Embeddings.EmbedQuery(ctx, "ping"); err != nil {
+		log.Error("embeddings not available", "error", err)
+	} else {
+		log.Info("embeddings ok")
+	}
+
 	return nil
 }
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -107,6 +107,9 @@ func startService(rt *runtime.Runtime) (*service, error) {
 	c := rt.Config
 	log := slog.With("comp", "mailroom")
 
+	// services which every deployment has, and which the runtime doesn't build for itself
+	rt.Embeddings = intfloat.NewService(rt.HTTP.Services, c.EmbeddingsEndpoint, c.EmbeddingsModel)
+
 	// log what we can and can't reach before we start doing anything with it
 	if err := testConnections(s.ctx, rt); err != nil {
 		return nil, err
@@ -123,12 +126,6 @@ func startService(rt *runtime.Runtime) (*service, error) {
 		}
 	} else {
 		log.Warn("fcm not configured, no android syncing")
-	}
-
-	if c.EmbeddingsEndpoint != "" {
-		rt.Embeddings = intfloat.NewService(rt.HTTP.Services, c.EmbeddingsEndpoint, c.EmbeddingsModel)
-	} else {
-		log.Warn("embeddings not configured, no knowledge indexing or search")
 	}
 
 	if err := rt.Start(); err != nil {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -73,8 +73,8 @@ type Config struct {
 	CentrifugoEndpoint string `help:"the endpoint of the Centrifugo server" validate:"url"`
 	CentrifugoKey      string `help:"the API key for the Centrifugo server"`
 
-	EmbeddingsEndpoint string `validate:"omitempty,http_url" help:"the base URL of an OpenAI compatible embeddings service, leave empty to disable knowledge indexing and search"`
-	EmbeddingsModel    string `help:"the model to request from the embeddings service"`
+	EmbeddingsEndpoint string `validate:"required,http_url" help:"the base URL of an OpenAI compatible embeddings service"`
+	EmbeddingsModel    string `validate:"required"          help:"the e5 model to request from the embeddings service"`
 
 	LatencyExcludedOrgs []int  `help:"comma separated list of org IDs to exclude from latency metrics"`
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
@@ -113,7 +113,7 @@ func NewDefaultConfig() *Config {
 
 		CentrifugoEndpoint: "http://localhost:8000/api",
 
-		EmbeddingsEndpoint: "", // empty disables knowledge indexing and search
+		EmbeddingsEndpoint: "http://localhost:3000/v1",
 		EmbeddingsModel:    "intfloat/multilingual-e5-small",
 
 		WorkersRealtime:  32,


### PR DESCRIPTION
Follow-up to #1203, which added the embeddings service as an optional one. Now that the settings are rolled out everywhere, the service is treated as part of the standard set rather than something a deployment may or may not have — which means the knowledge base work in #1185 doesn't have to carry a disabled path through every call site.

- `EmbeddingsEndpoint` is validated as `required` and defaults to a local endpoint, so a deployment that hasn't set it fails config parsing rather than silently running without the feature. `EmbeddingsModel` is required too — it's passed straight through to the inference server, so an empty one would fail every request at the point of use instead.
- The client is built for every deployment, next to the runtime's own services rather than in the block of ones that are only enabled in some deployments.
- Startup probes it along with the other backing services, by embedding a trivial string. That's the only check that covers both reachability and the configured model actually being served — a model mismatch otherwise wouldn't surface until the first thing we tried to index.

Being unreachable at startup is logged rather than fatal, matching DynamoDB and Elastic: indexing records its failures and retries them, so it recovers by itself once the service is back. Postgres and Valkey remain the only fatal ones.