### PR TITLE
Always construct LLM services with the runtime's services client

### DIFF
--- a/core/models/llm.go
+++ b/core/models/llm.go
@@ -47,7 +47,7 @@ func RegisterLLMService(typ string, fn func(*runtime.Runtime, *LLM, *http.Client
 
 func llmServiceFactory(rt *runtime.Runtime) engine.LLMServiceFactory {
 	return func(llm *core.LLM) (flows.LLMService, error) {
-		return llm.Asset().(*LLM).AsService(rt, rt.HTTP.Services)
+		return llm.Asset().(*LLM).AsService(rt)
 	}
 }
 
@@ -74,12 +74,16 @@ func (l *LLM) Config() Config          { return l.Config_ }
 func (l *LLM) MaxOutputTokens() int    { return min(l.MaxOutputTokens_, maxOutputTokensLimit) }
 func (l *LLM) Roles() []assets.LLMRole { return l.Roles_ }
 
-func (l *LLM) AsService(rt *runtime.Runtime, client *http.Client) (flows.LLMService, error) {
+// AsService constructs the service for this LLM. It's always given rt.HTTP.Services - the client for fixed
+// outbound targets - rather than letting the caller choose, because a caller which passes something else
+// (e.g. http.DefaultClient) silently loses that client's timeout, connection pooling and, since tracing
+// became a property of the client rather than of each call, its trace capture too.
+func (l *LLM) AsService(rt *runtime.Runtime) (flows.LLMService, error) {
 	fn := registeredLLMServices[l.Type()]
 	if fn == nil {
 		return nil, fmt.Errorf("unknown type '%s' for LLM: %s", l.Type(), l.UUID())
 	}
-	return fn(rt, l, client)
+	return fn(rt, l, rt.HTTP.Services)
 }
 
 // RecordCall records stats for an LLM call and returns the daily count rows to be inserted.

--- a/core/models/llm_test.go
+++ b/core/models/llm_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -9,7 +10,10 @@ import (
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/test/services"
 	"github.com/nyaruka/mailroom/v26/core/models"
+	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
@@ -50,6 +54,32 @@ func TestLLMs(t *testing.T) {
 
 	assert.Equal(t, "Claude", oa.LLMByID(testdb.Anthropic.ID).Name())
 	assert.Nil(t, oa.LLMByID(1235))
+}
+
+func TestLLMAsService(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	// register a service type which records the client it's constructed with
+	var gotClient *http.Client
+	models.RegisterLLMService("test_capture", func(rt *runtime.Runtime, l *models.LLM, c *http.Client) (flows.LLMService, error) {
+		gotClient = c
+		return services.NewLLM(), nil
+	})
+
+	llm := &models.LLM{UUID_: "8b3d0b6f-1f45-4b8b-a0b1-2a1e63dc4c9e", Type_: "test_capture"}
+
+	svc, err := llm.AsService(rt)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+
+	// services are always given the client for fixed outbound targets, never one of the caller's choosing,
+	// so they get its tracing, timeout and connection pooling
+	assert.Same(t, rt.HTTP.Services, gotClient)
+
+	unknown := &models.LLM{UUID_: "0dbf1d3e-2c0f-4c1f-9c6a-9f8c1e4d5b7a", Type_: "nope"}
+
+	_, err = unknown.AsService(rt)
+	assert.EqualError(t, err, "unknown type 'nope' for LLM: 0dbf1d3e-2c0f-4c1f-9c6a-9f8c1e4d5b7a")
 }
 
 func TestLLMRecordCall(t *testing.T) {

--- a/web/llm/translate.go
+++ b/web/llm/translate.go
@@ -73,7 +73,7 @@ func handleTranslate(ctx context.Context, rt *runtime.Runtime, r *translateReque
 		return nil, 0, fmt.Errorf("LLM with ID %d does not support editing", r.LLMID)
 	}
 
-	llmSvc, err := llm.AsService(rt, http.DefaultClient)
+	llmSvc, err := llm.AsService(rt)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating LLM service: %w", err)
 	}


### PR DESCRIPTION
`LLM.AsService` took an `*http.Client` from the caller. That parameter predates the runtime being threaded through the same method — once callers had `rt` they also had `rt.HTTP.Services`, and the parameter's only remaining effect was to let a caller pass something else. One had: `/llm/translate` constructed its service with `http.DefaultClient`, so LLM calls through that endpoint ran with no timeout, the default connection pool, and no trace capture.

The tracing part matters more than it used to. Since `httpx.WithTraces` became context-scoped, tracing is a property of the client rather than something each call assembles for itself, so a service handed a plain client collects nothing — and reports no error while doing it. That's a silent failure with no signal at the boundary where the mistake is made.

So rather than fixing the one call site, this drops the parameter and takes `rt.HTTP.Services` inside `AsService`. No caller can pick a different client, which makes the mistake unrepresentable instead of merely corrected.

## Changes

- `LLM.AsService(rt)` — no longer takes a client, uses `rt.HTTP.Services`
- `/llm/translate` — picks up the correct client as a result
- `TestLLMAsService` — registers a service type that records the client it's constructed with, and asserts it's the runtime's

The registry signature is unchanged: service constructors still receive the client, since they hold it and tests construct them directly with mocks.

## Note for callers

This is a breaking signature change, but a compile error rather than a silent behavior change — which is the point. Any out-of-tree caller passing its own client was, by construction, passing the wrong one.

## Test plan

- `TestLLMAsService` fails if `AsService` passes anything other than `rt.HTTP.Services` — verified by mutating it back to `http.DefaultClient` and watching the assertion fail
- Full suite green

Part of #1208 — deliberately not auto-closing it, since the IVR `DownloadMedia` calls noted there are a separate concern (missing timeout rather than missing tracing) and aren't touched here.