### PR TITLE
Fix indexing of contacts created by sending a broadcast to URNs

### DIFF
--- a/core/models/broadcast.go
+++ b/core/models/broadcast.go
@@ -134,11 +134,16 @@ type BroadcastBatch struct {
 	Broadcast   *Broadcast  `json:"broadcast,omitempty"`
 
 	ContactIDs []ContactID `json:"contact_ids"`
+
+	// subset of contact_ids that were created resolving the broadcast's URN recipients - they won't generate change
+	// events so need to be explicitly indexed
+	CreatedContactIDs []ContactID `json:"created_contact_ids,omitempty"`
 }
 
-func (b *Broadcast) CreateBatch(contactIDs []ContactID) *BroadcastBatch {
+func (b *Broadcast) CreateBatch(contactIDs, createdContactIDs []ContactID) *BroadcastBatch {
 	bb := &BroadcastBatch{
-		ContactIDs: contactIDs,
+		ContactIDs:        contactIDs,
+		CreatedContactIDs: createdContactIDs,
 	}
 
 	if b.ID != NilBroadcastID {

--- a/core/models/broadcast_test.go
+++ b/core/models/broadcast_test.go
@@ -117,11 +117,12 @@ func TestNonPersistentBroadcasts(t *testing.T) {
 	assert.Equal(t, "", bcast.Query)
 	assert.Equal(t, models.NoExclusions, bcast.Exclusions)
 
-	batch := bcast.CreateBatch([]models.ContactID{testdb.Dan.ID, testdb.Bob.ID})
+	batch := bcast.CreateBatch([]models.ContactID{testdb.Dan.ID, testdb.Bob.ID}, []models.ContactID{testdb.Dan.ID})
 
 	assert.Equal(t, models.NilBroadcastID, batch.BroadcastID)
 	assert.NotNil(t, testdb.Org1.ID, batch.Broadcast)
 	assert.Equal(t, []models.ContactID{testdb.Dan.ID, testdb.Bob.ID}, batch.ContactIDs)
+	assert.Equal(t, []models.ContactID{testdb.Dan.ID}, batch.CreatedContactIDs)
 }
 
 func TestBroadcastSend(t *testing.T) {

--- a/core/runner/broadcasts.go
+++ b/core/runner/broadcasts.go
@@ -25,7 +25,20 @@ func BroadcastWithLock(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 		}
 	}
 
+	created := make(map[models.ContactID]bool, len(batch.CreatedContactIDs))
+	for _, id := range batch.CreatedContactIDs {
+		created[id] = true
+	}
+
 	for _, scene := range scenes {
+		// contacts created resolving the broadcast's URN recipients won't generate any change events so add a
+		// contact_created event to ensure they get indexed
+		if created[scene.ContactID()] {
+			if err := scene.AddEvent(ctx, rt, oa, NewContactCreatedEvent(), broadcast.CreatedByID, ""); err != nil {
+				return nil, nil, fmt.Errorf("error adding contact created event to broadcast scene: %w", err)
+			}
+		}
+
 		if mode == models.StartModeSkip && scene.DBContact.CurrentSessionUUID() != "" {
 			continue
 		}

--- a/core/runner/scene_test.go
+++ b/core/runner/scene_test.go
@@ -667,8 +667,8 @@ func TestBroadcastWithLock(t *testing.T) {
 
 	defer test.MockUniverse()()
 
-	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID})
-	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID})
+	batch1 := bcast.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, nil)
+	batch2 := bcast.CreateBatch([]models.ContactID{testdb.Cat.ID}, nil)
 
 	scenes, skipped, err := runner.BroadcastWithLock(ctx, rt, oa, bcast, batch1, models.StartModeBackground)
 	assert.NoError(t, err)
@@ -734,7 +734,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast2, err := models.GetBroadcastByID(ctx, rt.DB, b2.ID)
 	require.NoError(t, err)
 
-	skipBatch := bcast2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID})
+	skipBatch := bcast2.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, nil)
 	scenes, skipped, err = runner.BroadcastWithLock(ctx, rt, oa, bcast2, skipBatch, models.StartModeSkip)
 	assert.NoError(t, err)
 	assert.Len(t, skipped, 0) // all contacts were locked successfully
@@ -757,7 +757,7 @@ func TestBroadcastWithLock(t *testing.T) {
 	bcast3, err := models.GetBroadcastByID(ctx, rt.DB, b3.ID)
 	require.NoError(t, err)
 
-	intBatch := bcast3.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID})
+	intBatch := bcast3.CreateBatch([]models.ContactID{testdb.Ann.ID, testdb.Bob.ID, testdb.Cat.ID}, nil)
 	scenes, skipped, err = runner.BroadcastWithLock(ctx, rt, oa, bcast3, intBatch, models.StartModeInterrupt)
 	assert.NoError(t, err)
 	assert.Len(t, skipped, 0)

--- a/core/search/resolve.go
+++ b/core/search/resolve.go
@@ -110,6 +110,19 @@ func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 			matches = append(matches, c.ID())
 			createdIDs = append(createdIDs, c.ID())
 		}
+	} else if len(createdContacts) > 0 {
+		// excluded created contacts aren't returned to the caller so nothing downstream will index them - do it here
+		contacts := make([]*core.Contact, 0, len(createdContacts))
+		for _, c := range createdContacts {
+			contact, err := c.EngineContact(oa)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error creating engine contact for %s: %w", c.UUID(), err)
+			}
+			contacts = append(contacts, contact)
+		}
+		if err := IndexContacts(ctx, rt, oa, contacts, nil); err != nil {
+			return nil, nil, fmt.Errorf("error indexing created contacts: %w", err)
+		}
 	}
 
 	return matches, createdIDs, nil

--- a/core/search/resolve.go
+++ b/core/search/resolve.go
@@ -19,14 +19,16 @@ type Recipients struct {
 	ExcludeGroupIDs []models.GroupID
 }
 
-// ResolveRecipients resolves a set of contacts, groups, urns etc into a set of unique contacts
-func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, userID models.UserID, flow *models.Flow, recipients *Recipients, limit int) ([]models.ContactID, error) {
+// ResolveRecipients resolves a set of contacts, groups, urns etc into a set of unique contacts. Also returns the ids
+// of any contacts created by resolving raw URNs - such contacts won't generate change events so callers may need to
+// arrange indexing for them.
+func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, userID models.UserID, flow *models.Flow, recipients *Recipients, limit int) ([]models.ContactID, []models.ContactID, error) {
 	idsSeen := make(map[models.ContactID]bool)
 
 	// start by loading the explicitly listed contacts
 	includeContacts, err := models.LoadContacts(ctx, rt.DB, oa, recipients.ContactIDs)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, c := range includeContacts {
 		idsSeen[c.ID()] = true
@@ -34,12 +36,13 @@ func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 
 	// created contacts are handled separately because they won't be indexed
 	var createdContacts map[urns.URN]*models.Contact
+	var createdIDs []models.ContactID
 
 	// resolve any raw URNs
 	if len(recipients.URNs) > 0 {
 		fetchedByURN, createdByURN, err := models.GetOrCreateContactsFromURNs(ctx, rt.DB, oa, userID, recipients.URNs)
 		if err != nil {
-			return nil, fmt.Errorf("error getting contact ids from urns: %w", err)
+			return nil, nil, fmt.Errorf("error getting contact ids from urns: %w", err)
 		}
 		for _, c := range fetchedByURN {
 			if !idsSeen[c.ID()] {
@@ -77,8 +80,9 @@ func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 		}
 		for _, c := range createdContacts {
 			matches = append(matches, c.ID())
+			createdIDs = append(createdIDs, c.ID())
 		}
-		return matches, nil
+		return matches, createdIDs, nil
 	}
 
 	if len(includeContacts) > 0 || len(includeGroups) > 0 || recipients.Query != "" {
@@ -90,12 +94,12 @@ func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 
 		query, err := BuildRecipientsQuery(oa, flow, includeGroups, includeContactUUIDs, recipients.Query, recipients.Exclusions, excludeGroups)
 		if err != nil {
-			return nil, fmt.Errorf("error building query: %w", err)
+			return nil, nil, fmt.Errorf("error building query: %w", err)
 		}
 
 		matches, err = GetContactIDsForQuery(ctx, rt, oa, nil, models.ContactStatusActive, query, limit)
 		if err != nil {
-			return nil, fmt.Errorf("error performing contact search: %w", err)
+			return nil, nil, fmt.Errorf("error performing contact search: %w", err)
 		}
 	}
 
@@ -104,8 +108,9 @@ func ResolveRecipients(ctx context.Context, rt *runtime.Runtime, oa *models.OrgA
 	if recipients.Exclusions.NotSeenSinceDays == 0 {
 		for _, c := range createdContacts {
 			matches = append(matches, c.ID())
+			createdIDs = append(createdIDs, c.ID())
 		}
 	}
 
-	return matches, nil
+	return matches, createdIDs, nil
 }

--- a/core/search/resolve_test.go
+++ b/core/search/resolve_test.go
@@ -1,8 +1,11 @@
 package search_test
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/nyaruka/gocommon/elastic"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/search"
@@ -103,4 +106,30 @@ func TestResolveRecipients(t *testing.T) {
 		assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "contact ids mismatch in %d", i)
 		assert.ElementsMatch(t, tc.expectedCreatedIDs, actualCreatedIDs, "created contact ids mismatch in %d", i)
 	}
+}
+
+func TestResolveRecipientsIndexesExcludedCreatedContacts(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	// resolve a raw URN with a last seen exclusion which the created contact can't satisfy
+	matches, createdIDs, err := search.ResolveRecipients(ctx, rt, oa, testdb.Admin.ID, nil, &search.Recipients{
+		URNs:       []urns.URN{"tel:+1234000099"},
+		Exclusions: models.Exclusions{NotSeenSinceDays: 10},
+	}, -1)
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+	assert.Empty(t, createdIDs)
+
+	// contact is created but excluded, so it should have been indexed directly
+	rt.ES.Writer.Flush()
+	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
+	require.NoError(t, err)
+
+	src := map[string]any{"query": elastic.Nested("urns", elastic.Term("urns.path.keyword", "+1234000099"))}
+	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Count, "expected excluded created contact to be indexed")
 }

--- a/core/search/resolve_test.go
+++ b/core/search/resolve_test.go
@@ -22,10 +22,11 @@ func TestResolveRecipients(t *testing.T) {
 	require.NoError(t, err)
 
 	tcs := []struct {
-		flow        *testdb.Flow
-		recipients  *search.Recipients
-		limit       int
-		expectedIDs []models.ContactID
+		flow               *testdb.Flow
+		recipients         *search.Recipients
+		limit              int
+		expectedIDs        []models.ContactID
+		expectedCreatedIDs []models.ContactID
 	}{
 		{ // 0 nobody
 			recipients:  &search.Recipients{},
@@ -68,8 +69,9 @@ func TestResolveRecipients(t *testing.T) {
 				URNs:       []urns.URN{"tel:+1234000001", "tel:+1234000002"},
 				Exclusions: models.Exclusions{InAFlow: true},
 			},
-			limit:       -1,
-			expectedIDs: []models.ContactID{testdb.Bob.ID, 30000, 30001},
+			limit:              -1,
+			expectedIDs:        []models.ContactID{testdb.Bob.ID, 30000, 30001},
+			expectedCreatedIDs: []models.ContactID{30000, 30001},
 		},
 		{ // 6 new contacts not included if excluding based on last seen
 			recipients: &search.Recipients{
@@ -96,8 +98,9 @@ func TestResolveRecipients(t *testing.T) {
 			flow = tc.flow.Load(t, rt, oa)
 		}
 
-		actualIDs, err := search.ResolveRecipients(ctx, rt, oa, testdb.Admin.ID, flow, tc.recipients, tc.limit)
+		actualIDs, actualCreatedIDs, err := search.ResolveRecipients(ctx, rt, oa, testdb.Admin.ID, flow, tc.recipients, tc.limit)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, tc.expectedIDs, actualIDs, "contact ids mismatch in %d", i)
+		assert.ElementsMatch(t, tc.expectedCreatedIDs, actualCreatedIDs, "created contact ids mismatch in %d", i)
 	}
 }

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -59,7 +59,7 @@ func (t *SendBroadcast) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 }
 
 func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAssets, bcast *models.Broadcast) error {
-	contactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
+	contactIDs, createdContactIDs, err := search.ResolveRecipients(ctx, rt, oa, bcast.CreatedByID, nil, &search.Recipients{
 		ContactIDs:      bcast.ContactIDs,
 		GroupIDs:        bcast.GroupIDs,
 		URNs:            bcast.URNs,
@@ -105,10 +105,22 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 		q = rt.Queues.Realtime
 	}
 
+	createdIDs := make(map[models.ContactID]bool, len(createdContactIDs))
+	for _, id := range createdContactIDs {
+		createdIDs[id] = true
+	}
+
 	// create tasks for batches of contacts
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
 	for i, idBatch := range idBatches {
-		batch := bcast.CreateBatch(idBatch)
+		var createdBatch []models.ContactID
+		for _, id := range idBatch {
+			if createdIDs[id] {
+				createdBatch = append(createdBatch, id)
+			}
+		}
+
+		batch := bcast.CreateBatch(idBatch, createdBatch)
 		batchTask := &SendBroadcastBatch{
 			BatchTask:      BatchTask{BatchOwnerUUID: uuids.UUID(bcast.UUID), TotalBatches: len(idBatches)},
 			BroadcastBatch: batch,

--- a/core/tasks/send_broadcast_test.go
+++ b/core/tasks/send_broadcast_test.go
@@ -1,11 +1,14 @@
 package tasks_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
+	"github.com/nyaruka/gocommon/elastic"
 	"github.com/nyaruka/gocommon/i18n"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
@@ -167,6 +170,48 @@ func TestBroadcastsFromEvents(t *testing.T) {
 		lastNow = time.Now()
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func TestSendBroadcastToURNsIndexesCreatedContacts(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdb.Org1.ID)
+	require.NoError(t, err)
+
+	// send a broadcast to a URN that doesn't belong to an existing contact
+	bcast := models.NewBroadcast(
+		oa.OrgID(),
+		core.BroadcastTranslations{"eng": {Text: "hello"}},
+		"eng",
+		false,
+		nil,
+		nil,
+		[]urns.URN{"tel:+16055749999"},
+		"",
+		models.NoExclusions,
+		testdb.Admin.ID,
+	)
+	err = models.InsertBroadcast(ctx, rt.DB, bcast)
+	require.NoError(t, err)
+
+	err = tasks.Queue(ctx, rt, rt.Queues.Batch, testdb.Org1.ID, &tasks.SendBroadcast{Broadcast: bcast}, false)
+	require.NoError(t, err)
+
+	testsuite.FlushTasks(t, rt)
+
+	// a contact should have been created for the URN and sent the broadcast message
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM contacts_contacturn WHERE identity = 'tel:+16055749999'`).Returns(1)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE org_id = 1 AND text = 'hello'`).Returns(1)
+
+	// and the created contact should have been indexed
+	rt.ES.Writer.Flush()
+	_, err = rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
+	require.NoError(t, err)
+
+	src := map[string]any{"query": elastic.Nested("urns", elastic.Term("urns.path.keyword", "+16055749999"))}
+	resp, err := rt.ES.Client.Count().Index(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Count, "expected created contact to be indexed")
 }
 
 func TestSendBroadcastTask(t *testing.T) {

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -81,7 +81,8 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 			limit = 1
 		}
 
-		contactIDs, err = search.ResolveRecipients(ctx, rt, oa, start.CreatedByID, flow, &search.Recipients{
+		// created contacts don't need explicit indexing here because starting them in a flow will index them
+		contactIDs, _, err = search.ResolveRecipients(ctx, rt, oa, start.CreatedByID, flow, &search.Recipients{
 			ContactIDs:      start.ContactIDs,
 			GroupIDs:        start.GroupIDs,
 			URNs:            start.URNs,


### PR DESCRIPTION
## Summary

Contacts created by sending a broadcast to a raw URN were never indexed in Elasticsearch. The only event raised for them is `msg_created`, whose handler doesn't attach the contact indexing hook — unlike flow starts, where session events take care of indexing. This carries created-ness across the task boundary and raises the `contact_created` pseudo event (#1219) for those contacts so they get indexed. It also closes the related hole where a contact created from a URN recipient but then dropped by a `not_seen_since` exclusion was never indexed either.

## Changes

- `search.ResolveRecipients` now also returns the IDs of contacts it created from raw URNs. The flow start task ignores them since starting a session already indexes the contact.
- `models.BroadcastBatch` gains an additive `created_contact_ids` field (omitted when empty), populated per batch by the send broadcast task.
- `runner.BroadcastWithLock` adds a `contact_created` event to scenes for those contacts, which attaches the indexing post-commit hook (deduped, so contacts that generate other indexing events aren't double-indexed).
- When a `not_seen_since` exclusion drops created contacts from the results, `ResolveRecipients` indexes them directly — they're persisted but excluded from sending, so nothing downstream would ever index them. This covers both the broadcast and flow start paths.

## Test plan

- New `TestSendBroadcastToURNsIndexesCreatedContacts`: broadcast to a fresh tel URN, flush tasks and the ES writer, assert the created contact has an ES document. Verified it fails (0 docs) without the runner change.
- New `TestResolveRecipientsIndexesExcludedCreatedContacts`: resolve a raw URN with a `not_seen_since` exclusion, assert the contact is returned in neither result but is indexed.
- Extended `TestResolveRecipients` and broadcast batch tests to cover the created-IDs plumbing.
- Full test suite passes.