### PR TITLE
Index contacts created by an import which produce no change events

### DIFF
--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -105,15 +105,13 @@ func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 	// them explicitly. Contacts that were updated rather than created already have a document, and any changes to
 	// them will have been indexed by the hooks.
 	created := make([]*core.Contact, 0, len(imports))
-	currentFlows := make(map[models.ContactID]models.FlowID, len(imports))
 	for _, imp := range imports {
 		if imp.created {
 			created = append(created, imp.contact)
-			currentFlows[imp.mc.ID()] = imp.mc.CurrentFlowID()
 		}
 	}
 
-	if err := search.IndexContacts(ctx, rt, oa, created, currentFlows); err != nil {
+	if err := search.IndexContacts(ctx, rt, oa, created, nil); err != nil {
 		return fmt.Errorf("error indexing new contacts: %w", err)
 	}
 

--- a/core/imports/contacts.go
+++ b/core/imports/contacts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/goflow/flows/modifiers"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/runner"
+	"github.com/nyaruka/mailroom/v26/core/search"
 	"github.com/nyaruka/mailroom/v26/runtime"
 	"github.com/vinovest/sqlx"
 )
@@ -97,6 +98,23 @@ func ImportBatch(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets,
 				}
 			}
 		}
+	}
+
+	// contacts created by this import aren't necessarily indexed by the modifier hooks - a record with only URNs
+	// produces no change events at all, because the contact is created with those URNs already on it - so index
+	// them explicitly. Contacts that were updated rather than created already have a document, and any changes to
+	// them will have been indexed by the hooks.
+	created := make([]*core.Contact, 0, len(imports))
+	currentFlows := make(map[models.ContactID]models.FlowID, len(imports))
+	for _, imp := range imports {
+		if imp.created {
+			created = append(created, imp.contact)
+			currentFlows[imp.mc.ID()] = imp.mc.CurrentFlowID()
+		}
+	}
+
+	if err := search.IndexContacts(ctx, rt, oa, created, currentFlows); err != nil {
+		return fmt.Errorf("error indexing new contacts: %w", err)
 	}
 
 	if err := markBatchComplete(ctx, rt.DB, b, imports); err != nil {

--- a/core/imports/contacts_test.go
+++ b/core/imports/contacts_test.go
@@ -1,6 +1,7 @@
 package imports_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/dbutil"
+	"github.com/nyaruka/gocommon/elastic"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -148,6 +150,37 @@ func TestContactImports(t *testing.T) {
 
 		err = os.WriteFile("testdata/contacts.json", testJSON, 0600)
 		require.NoError(t, err)
+	}
+}
+
+func TestContactImportsIndexing(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	oa := testdb.Org1.Load(t, rt)
+
+	// records which change nothing about the contact they create - i.e. only URNs - produce no change events and so
+	// aren't indexed by the modifier hooks, but should still end up in Elastic
+	importID := testdb.InsertContactImport(t, rt, testdb.Org1, models.ImportStatusProcessing, testdb.Admin)
+	batchID := testdb.InsertContactImportBatch(t, rt, importID, []byte(`[
+		{"name": "Norbert", "urns": ["tel:+16055740001"]},
+		{"urns": ["tel:+16055740002"]},
+		{"urns": ["tel:+16055740003"], "fields": {"age": "39"}}
+	]`))
+
+	batch, err := models.LoadContactImportBatch(ctx, rt.DB, batchID)
+	require.NoError(t, err)
+
+	require.NoError(t, imports.ImportBatch(ctx, rt, oa, batch, testdb.Admin.ID))
+
+	rt.ES.Writer.Flush()
+	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
+	require.NoError(t, err)
+
+	for _, path := range []string{"+16055740001", "+16055740002", "+16055740003"} {
+		src := map[string]any{"query": elastic.Nested("urns", elastic.Term("urns.path.keyword", path))}
+		resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), resp.Count, "expected new contact with URN %s to be indexed", path)
 	}
 }
 


### PR DESCRIPTION
## Summary

Contacts created by a contact import were only indexed in Elasticsearch as a side effect of the post-commit hooks attached by contact change event handlers. An import record carrying nothing but URNs produces no change events at all, so such contacts were created in the database but never indexed.

## The problem

`ImportBatch` applies each record's modifiers via `runner.ModifyWithoutLock` and relies on the resulting events — `contact_name_changed`, `contact_field_changed`, `contact_urns_changed`, etc. — to attach the `IndexContacts` post-commit hook.

For a contact the import just created, the always-added `urns` modifier is a no-op: the contact was created with exactly those URNs, so `Routes.Apply` reports nothing modified and logs no event. If the record has no name, language, fields, groups or non-active status either, the record produces zero events, no hook is attached, and the contact never reaches Elasticsearch.

Since indexing is event-driven, nothing catches up afterwards. The contact stays invisible to search — and to everything built on it — until a full reindex or some later change to that contact.

| Import record | Contact in DB | Document in Elastic (before) | (after) |
|---|---|---|---|
| `{"name": "Norbert", "urns": ["tel:+16055740001"]}` | yes | yes | yes |
| `{"urns": ["tel:+16055740002"]}` | yes | **no** | yes |
| `{"urns": ["tel:+16055740003"], "fields": {"age": "39"}}` | yes | yes | yes |

## Changes

**`core/imports/contacts.go`** — after the batch's modifiers are applied and committed, explicitly index the contacts the batch created, mirroring what `POST /contact/create` already does for a single contact.

This is scoped to created contacts rather than the whole batch: an updated contact already has a document and the hooks cover its changes, so indexing everything would roughly double Elasticsearch write volume on large imports for no gain. For a created contact the redundant write, when a hook also fired, is idempotent — same document ID, same content, and the version is a nanosecond timestamp so the later write wins.

Indexing runs before `markBatchComplete`, so a failure to queue documents fails the batch rather than reporting it as successfully imported.

**`core/imports/contacts_test.go`** — `TestContactImportsIndexing` covers the regression.

## Test plan

- [x] New `TestContactImportsIndexing` imports three records (named, URN-only, field-only), flushes the writer, refreshes the index, and asserts each URN resolves to exactly one document
- [x] Confirmed the new test fails without the fix, on the URN-only record specifically (`expected: 1, actual: 0`)
- [x] `go test ./...` passes

## Note for operators

This fixes new imports only. Contacts already missing from the index as a result of this need a full contact reindex, or `POST /contact/reindex` for a known set.