### PR TITLE
Download IVR media with the service's own HTTP client

### DIFF
--- a/services/ivr/bandwidth/service.go
+++ b/services/ivr/bandwidth/service.go
@@ -148,7 +148,7 @@ func (s *service) CheckStartRequest(r *http.Request) models.CallError {
 func (s *service) DownloadMedia(url string) (*http.Response, error) {
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
 	req.SetBasicAuth(s.username, s.password)
-	return http.DefaultClient.Do(req)
+	return s.httpClient.Do(req)
 }
 
 // HangupCall implements ivr.Service.

--- a/services/ivr/bandwidth/service_test.go
+++ b/services/ivr/bandwidth/service_test.go
@@ -2,10 +2,12 @@ package bandwidth_test
 
 import (
 	"encoding/xml"
+	"io"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
@@ -18,6 +20,7 @@ import (
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResponseForSprint(t *testing.T) {
@@ -112,6 +115,39 @@ func TestResponseForSprint(t *testing.T) {
 		assert.NoError(t, err, "%d: unexpected error")
 		assert.Equal(t, xml.Header+tc.expected, response, "%d: unexpected response", i)
 	}
+}
+
+func TestDownloadMedia(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	bwChannel := testdb.InsertChannel(t, rt, testdb.Org1, "BW", "Bandwidth", "123", []string{"tel"}, "CASR",
+		map[string]any{"username": "user", "password": "pass", "voice_application_id": "app-id", "account_id": "acc-id"})
+
+	oa := testdb.Org1.Load(t, rt)
+	ch := oa.ChannelByUUID(bwChannel.UUID)
+
+	client, mocks := testsuite.MockedHTTP(map[string][]*httpx.MockResponse{
+		"https://voice.bandwidth.com/recordings/foo.wav": {
+			httpx.NewMockResponse(200, nil, []byte(`AUDIO`)),
+		},
+	})
+
+	svc, err := bandwidth.NewServiceFromChannel(client, ch)
+	require.NoError(t, err)
+
+	resp, err := svc.DownloadMedia("https://voice.bandwidth.com/recordings/foo.wav")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, []byte(`AUDIO`), body)
+
+	// the download has to go via the service's own client, not http.DefaultClient
+	require.Len(t, mocks.Requests(), 1)
+	username, password, _ := mocks.Requests()[0].BasicAuth()
+	assert.Equal(t, "user", username)
+	assert.Equal(t, "pass", password)
 }
 
 func TestRedactValues(t *testing.T) {

--- a/services/ivr/twiml/service.go
+++ b/services/ivr/twiml/service.go
@@ -179,7 +179,7 @@ func NewService(httpClient *http.Client, accountSID string, authToken string) iv
 func (s *service) DownloadMedia(url string) (*http.Response, error) {
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
 	req.SetBasicAuth(s.accountSID, s.authToken)
-	return http.DefaultClient.Do(req)
+	return s.httpClient.Do(req)
 }
 
 func (s *service) CheckStartRequest(r *http.Request) models.CallError {

--- a/services/ivr/twiml/service_test.go
+++ b/services/ivr/twiml/service_test.go
@@ -2,12 +2,14 @@ package twiml_test
 
 import (
 	"encoding/xml"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
@@ -20,6 +22,7 @@ import (
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResponseForSprint(t *testing.T) {
@@ -137,6 +140,30 @@ func TestURNForRequest(t *testing.T) {
 
 	_, err = s.URNForRequest(makeRequest(`CallSid=12345&AccountSid=23456&To=%2B12029795079&Called=%2B12029795079&CallStatus=queued&ApiVersion=2010-04-01&Direction=inbound`))
 	assert.EqualError(t, err, "no Caller or From parameter found in request")
+}
+
+func TestDownloadMedia(t *testing.T) {
+	client, mocks := testsuite.MockedHTTP(map[string][]*httpx.MockResponse{
+		"https://api.twilio.com/recordings/foo.wav": {
+			httpx.NewMockResponse(200, nil, []byte(`AUDIO`)),
+		},
+	})
+
+	svc := twiml.NewService(client, "12345", "sesame")
+
+	resp, err := svc.DownloadMedia("https://api.twilio.com/recordings/foo.wav")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, []byte(`AUDIO`), body)
+
+	// the download has to go via the service's own client, not http.DefaultClient
+	require.Len(t, mocks.Requests(), 1)
+	username, password, _ := mocks.Requests()[0].BasicAuth()
+	assert.Equal(t, "12345", username)
+	assert.Equal(t, "sesame", password)
 }
 
 func TestRedactValues(t *testing.T) {

--- a/services/ivr/vonage/service.go
+++ b/services/ivr/vonage/service.go
@@ -165,7 +165,7 @@ func (s *service) DownloadMedia(url string) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	return http.DefaultClient.Do(req)
+	return s.httpClient.Do(req)
 }
 
 func (s *service) CheckStartRequest(r *http.Request) models.CallError {

--- a/services/ivr/vonage/service_test.go
+++ b/services/ivr/vonage/service_test.go
@@ -144,6 +144,34 @@ func TestResponseForSprint(t *testing.T) {
 	assert.Equal(t, float64(7200), decodedBody["length_timer"])
 }
 
+func TestDownloadMedia(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+
+	oa := testdb.Org1.Load(t, rt)
+	ch := oa.ChannelByUUID(testdb.VonageChannel.UUID)
+
+	client, mocks := testsuite.MockedHTTP(map[string][]*httpx.MockResponse{
+		"https://api.nexmo.com/recordings/foo.wav": {
+			httpx.NewMockResponse(200, nil, []byte(`AUDIO`)),
+		},
+	})
+
+	svc, err := NewServiceFromChannel(client, ch)
+	require.NoError(t, err)
+
+	resp, err := svc.DownloadMedia("https://api.nexmo.com/recordings/foo.wav")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, []byte(`AUDIO`), body)
+
+	// the download has to go via the service's own client, not http.DefaultClient
+	require.Len(t, mocks.Requests(), 1)
+	assert.Regexp(t, `^Bearer \S+$`, mocks.Requests()[0].Header.Get("Authorization"))
+}
+
 func TestRedactValues(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 


### PR DESCRIPTION
The three IVR services are each constructed with an `*http.Client` — `ivr.GetService(rt.HTTP.Services, ch)` — and keep it as `s.httpClient`. Every method uses it except `DownloadMedia`, which reaches past it for `http.DefaultClient`. Nothing about the call site makes that visible: the right client is already a field on the receiver, one line above the wrong one.

What the service's client carries and `http.DefaultClient` doesn't:

- **A 1-minute timeout.** `http.DefaultClient` has a zero `Timeout`, so a media host that accepts the connection and then stalls hangs the download indefinitely. `buildMsgResume` retries a failed download 45 times with a second between attempts, so the bound it thinks it has is on failures — not on a request that never returns.
- **The tuned connection pool and TLS settings** from `newBaseTransport`, rather than the shared process-wide default.

## Not a tracing change

`rt.HTTP.Services` also carries `httpx.WithTraces`, but that only captures a request whose context holds an `httpx.TraceCollector`. These methods build requests with `http.NewRequest`, so there's no collector on the context and nothing is traced either before or after this change — and equally, no caller's channel log gains unexpected media-download entries. Untraced requests are passed straight through without the response body being buffered, which for audio downloads is what you want anyway.

Threading a context through `DownloadMedia` so these could be traced is a bigger change with a different rationale; not folded in here.

## Behavior change worth knowing

`http.Client.Timeout` spans the whole exchange, including the caller's read of the body — so the download is now bounded end to end at a minute where previously it was unbounded. That's the point of the fix (a stalled host fails and lets `buildMsgResume` retry instead of hanging), and a minute is ample for call recordings, but it is a real bound where there was none.

## Changes

- `twiml`, `vonage` and `bandwidth` `DownloadMedia` — `s.httpClient.Do(req)` instead of `http.DefaultClient.Do(req)`
- a `TestDownloadMedia` in each package, serving the media from mocks installed on the service's own client and asserting the auth each service applies (basic for twiml/bandwidth, bearer JWT for vonage)

## Test plan

- each `TestDownloadMedia` fails against the unfixed code — verified by mutating all three back to `http.DefaultClient`, at which point the mocking transport records no request and the download leaves for the real network
- `gofmt -l .`, `go build ./...`, `go vet ./...` and the full suite green

Closes #1208
