### PR TITLE
Refresh both batch tracker keys as batches complete

### DIFF
--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -11,13 +11,18 @@ import (
 
 const (
 	batchTrackerKeyBase = "batch_task"
-	batchTrackerTTL     = 24 * time.Hour
+
+	// how long tracker keys survive without progress - refreshed on every completion, so this bounds the gap
+	// between batches of a set completing (which for a throttled org is queue wait) rather than how long the
+	// set as a whole takes
+	batchTrackerTTL = 24 * time.Hour
 )
 
 // BatchTracker tracks progress of a set of batch tasks split out from an owning task or object, using two Valkey keys:
 // a simple key marking that processing of the set has started, and a hash of the task IDs of completed batches. Because
 // completions are recorded as distinct hash fields, marking the same batch as done more than once has no effect, and
-// the completed count can't reach the total until all batches are really done.
+// the completed count can't reach the total until all batches are really done. Both keys have their TTL refreshed as
+// batches complete, so a set only loses its tracking if it makes no progress at all for the length of the TTL.
 type BatchTracker struct {
 	startedKey string
 	batchesKey string
@@ -49,11 +54,14 @@ func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID)
 	vc := vk.Get()
 	defer vc.Close()
 
-	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, string(taskID), int(batchTrackerTTL/time.Second)))
+	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, t.startedKey, string(taskID), int(batchTrackerTTL/time.Second)))
 }
 
-var trackerDone = valkey.NewScript(1, `
+// records a batch as complete and extends the lifetime of both keys - if the started key were allowed to expire while
+// batches were still being processed, a later batch would think it was the first to start
+var trackerDone = valkey.NewScript(2, `
 redis.call('HSET', KEYS[1], ARGV[1], 1)
 redis.call('EXPIRE', KEYS[1], ARGV[2])
+redis.call('EXPIRE', KEYS[2], ARGV[2])
 return redis.call('HLEN', KEYS[1])
 `)

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -74,4 +74,15 @@ func TestBatchTracker(t *testing.T) {
 	first, err = tracker.Started(ctx, rt.VK)
 	assert.NoError(t, err)
 	assert.False(t, first)
+
+	// but a set which stalls for longer than the TTL loses its tracking rather than having it resurrected
+	vc.Do("DEL", startedKey)
+
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 5, completed)
+
+	exists, err := valkey.Int(vc.Do("EXISTS", startedKey))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, exists)
 }

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -7,12 +7,22 @@ import (
 	"github.com/nyaruka/mailroom/v26/core/tasks"
 	"github.com/nyaruka/mailroom/v26/testsuite"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBatchTracker(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 	vc := rt.VK.Get()
 	defer vc.Close()
+
+	const startedKey = "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:started"
+	const batchesKey = "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:batches"
+
+	ttlOf := func(key string) int {
+		ttl, err := valkey.Int(vc.Do("TTL", key))
+		require.NoError(t, err)
+		return ttl
+	}
 
 	tracker := tasks.NewBatchTracker("7de40d16-0286-4938-be6b-9974e12e1b0f")
 
@@ -21,9 +31,7 @@ func TestBatchTracker(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, first)
 
-	ttl, err := valkey.Int(vc.Do("TTL", "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:started"))
-	assert.NoError(t, err)
-	assert.Greater(t, ttl, 0)
+	assert.Greater(t, ttlOf(startedKey), 0)
 
 	// subsequent batches aren't first
 	first, err = tracker.Started(ctx, rt.VK)
@@ -35,9 +43,7 @@ func TestBatchTracker(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
 
-	ttl, err = valkey.Int(vc.Do("TTL", "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:batches"))
-	assert.NoError(t, err)
-	assert.Greater(t, ttl, 0)
+	assert.Greater(t, ttlOf(batchesKey), 0)
 
 	// completing the same batch again changes nothing
 	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
@@ -51,4 +57,21 @@ func TestBatchTracker(t *testing.T) {
 	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, completed)
+
+	// simulate a set which has made no progress for a while by shortening the TTLs of both keys
+	vc.Do("EXPIRE", startedKey, 60)
+	vc.Do("EXPIRE", batchesKey, 60)
+
+	// completing another batch refreshes both, so that a set only loses its tracking if it stalls completely
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000")
+	assert.NoError(t, err)
+	assert.Equal(t, 4, completed)
+
+	assert.Greater(t, ttlOf(startedKey), 60)
+	assert.Greater(t, ttlOf(batchesKey), 60)
+
+	// so a later batch never thinks it's the first to start
+	first, err = tracker.Started(ctx, rt.VK)
+	assert.NoError(t, err)
+	assert.False(t, first)
 }


### PR DESCRIPTION
## Summary

A set of batch tasks is tracked in Valkey by two keys: one marking the set as started, and a hash of the task IDs of completed batches. Only the hash had its TTL extended as batches completed, so the started key expired a fixed period after the first batch ran no matter how much of the set was left. This makes both keys track progress rather than age.

## Changes

- `core/tasks/tracker.go` — the `trackerDone` script now takes both keys and extends the lifetime of each, so neither can lapse while the set is still completing batches. The comment on `batchTrackerTTL` now states the invariant it actually provides: it bounds the gap between batches of a set completing, not the duration of the set.
- `core/tasks/tracker_test.go` — covers the refresh by shortening both TTLs mid-set, completing another batch, and asserting both are extended and that a subsequent `Started` still reports not-first. Also asserts the complementary boundary: once the started key has genuinely gone, a later completion does not recreate it, so a stalled set stays untracked rather than being resurrected in a misleading state.

## Behavior

A set whose batches are queued behind a throttled org can span much more than the TTL while still making steady progress.

| | Before | After |
|---|---|---|
| Started key | expires TTL after the first batch runs | extended by every completion |
| Batches hash | extended by every completion | unchanged |
| Long-running set | a later batch is treated as the first to start | tracking holds for as long as batches keep completing |

Treating a later batch as the first to start means re-marking the owning start or broadcast as started, which can race with the last batch marking it completed and leave it stuck in a started state.

The remaining exposure is a set that makes no progress at all for the whole TTL — an org whose outbox never drains, so its queue is never resumed. No TTL fixes that case; it needs the owning object's status to be reconciled against the tracker.

## Test plan

- `TestBatchTracker` covers the refresh of both keys, the not-first result afterwards, and the expired-key boundary
- Confirmed the new assertions fail against the previous script and pass with the change
- Full suite green locally, and CI green on the final head