### PR TITLE
Ignore calls attached to non-voice sessions when reading them

### DIFF
--- a/core/models/session.go
+++ b/core/models/session.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -89,7 +88,7 @@ func (s *Session) EngineSession(ctx context.Context, rt *runtime.Runtime, sa flo
 
 	// non-voice sessions created by older versions can have a call attached which would make them unreadable without
 	// one, so strip that out (TODO: remove once all such sessions have ended)
-	if s.SessionType != FlowTypeVoice && call == nil && bytes.Contains(output, []byte(`"call_uuid"`)) {
+	if s.SessionType != FlowTypeVoice && call == nil && s.CallUUID != "" {
 		var envelope map[string]json.RawMessage
 		if err := json.Unmarshal(output, &envelope); err == nil {
 			delete(envelope, "call_uuid")

--- a/core/models/session.go
+++ b/core/models/session.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -83,7 +85,19 @@ func NewSession(oa *OrgAssets, fs flows.Session, sprint flows.Sprint, call *Call
 
 // EngineSession creates a flow session for the passed in session object
 func (s *Session) EngineSession(ctx context.Context, rt *runtime.Runtime, sa flows.SessionAssets, env envs.Environment, contact *core.Contact, call *core.Call) (flows.Session, error) {
-	session, err := goflow.Engine(rt).ReadSession(sa, []byte(s.Output), env, contact, call, assets.IgnoreMissing)
+	output := s.Output
+
+	// non-voice sessions created by older versions can have a call attached which would make them unreadable without
+	// one, so strip that out (TODO: remove once all such sessions have ended)
+	if s.SessionType != FlowTypeVoice && call == nil && bytes.Contains(output, []byte(`"call_uuid"`)) {
+		var envelope map[string]json.RawMessage
+		if err := json.Unmarshal(output, &envelope); err == nil {
+			delete(envelope, "call_uuid")
+			output = jsonx.MustMarshal(envelope)
+		}
+	}
+
+	session, err := goflow.Engine(rt).ReadSession(sa, output, env, contact, call, assets.IgnoreMissing)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal session: %w", err)
 	}

--- a/core/models/session_test.go
+++ b/core/models/session_test.go
@@ -121,6 +121,7 @@ func TestEngineSession(t *testing.T) {
 	jsonx.MustUnmarshal(session.Output, &envelope)
 	envelope["call_uuid"] = json.RawMessage(`"0199ba54-f47c-77a1-a3b0-a83bd7f6c6a5"`)
 	session.Output = jsonx.MustMarshal(envelope)
+	session.CallUUID = "0199ba54-f47c-77a1-a3b0-a83bd7f6c6a5"
 
 	// should still be readable without a call because the stored call is ignored for non-voice sessions
 	readSession, err := session.EngineSession(ctx, rt, oa.SessionAssets(), oa.Env(), flowSession.Contact(), nil)

--- a/core/models/session_test.go
+++ b/core/models/session_test.go
@@ -1,11 +1,13 @@
 package models_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
@@ -98,6 +100,37 @@ func TestInsertSessions(t *testing.T) {
 	// check that matches what is in the db
 	assertdb.Query(t, rt.DB, `SELECT status, session_type, current_flow_uuid FROM flows_flowsession`).
 		Columns(map[string]any{"status": "C", "session_type": "M", "current_flow_uuid": nil})
+}
+
+func TestEngineSession(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	testFlows := testdb.ImportFlows(t, rt, testdb.Org1, "testdata/session_test_flows.json")
+	flow := testFlows[0]
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdb.Org1.ID, models.RefreshFlows)
+	require.NoError(t, err)
+
+	_, flowSession, sprint := test.NewSessionBuilder().WithAssets(oa.SessionAssets()).WithFlow(flow.UUID).
+		WithContact(testdb.Bob.UUID, core.ContactID(testdb.Bob.ID), "Bob", "eng", "").MustBuild()
+
+	session := models.NewSession(oa, flowSession, sprint, nil)
+
+	// simulate a legacy messaging session created with a call attached to it
+	var envelope map[string]json.RawMessage
+	jsonx.MustUnmarshal(session.Output, &envelope)
+	envelope["call_uuid"] = json.RawMessage(`"0199ba54-f47c-77a1-a3b0-a83bd7f6c6a5"`)
+	session.Output = jsonx.MustMarshal(envelope)
+
+	// should still be readable without a call because the stored call is ignored for non-voice sessions
+	readSession, err := session.EngineSession(ctx, rt, oa.SessionAssets(), oa.Env(), flowSession.Contact(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, readSession.Call())
+
+	// but a voice session read without a matching call is still an error
+	session.SessionType = models.FlowTypeVoice
+	_, err = session.EngineSession(ctx, rt, oa.SessionAssets(), oa.Env(), flowSession.Contact(), nil)
+	assert.ErrorContains(t, err, "session call doesn't match provided")
 }
 
 func TestGetContactWaitingSession(t *testing.T) {

--- a/core/models/session_test.go
+++ b/core/models/session_test.go
@@ -128,6 +128,9 @@ func TestEngineSession(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, readSession.Call())
 
+	// and re-serializing it (as a subsequent update would) no longer includes the call
+	assert.NotContains(t, string(jsonx.MustMarshal(readSession)), `"call_uuid"`)
+
 	// but a voice session read without a matching call is still an error
 	session.SessionType = models.FlowTypeVoice
 	_, err = session.EngineSession(ctx, rt, oa.SessionAssets(), oa.Env(), flowSession.Contact(), nil)


### PR DESCRIPTION
## Summary

Follow-up to #1211, which stopped attaching calls to non-voice sessions started by incoming call triggers. Sessions created before that fix still have a `call_uuid` in their stored output, so every resume (incoming message, wait timeout, wait expiration) still fails with `session call doesn't match provided`, leaving them permanently stuck waiting.

## Changes

- `Session.EngineSession` now strips the top-level `call_uuid` from the stored output before reading it with the engine, when the session isn't a voice session, no call was provided, and the session row has a `call_uuid` set. Voice sessions are unaffected and still require a matching call.
- The gate is an O(1) check against the session's `call_uuid` column (which all affected sessions have set), so normal session reads pay no extra cost — no scanning or re-parsing of the output.
- This self-heals affected sessions: the next successful resume re-serializes the output without the call. Since sessions expire within ~31 days, this workaround can be removed once all sessions created before #1211 have ended (marked with a TODO).

## Test plan

- New `TestEngineSession` covers reading a messaging session whose output has a legacy `call_uuid` (succeeds, call is dropped, and the session re-serializes without it) and a voice session read without a call (still errors).
- Existing test suites for `core/models/...`, `core/tasks/...`, `core/runner/...` and `web/...` pass.