### PR TITLE
Don't attach calls to non-voice sessions started by incoming call triggers

### DIFF
--- a/core/tasks/ctasks/event_received.go
+++ b/core/tasks/ctasks/event_received.go
@@ -121,6 +121,13 @@ func (t *EventReceived) handle(ctx context.Context, rt *runtime.Runtime, oa *mod
 					return nil, fmt.Errorf("error requesting call: %w", err)
 				}
 			} else {
+				// an incoming call can trigger a non-voice flow, in which case the call will be
+				// rejected and shouldn't be attached to the session
+				if flowType != models.FlowTypeVoice {
+					scene.DBCall = nil
+					scene.Call = nil
+				}
+
 				if err := scene.StartSession(ctx, rt, oa, trig, flowType.Interrupts()); err != nil {
 					return nil, fmt.Errorf("error starting session: %w", err)
 				}

--- a/core/tasks/ctasks/event_received_test.go
+++ b/core/tasks/ctasks/event_received_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
@@ -151,4 +152,53 @@ func TestEventReceived(t *testing.T) {
 	// and she has no upcoming campaign events
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contactfire WHERE contact_id = $1 AND fire_type = 'C'`, testdb.Ann.ID).Returns(0)
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contactfire WHERE contact_id = $1 AND fire_type = 'C'`, testdb.Cat.ID).Returns(1)
+}
+
+func TestIncomingCallStartsMessagingFlow(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	// incoming call trigger pointing at a messaging flow
+	testdb.InsertIncomingCallTrigger(t, rt, testdb.Org1, testdb.Favorites, nil, nil, testdb.TwilioChannel)
+	models.FlushCache()
+
+	oa := testdb.Org1.Load(t, rt)
+
+	mcs, err := models.LoadContactsByUUID(ctx, rt.DB, oa, []core.ContactUUID{testdb.Ann.UUID})
+	require.NoError(t, err)
+	mc := mcs[0]
+
+	ch := oa.ChannelByID(testdb.TwilioChannel.ID)
+	call := models.NewIncomingCall(oa.OrgID(), ch, mc, testdb.Ann.URNID, "ext123")
+	require.NoError(t, models.InsertCalls(ctx, rt.DB, []*models.Call{call}))
+
+	// handle the incoming call event inline as the IVR web handler does
+	task := &ctasks.EventReceived{
+		EventType: models.EventTypeIncomingCall,
+		ChannelID: testdb.TwilioChannel.ID,
+		URNID:     testdb.Ann.URNID,
+	}
+	scene, err := task.Handle(ctx, rt, oa, mc, call)
+	require.NoError(t, err)
+	require.NotNil(t, scene.Session)
+	assert.Equal(t, flows.FlowTypeMessaging, scene.Session.Type())
+
+	// reload contact to pick up current_session_uuid
+	mcs, err = models.LoadContactsByUUID(ctx, rt.DB, oa, []core.ContactUUID{testdb.Ann.UUID})
+	require.NoError(t, err)
+	mc = mcs[0]
+
+	// check the messaging session was created without the call attached
+	session, err := models.GetContactWaitingSession(ctx, rt, oa, mc)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, models.FlowTypeMessaging, session.SessionType)
+	assert.Equal(t, core.CallUUID(""), session.CallUUID)
+	assert.NotContains(t, string(session.Output), `"call_uuid"`)
+
+	// and thus can be resumed for expiration
+	exp := &ctasks.WaitExpired{SessionUUID: session.UUID, SprintUUID: session.LastSprintUUID}
+	err = exp.Perform(ctx, rt, oa, mc)
+	assert.NoError(t, err)
+
+	assertdb.Query(t, rt.DB, `SELECT status FROM flows_flowsession WHERE uuid = $1`, session.UUID).Returns("C")
 }


### PR DESCRIPTION
## Summary

An incoming-call trigger can point to a messaging (or background) flow, in which case the call is rejected but the flow is still started. Previously the session was created with the call attached, so its output was serialized with a `call_uuid` — and every subsequent resume (incoming message, wait timeout, wait expiration) reads the session without providing a call, failing with:

```
unable to unmarshal session: session call doesn't match provided
```

This left such sessions permanently stuck waiting, erroring on every resume attempt until interrupted.

## Changes

- `EventReceived.handle` now detaches the call from the scene (`scene.DBCall` / `scene.Call`) before starting a session for a non-voice flow, so neither the session output nor the `flows_flowsession.call_uuid` column references the call. Voice flows triggered by an incoming call keep the call attached as before.
- The `call_received` event on the trigger still records the call details — only the session's call association is dropped.

## Test plan

- New regression test `TestIncomingCallStartsMessagingFlow` replays the scenario: incoming call → inbound-call trigger → messaging flow, then verifies the waiting session has no call attached and can be resumed by a wait expiration (this previously failed with the error above).
- Existing test suites for `core/tasks/...`, `core/runner/...` and `web/...` pass.

## Notes

This only fixes newly created sessions — existing waiting sessions that already have a `call_uuid` in their output will still fail to resume and need separate remediation.