### PR TITLE
Fix flaky TestDeindex by waiting for asynchronous message de-indexing

### DIFF
--- a/testsuite/elastic.go
+++ b/testsuite/elastic.go
@@ -240,6 +240,10 @@ type IndexedMessage struct {
 	Text        string `json:"text"`
 }
 
+// GetIndexedMessages returns the documents currently in this binary's message indexes. It refreshes the
+// indexes first so that writes which have already been applied are visible - but note that a refresh does
+// not wait for an in-flight delete-by-query task, so after an operation which de-indexes asynchronously
+// (e.g. search.DeindexMessagesByContact) use WaitForIndexedMessages instead.
 func GetIndexedMessages(t *testing.T, rt *runtime.Runtime, clear bool) []IndexedMessage {
 	t.Helper()
 
@@ -276,6 +280,32 @@ func GetIndexedMessages(t *testing.T, rt *runtime.Runtime, clear bool) []Indexed
 	if clear {
 		clearElasticMessages(t, rt)
 	}
+
+	return msgs
+}
+
+// WaitForIndexedMessages waits for this binary's message indexes to contain exactly count documents and
+// returns them, failing the test if that doesn't happen within a few seconds. Use this rather than
+// GetIndexedMessages when asserting on the result of an asynchronous de-index: Elastic runs a
+// delete-by-query issued with wait_for_completion=false as a background task, so the documents can still
+// be there when the request returns and refreshing the index doesn't wait for the task.
+func WaitForIndexedMessages(t *testing.T, rt *runtime.Runtime, count int) []IndexedMessage {
+	t.Helper()
+
+	const timeout = 10 * time.Second
+	const interval = 50 * time.Millisecond
+
+	var msgs []IndexedMessage
+
+	for deadline := time.Now().Add(timeout); ; {
+		msgs = GetIndexedMessages(t, rt, false)
+		if len(msgs) == count || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(interval)
+	}
+
+	require.Len(t, msgs, count, "timed out waiting for message index to contain %d document(s)", count)
 
 	return msgs
 }

--- a/web/contact/base_test.go
+++ b/web/contact/base_test.go
@@ -62,9 +62,9 @@ func TestDeindex(t *testing.T) {
 
 	testsuite.RunWebTests(t, rt, "testdata/deindex.json")
 
-	// Bob and Cat's messages should have been removed, Ann's should remain
-	msgs = testsuite.GetIndexedMessages(t, rt, false)
-	assert.Len(t, msgs, 1)
+	// Bob and Cat's messages should have been removed, Ann's should remain - message de-indexing happens
+	// via a delete-by-query which Elastic performs asynchronously, so we wait for it to be applied
+	msgs = testsuite.WaitForIndexedMessages(t, rt, 1)
 	assert.Equal(t, string(testdb.Ann.UUID), msgs[0].ContactUUID)
 }
 


### PR DESCRIPTION
`TestDeindex` was flaky in CI: after posting to `/mi/contact/deindex` it asserted that only one message remained indexed, and intermittently got all three back. It always passed on a rerun or in isolation.

## Cause

The de-index handler treats contacts and messages differently:

* contacts go through `DeindexContactsByUUID`, a synchronous bulk delete whose result the handler counts and returns
* messages go through `DeindexMessagesByContact`, a delete-by-query issued with `wait_for_completion=false`, which Elasticsearch runs as a background task

Nothing on the test side waited for that task. `GetIndexedMessages` flushes the bulk writer (unrelated to a server-side delete-by-query), refreshes and searches — and a refresh only publishes changes that have already been applied. Under load the read could land before the delete ran, which is why only the messages assertion failed.

## Fix

Test-side only. Adds `testsuite.WaitForIndexedMessages`, which polls until the message indexes hold the expected number of documents, bounded by a timeout and failing with the actual index contents if it doesn't converge. `TestDeindex` uses it in place of a bare read; the assertions themselves are unchanged. `GetIndexedMessages` now documents the trap and points at the new helper.

Production code is deliberately left alone — asynchronous deletion is the right behaviour for a request handler that shouldn't block on a bulk delete. Waiting on the tasks API was the alternative, but the task list can't be filtered by index, so a shared Elasticsearch would mean waiting on unrelated deletes.

## Verification

The race was reproduced deterministically by widening the window (a large delete-by-query, then an immediate refresh and read, which returned every document as still indexed). With the fix, the test was run 50 times in a row alongside a concurrent run of the rest of the suite, plus the full suite — all green.