### PR TITLE
Add an index of in-flight batch task sets and an endpoint to list them

### DIFF
--- a/cmd/mailroom/main.go
+++ b/cmd/mailroom/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/nyaruka/mailroom/v26/web/public"
 	_ "github.com/nyaruka/mailroom/v26/web/simulation"
 	_ "github.com/nyaruka/mailroom/v26/web/socket"
+	_ "github.com/nyaruka/mailroom/v26/web/task"
 	_ "github.com/nyaruka/mailroom/v26/web/ticket"
 )
 

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -44,6 +44,19 @@ type BatchTask struct {
 	TotalBatches   int        `json:"total_batches,omitempty"`
 }
 
+// RecordQueued records that a set of batch tasks has been queued, so that it's trackable as in-flight work before any
+// of its batches have run. Tracker errors are logged rather than escalated - the cost is just that the set won't be
+// listed as in-flight work.
+func RecordQueued(ctx context.Context, rt *runtime.Runtime, ownerUUID uuids.UUID, info *BatchInfo) {
+	if ownerUUID == "" {
+		return // shouldn't happen but better than all such sets sharing a tracker
+	}
+
+	if err := NewBatchTracker(ownerUUID).Queued(ctx, rt.VK, info); err != nil {
+		slog.Error("error recording batch tasks as queued", "error", err, "owner_uuid", ownerUUID)
+	}
+}
+
 // RecordStarted marks processing of this batch's set as started in its owner's tracker and returns whether this was
 // the first batch of the set to start. Tracker errors are logged rather than escalated - the cost is just that the
 // owner is never marked as started.
@@ -69,7 +82,7 @@ func (b *BatchTask) RecordComplete(ctx context.Context, rt *runtime.Runtime, tas
 		return false // shouldn't happen but better than all such batches sharing a tracker
 	}
 
-	completed, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID)
+	completed, err := NewBatchTracker(b.BatchOwnerUUID).Done(ctx, rt.VK, taskID, b.TotalBatches)
 	if err != nil {
 		slog.Error("error recording batch task completion", "error", err, "owner_uuid", b.BatchOwnerUUID)
 		return false

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -140,7 +140,6 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 	RecordQueued(ctx, rt, uuids.UUID(taskID), &BatchInfo{
 		Type:     TypePopulateGroupBatch,
 		OrgID:    oa.OrgID(),
-		OrgName:  oa.Org().Name(),
 		Label:    groupName,
 		Total:    len(batches),
 		QueuedOn: dates.Now(),

--- a/core/tasks/populate_group.go
+++ b/core/tasks/populate_group.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -130,6 +131,20 @@ func (t *PopulateGroup) Perform(ctx context.Context, rt *runtime.Runtime, oa *mo
 
 	// chunk contacts into batches and queue a task for each - batches are owned by this task, identified by its ID
 	batches := slices.Collect(slices.Chunk(recheckIDs, populateBatchSize))
+
+	var groupName string
+	if group := oa.GroupByID(t.GroupID); group != nil {
+		groupName = group.Name()
+	}
+
+	RecordQueued(ctx, rt, uuids.UUID(taskID), &BatchInfo{
+		Type:     TypePopulateGroupBatch,
+		OrgID:    oa.OrgID(),
+		OrgName:  oa.Org().Name(),
+		Label:    groupName,
+		Total:    len(batches),
+		QueuedOn: dates.Now(),
+	})
 
 	for _, batch := range batches {
 		task := &PopulateGroupBatch{

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -117,7 +117,6 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	RecordQueued(ctx, rt, uuids.UUID(bcast.UUID), &BatchInfo{
 		Type:     TypeSendBroadcastBatch,
 		OrgID:    bcast.OrgID,
-		OrgName:  oa.Org().Name(),
 		Total:    len(idBatches),
 		QueuedOn: dates.Now(),
 	})

--- a/core/tasks/send_broadcast.go
+++ b/core/tasks/send_broadcast.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -112,6 +113,15 @@ func createBroadcastBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 
 	// create tasks for batches of contacts
 	idBatches := slices.Collect(slices.Chunk(contactIDs, broadcastBatchSize))
+
+	RecordQueued(ctx, rt, uuids.UUID(bcast.UUID), &BatchInfo{
+		Type:     TypeSendBroadcastBatch,
+		OrgID:    bcast.OrgID,
+		OrgName:  oa.Org().Name(),
+		Total:    len(idBatches),
+		QueuedOn: dates.Now(),
+	})
+
 	for i, idBatch := range idBatches {
 		var createdBatch []models.ContactID
 		for _, id := range idBatch {

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/mailroom/v26/core/models"
@@ -116,6 +117,15 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 
 	// split the contact ids into batches to become batch tasks
 	idBatches := slices.Collect(slices.Chunk(contactIDs, FlowStartBatchSize))
+
+	RecordQueued(ctx, rt, start.UUID, &BatchInfo{
+		Type:     TypeStartFlowBatch,
+		OrgID:    start.OrgID,
+		OrgName:  oa.Org().Name(),
+		Label:    flow.Name(),
+		Total:    len(idBatches),
+		QueuedOn: dates.Now(),
+	})
 
 	for i, idBatch := range idBatches {
 		batchTask := &StartFlowBatch{

--- a/core/tasks/start_flow.go
+++ b/core/tasks/start_flow.go
@@ -121,7 +121,6 @@ func createFlowStartBatches(ctx context.Context, rt *runtime.Runtime, oa *models
 	RecordQueued(ctx, rt, start.UUID, &BatchInfo{
 		Type:     TypeStartFlowBatch,
 		OrgID:    start.OrgID,
-		OrgName:  oa.Org().Name(),
 		Label:    flow.Name(),
 		Total:    len(idBatches),
 		QueuedOn: dates.Now(),

--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -2,15 +2,22 @@ package tasks
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/mailroom/v26/core/models"
 )
 
 const (
 	batchTrackerKeyBase = "batch_task"
+
+	// sorted set of the owner UUIDs of sets which haven't finished, scored by when they last made progress
+	batchTrackerIndexKey = "batch_tasks"
 
 	// how long tracker keys survive without progress - refreshed on every completion, so this bounds the gap
 	// between batches of a set completing (which for a throttled org is queue wait) rather than how long the
@@ -18,22 +25,64 @@ const (
 	batchTrackerTTL = 24 * time.Hour
 )
 
-// BatchTracker tracks progress of a set of batch tasks split out from an owning task or object, using two Valkey keys:
-// a simple key marking that processing of the set has started, and a hash of the task IDs of completed batches. Because
-// completions are recorded as distinct hash fields, marking the same batch as done more than once has no effect, and
-// the completed count can't reach the total until all batches are really done. Both keys have their TTL refreshed as
-// batches complete, so a set only loses its tracking if it makes no progress at all for the length of the TTL.
+// BatchInfo describes a set of batch tasks. It's recorded when the set is queued so that the set can be displayed
+// without having to look up its owner.
+type BatchInfo struct {
+	Type     string       `json:"type"`
+	OrgID    models.OrgID `json:"org_id"`
+	OrgName  string       `json:"org_name"`
+	Label    string       `json:"label,omitempty"` // name of the owning asset where the set has one, e.g. a flow
+	Total    int          `json:"total"`
+	QueuedOn time.Time    `json:"queued_on"`
+}
+
+// BatchStatus is the progress of a set of batch tasks.
+type BatchStatus struct {
+	OwnerUUID uuids.UUID `json:"owner_uuid"`
+	Info      *BatchInfo `json:"info"`      // nil if the set's info has expired or was never recorded
+	Started   bool       `json:"started"`   // whether any of its batches has begun processing
+	Completed int        `json:"completed"` // how many of its batches have finished
+	LastOn    time.Time  `json:"last_on"`   // when it last made progress
+}
+
+// BatchTracker tracks progress of a set of batch tasks split out from an owning task or object, using three Valkey
+// keys: a simple key marking that processing of the set has started, a hash of the task IDs of completed batches, and
+// a key describing the set. Because completions are recorded as distinct hash fields, marking the same batch as done
+// more than once has no effect, and the completed count can't reach the total until all batches are really done. All
+// three keys have their TTL refreshed as batches complete, so a set only loses its tracking if it makes no progress
+// at all for the length of the TTL.
+//
+// Sets which haven't finished are also held in a single index, so that they can be listed without scanning the
+// keyspace - see GetBatchTasks.
 type BatchTracker struct {
+	ownerUUID  uuids.UUID
 	startedKey string
 	batchesKey string
+	infoKey    string
 }
 
 // NewBatchTracker creates a tracker for the batches owned by the object or task with the given UUID.
 func NewBatchTracker(ownerUUID uuids.UUID) *BatchTracker {
 	return &BatchTracker{
+		ownerUUID:  ownerUUID,
 		startedKey: fmt.Sprintf("%s:%s:started", batchTrackerKeyBase, ownerUUID),
 		batchesKey: fmt.Sprintf("%s:%s:batches", batchTrackerKeyBase, ownerUUID),
+		infoKey:    fmt.Sprintf("%s:%s:info", batchTrackerKeyBase, ownerUUID),
 	}
+}
+
+// Queued records that the set has been queued, making it visible as in-flight work before any of its batches run -
+// which for a throttled org can be a long time.
+func (t *BatchTracker) Queued(ctx context.Context, vk *valkey.Pool, info *BatchInfo) error {
+	vc := vk.Get()
+	defer vc.Close()
+
+	now := dates.Now()
+
+	_, err := trackerQueued.DoContext(ctx, vc, t.infoKey, batchTrackerIndexKey,
+		jsonx.MustMarshal(info), int(batchTrackerTTL/time.Second), now.Unix(), string(t.ownerUUID), cutoff(now),
+	)
+	return err
 }
 
 // Started records that processing of the set has started and returns whether this was the first batch to do so.
@@ -49,19 +98,119 @@ func (t *BatchTracker) Started(ctx context.Context, vk *valkey.Pool) (bool, erro
 	return reply != nil, nil // SET .. NX returns nil if key already existed
 }
 
-// Done records the batch with the given task ID as complete and returns the number of completed batches.
-func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID) (int, error) {
+// Done records the batch with the given task ID as complete and returns the number of completed batches. The total
+// number of batches in the set is passed so that a set which is finished can be dropped from the index.
+func (t *BatchTracker) Done(ctx context.Context, vk *valkey.Pool, taskID TaskID, total int) (int, error) {
 	vc := vk.Get()
 	defer vc.Close()
 
-	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, t.startedKey, string(taskID), int(batchTrackerTTL/time.Second)))
+	return valkey.Int(trackerDone.DoContext(ctx, vc, t.batchesKey, t.startedKey, t.infoKey, batchTrackerIndexKey,
+		string(taskID), int(batchTrackerTTL/time.Second), dates.Now().Unix(), string(t.ownerUUID), total,
+	))
 }
 
-// records a batch as complete and extends the lifetime of both keys - if the started key were allowed to expire while
-// batches were still being processed, a later batch would think it was the first to start
-var trackerDone = valkey.NewScript(2, `
+// records the set as queued and adds it to the index, trimming sets which are older than the TTL and so can no
+// longer have any state of their own
+var trackerQueued = valkey.NewScript(2, `
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+redis.call('ZADD', KEYS[2], ARGV[3], ARGV[4])
+redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', ARGV[5])
+`)
+
+// records a batch as complete and extends the lifetime of the set's other keys - if the started key were allowed to
+// expire while batches were still being processed, a later batch would think it was the first to start. The set is
+// rescored in the index so that it's ordered by when it last made progress, or dropped from it once it's finished.
+var trackerDone = valkey.NewScript(4, `
 redis.call('HSET', KEYS[1], ARGV[1], 1)
 redis.call('EXPIRE', KEYS[1], ARGV[2])
 redis.call('EXPIRE', KEYS[2], ARGV[2])
-return redis.call('HLEN', KEYS[1])
+redis.call('EXPIRE', KEYS[3], ARGV[2])
+
+local completed = redis.call('HLEN', KEYS[1])
+local total = tonumber(ARGV[5])
+
+if total > 0 and completed >= total then
+    redis.call('ZREM', KEYS[4], ARGV[4])
+else
+    redis.call('ZADD', KEYS[4], ARGV[3], ARGV[4])
+end
+
+return completed
 `)
+
+// GetBatchTasks returns the sets of batch tasks which haven't finished, least recently active first - so the sets
+// which have gone longest without making progress come first.
+func GetBatchTasks(ctx context.Context, vk *valkey.Pool, limit int) ([]*BatchStatus, error) {
+	vc := vk.Get()
+	defer vc.Close()
+
+	// sets which can no longer have any state of their own shouldn't still be listed as in-flight
+	if _, err := valkey.DoContext(vc, ctx, "ZREMRANGEBYSCORE", batchTrackerIndexKey, "-inf", cutoff(dates.Now())); err != nil {
+		return nil, fmt.Errorf("error trimming batch task index: %w", err)
+	}
+
+	entries, err := valkey.Values(valkey.DoContext(vc, ctx, "ZRANGE", batchTrackerIndexKey, 0, limit-1, "WITHSCORES"))
+	if err != nil {
+		return nil, fmt.Errorf("error reading batch task index: %w", err)
+	}
+
+	statuses := make([]*BatchStatus, 0, len(entries)/2)
+
+	for i := 0; i+1 < len(entries); i += 2 {
+		ownerUUID, err := valkey.String(entries[i], nil)
+		if err != nil {
+			return nil, fmt.Errorf("error reading batch task owner UUID: %w", err)
+		}
+		lastOn, err := valkey.Int64(entries[i+1], nil)
+		if err != nil {
+			return nil, fmt.Errorf("error reading batch task score: %w", err)
+		}
+
+		statuses = append(statuses, &BatchStatus{OwnerUUID: uuids.UUID(ownerUUID), LastOn: time.Unix(lastOn, 0).UTC()})
+	}
+
+	// fetch the state of every set in a single round trip
+	for _, s := range statuses {
+		t := NewBatchTracker(s.OwnerUUID)
+
+		vc.Send("GET", t.infoKey)
+		vc.Send("EXISTS", t.startedKey)
+		vc.Send("HLEN", t.batchesKey)
+	}
+	if err := vc.Flush(); err != nil {
+		return nil, fmt.Errorf("error requesting batch task states: %w", err)
+	}
+
+	for _, s := range statuses {
+		infoJSON, err := valkey.Bytes(valkey.ReceiveContext(vc, ctx))
+		if err != nil && err != valkey.ErrNil {
+			return nil, fmt.Errorf("error reading info for batch task %s: %w", s.OwnerUUID, err)
+		}
+		started, err := valkey.Bool(valkey.ReceiveContext(vc, ctx))
+		if err != nil {
+			return nil, fmt.Errorf("error reading started for batch task %s: %w", s.OwnerUUID, err)
+		}
+		completed, err := valkey.Int(valkey.ReceiveContext(vc, ctx))
+		if err != nil {
+			return nil, fmt.Errorf("error reading completed for batch task %s: %w", s.OwnerUUID, err)
+		}
+
+		if len(infoJSON) > 0 {
+			info := &BatchInfo{}
+			if err := json.Unmarshal(infoJSON, info); err != nil {
+				return nil, fmt.Errorf("error unmarshaling info for batch task %s: %w", s.OwnerUUID, err)
+			}
+			s.Info = info
+		}
+
+		s.Started = started
+		s.Completed = completed
+	}
+
+	return statuses, nil
+}
+
+// the index score below which a set has no state of its own left and so shouldn't still be listed
+func cutoff(now time.Time) int64 {
+	return now.Add(-batchTrackerTTL).Unix()
+}

--- a/core/tasks/tracker.go
+++ b/core/tasks/tracker.go
@@ -30,7 +30,6 @@ const (
 type BatchInfo struct {
 	Type     string       `json:"type"`
 	OrgID    models.OrgID `json:"org_id"`
-	OrgName  string       `json:"org_name"`
 	Label    string       `json:"label,omitempty"` // name of the owning asset where the set has one, e.g. a flow
 	Total    int          `json:"total"`
 	QueuedOn time.Time    `json:"queued_on"`

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -2,10 +2,13 @@ package tasks_test
 
 import (
 	"testing"
+	"time"
 
 	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
 	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,8 +18,12 @@ func TestBatchTracker(t *testing.T) {
 	vc := rt.VK.Get()
 	defer vc.Close()
 
+	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2025, 6, 12, 14, 12, 0, 0, time.UTC), time.Second))
+	defer dates.SetNowFunc(time.Now)
+
 	const startedKey = "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:started"
 	const batchesKey = "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:batches"
+	const infoKey = "batch_task:7de40d16-0286-4938-be6b-9974e12e1b0f:info"
 
 	ttlOf := func(key string) int {
 		ttl, err := valkey.Int(vc.Do("TTL", key))
@@ -25,6 +32,24 @@ func TestBatchTracker(t *testing.T) {
 	}
 
 	tracker := tasks.NewBatchTracker("7de40d16-0286-4938-be6b-9974e12e1b0f")
+
+	err := tracker.Queued(ctx, rt.VK, &tasks.BatchInfo{
+		Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Label: "Favorites", Total: 5, QueuedOn: dates.Now(),
+	})
+	assert.NoError(t, err)
+
+	assert.Greater(t, ttlOf(infoKey), 0)
+
+	// queued but not yet started, so listed with no progress
+	statuses, err := tasks.GetBatchTasks(ctx, rt.VK, 100)
+	assert.NoError(t, err)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, tasks.TypeStartFlowBatch, statuses[0].Info.Type)
+	assert.Equal(t, "TextIt", statuses[0].Info.OrgName)
+	assert.Equal(t, "Favorites", statuses[0].Info.Label)
+	assert.Equal(t, 5, statuses[0].Info.Total)
+	assert.False(t, statuses[0].Started)
+	assert.Equal(t, 0, statuses[0].Completed)
 
 	// first batch to start
 	first, err := tracker.Started(ctx, rt.VK)
@@ -39,36 +64,40 @@ func TestBatchTracker(t *testing.T) {
 	assert.False(t, first)
 
 	// first batch to complete
-	completed, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
+	completed, err := tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
 
 	assert.Greater(t, ttlOf(batchesKey), 0)
 
 	// completing the same batch again changes nothing
-	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000")
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, completed)
 
-	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000")
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0002-7000-8000-000000000000", 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, completed)
 
-	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000")
+	statuses, err = tasks.GetBatchTasks(ctx, rt.VK, 100)
+	assert.NoError(t, err)
+	require.Len(t, statuses, 1)
+	assert.True(t, statuses[0].Started)
+	assert.Equal(t, 2, statuses[0].Completed)
+
+	// simulate a set which has made no progress for a while by shortening the TTLs of its keys
+	vc.Do("EXPIRE", startedKey, 60)
+	vc.Do("EXPIRE", batchesKey, 60)
+	vc.Do("EXPIRE", infoKey, 60)
+
+	// completing another batch refreshes all three, so that a set only loses its tracking if it stalls completely
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0003-7000-8000-000000000000", 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, completed)
 
-	// simulate a set which has made no progress for a while by shortening the TTLs of both keys
-	vc.Do("EXPIRE", startedKey, 60)
-	vc.Do("EXPIRE", batchesKey, 60)
-
-	// completing another batch refreshes both, so that a set only loses its tracking if it stalls completely
-	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000")
-	assert.NoError(t, err)
-	assert.Equal(t, 4, completed)
-
 	assert.Greater(t, ttlOf(startedKey), 60)
 	assert.Greater(t, ttlOf(batchesKey), 60)
+	assert.Greater(t, ttlOf(infoKey), 60)
 
 	// so a later batch never thinks it's the first to start
 	first, err = tracker.Started(ctx, rt.VK)
@@ -78,11 +107,75 @@ func TestBatchTracker(t *testing.T) {
 	// but a set which stalls for longer than the TTL loses its tracking rather than having it resurrected
 	vc.Do("DEL", startedKey)
 
-	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000")
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0004-7000-8000-000000000000", 5)
 	assert.NoError(t, err)
-	assert.Equal(t, 5, completed)
+	assert.Equal(t, 4, completed)
 
 	exists, err := valkey.Int(vc.Do("EXISTS", startedKey))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exists)
+
+	// completing the last batch removes the set from the index
+	completed, err = tracker.Done(ctx, rt.VK, "01981fa0-0005-7000-8000-000000000000", 5)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, completed)
+
+	statuses, err = tasks.GetBatchTasks(ctx, rt.VK, 100)
+	assert.NoError(t, err)
+	assert.Len(t, statuses, 0)
+}
+
+func TestGetBatchTasks(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2025, 6, 12, 14, 12, 0, 0, time.UTC), time.Second))
+	defer dates.SetNowFunc(time.Now)
+
+	tracker1 := tasks.NewBatchTracker("11111111-0000-7000-8000-000000000000")
+	tracker2 := tasks.NewBatchTracker("22222222-0000-7000-8000-000000000000")
+	tracker3 := tasks.NewBatchTracker("33333333-0000-7000-8000-000000000000")
+
+	require.NoError(t, tracker1.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeSendBroadcastBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Total: 2, QueuedOn: dates.Now()}))
+	require.NoError(t, tracker2.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org2.ID, OrgName: "Nyaruka", Label: "Favorites", Total: 3, QueuedOn: dates.Now()}))
+	require.NoError(t, tracker3.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeImportContactBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Total: 4, QueuedOn: dates.Now()}))
+
+	// completing a batch of the first set rescores it to most recently active
+	_, err := tracker1.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 2)
+	require.NoError(t, err)
+
+	statuses, err := tasks.GetBatchTasks(ctx, rt.VK, 100)
+	assert.NoError(t, err)
+	require.Len(t, statuses, 3)
+
+	// least recently active first
+	assert.Equal(t, "22222222-0000-7000-8000-000000000000", string(statuses[0].OwnerUUID))
+	assert.Equal(t, "33333333-0000-7000-8000-000000000000", string(statuses[1].OwnerUUID))
+	assert.Equal(t, "11111111-0000-7000-8000-000000000000", string(statuses[2].OwnerUUID))
+	assert.Equal(t, 1, statuses[2].Completed)
+
+	// limit is respected
+	statuses, err = tasks.GetBatchTasks(ctx, rt.VK, 2)
+	assert.NoError(t, err)
+	require.Len(t, statuses, 2)
+	assert.Equal(t, "22222222-0000-7000-8000-000000000000", string(statuses[0].OwnerUUID))
+
+	// a set whose last activity is older than the TTL is trimmed from the index - its own keys have expired so
+	// there's nothing left to show for it
+	_, err = vc.Do("ZADD", "batch_tasks", time.Date(2025, 6, 10, 14, 12, 0, 0, time.UTC).Unix(), "44444444-0000-7000-8000-000000000000")
+	require.NoError(t, err)
+
+	statuses, err = tasks.GetBatchTasks(ctx, rt.VK, 100)
+	assert.NoError(t, err)
+	require.Len(t, statuses, 3)
+
+	// a set still in the index whose info key has expired is listed without info rather than dropped
+	vc.Do("DEL", "batch_task:22222222-0000-7000-8000-000000000000:info")
+
+	statuses, err = tasks.GetBatchTasks(ctx, rt.VK, 100)
+	assert.NoError(t, err)
+	require.Len(t, statuses, 3)
+	assert.Nil(t, statuses[0].Info)
+	assert.NotNil(t, statuses[1].Info)
 }

--- a/core/tasks/tracker_test.go
+++ b/core/tasks/tracker_test.go
@@ -34,7 +34,7 @@ func TestBatchTracker(t *testing.T) {
 	tracker := tasks.NewBatchTracker("7de40d16-0286-4938-be6b-9974e12e1b0f")
 
 	err := tracker.Queued(ctx, rt.VK, &tasks.BatchInfo{
-		Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Label: "Favorites", Total: 5, QueuedOn: dates.Now(),
+		Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org1.ID, Label: "Favorites", Total: 5, QueuedOn: dates.Now(),
 	})
 	assert.NoError(t, err)
 
@@ -45,7 +45,6 @@ func TestBatchTracker(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, statuses, 1)
 	assert.Equal(t, tasks.TypeStartFlowBatch, statuses[0].Info.Type)
-	assert.Equal(t, "TextIt", statuses[0].Info.OrgName)
 	assert.Equal(t, "Favorites", statuses[0].Info.Label)
 	assert.Equal(t, 5, statuses[0].Info.Total)
 	assert.False(t, statuses[0].Started)
@@ -137,9 +136,9 @@ func TestGetBatchTasks(t *testing.T) {
 	tracker2 := tasks.NewBatchTracker("22222222-0000-7000-8000-000000000000")
 	tracker3 := tasks.NewBatchTracker("33333333-0000-7000-8000-000000000000")
 
-	require.NoError(t, tracker1.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeSendBroadcastBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Total: 2, QueuedOn: dates.Now()}))
-	require.NoError(t, tracker2.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org2.ID, OrgName: "Nyaruka", Label: "Favorites", Total: 3, QueuedOn: dates.Now()}))
-	require.NoError(t, tracker3.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeImportContactBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Total: 4, QueuedOn: dates.Now()}))
+	require.NoError(t, tracker1.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeSendBroadcastBatch, OrgID: testdb.Org1.ID, Total: 2, QueuedOn: dates.Now()}))
+	require.NoError(t, tracker2.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org2.ID, Label: "Favorites", Total: 3, QueuedOn: dates.Now()}))
+	require.NoError(t, tracker3.Queued(ctx, rt.VK, &tasks.BatchInfo{Type: tasks.TypeImportContactBatch, OrgID: testdb.Org1.ID, Total: 4, QueuedOn: dates.Now()}))
 
 	// completing a batch of the first set rescores it to most recently active
 	_, err := tracker1.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 2)

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -3,6 +3,7 @@ package contact
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/nyaruka/gocommon/dates"
@@ -43,15 +44,18 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
 	ownerUUID := uuids.NewV7()
 
-	oa, err := models.GetOrgAssets(ctx, rt, r.OrgID)
-	if err != nil {
-		return nil, 0, fmt.Errorf("error loading org assets: %w", err)
+	// tracking is best-effort, so an error getting the org name for it shouldn't fail the import
+	var orgName string
+	if oa, err := models.GetOrgAssets(ctx, rt, r.OrgID); err != nil {
+		slog.Error("error loading org assets for batch tracking", "error", err, "org_id", r.OrgID)
+	} else {
+		orgName = oa.Org().Name()
 	}
 
 	tasks.RecordQueued(ctx, rt, ownerUUID, &tasks.BatchInfo{
 		Type:     tasks.TypeImportContactBatch,
 		OrgID:    r.OrgID,
-		OrgName:  oa.Org().Name(),
+		OrgName:  orgName,
 		Total:    len(imp.BatchIDs),
 		QueuedOn: dates.Now(),
 	})

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/mailroom/v26/core/models"
 	"github.com/nyaruka/mailroom/v26/core/tasks"
@@ -41,6 +42,19 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
 	ownerUUID := uuids.NewV7()
+
+	oa, err := models.GetOrgAssets(ctx, rt, r.OrgID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error loading org assets: %w", err)
+	}
+
+	tasks.RecordQueued(ctx, rt, ownerUUID, &tasks.BatchInfo{
+		Type:     tasks.TypeImportContactBatch,
+		OrgID:    r.OrgID,
+		OrgName:  oa.Org().Name(),
+		Total:    len(imp.BatchIDs),
+		QueuedOn: dates.Now(),
+	})
 
 	// create tasks for all batches
 	for _, bID := range imp.BatchIDs {

--- a/web/contact/import.go
+++ b/web/contact/import.go
@@ -3,7 +3,6 @@ package contact
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"github.com/nyaruka/gocommon/dates"
@@ -44,18 +43,9 @@ func handleImport(ctx context.Context, rt *runtime.Runtime, r *importRequest) (a
 	// generate a UUID to own this set of batches since unlike other batch tasks, these have no parent task
 	ownerUUID := uuids.NewV7()
 
-	// tracking is best-effort, so an error getting the org name for it shouldn't fail the import
-	var orgName string
-	if oa, err := models.GetOrgAssets(ctx, rt, r.OrgID); err != nil {
-		slog.Error("error loading org assets for batch tracking", "error", err, "org_id", r.OrgID)
-	} else {
-		orgName = oa.Org().Name()
-	}
-
 	tasks.RecordQueued(ctx, rt, ownerUUID, &tasks.BatchInfo{
 		Type:     tasks.TypeImportContactBatch,
 		OrgID:    r.OrgID,
-		OrgName:  orgName,
 		Total:    len(imp.BatchIDs),
 		QueuedOn: dates.Now(),
 	})

--- a/web/task/base_test.go
+++ b/web/task/base_test.go
@@ -21,10 +21,10 @@ func TestBatches(t *testing.T) {
 	tracker2 := tasks.NewBatchTracker("22222222-0000-7000-8000-000000000000")
 
 	require.NoError(t, tracker1.Queued(ctx, rt.VK, &tasks.BatchInfo{
-		Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Label: "Favorites", Total: 3, QueuedOn: dates.Now(),
+		Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org1.ID, Label: "Favorites", Total: 3, QueuedOn: dates.Now(),
 	}))
 	require.NoError(t, tracker2.Queued(ctx, rt.VK, &tasks.BatchInfo{
-		Type: tasks.TypeImportContactBatch, OrgID: testdb.Org2.ID, OrgName: "Nyaruka", Total: 2, QueuedOn: dates.Now(),
+		Type: tasks.TypeImportContactBatch, OrgID: testdb.Org2.ID, Total: 2, QueuedOn: dates.Now(),
 	}))
 
 	_, err := tracker2.Started(ctx, rt.VK)

--- a/web/task/base_test.go
+++ b/web/task/base_test.go
@@ -1,0 +1,36 @@
+package task_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/v26/core/tasks"
+	"github.com/nyaruka/mailroom/v26/testsuite"
+	"github.com/nyaruka/mailroom/v26/testsuite/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatches(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2025, 6, 12, 14, 12, 0, 0, time.UTC), time.Second))
+	defer dates.SetNowFunc(time.Now)
+
+	tracker1 := tasks.NewBatchTracker("11111111-0000-7000-8000-000000000000")
+	tracker2 := tasks.NewBatchTracker("22222222-0000-7000-8000-000000000000")
+
+	require.NoError(t, tracker1.Queued(ctx, rt.VK, &tasks.BatchInfo{
+		Type: tasks.TypeStartFlowBatch, OrgID: testdb.Org1.ID, OrgName: "TextIt", Label: "Favorites", Total: 3, QueuedOn: dates.Now(),
+	}))
+	require.NoError(t, tracker2.Queued(ctx, rt.VK, &tasks.BatchInfo{
+		Type: tasks.TypeImportContactBatch, OrgID: testdb.Org2.ID, OrgName: "Nyaruka", Total: 2, QueuedOn: dates.Now(),
+	}))
+
+	_, err := tracker2.Started(ctx, rt.VK)
+	require.NoError(t, err)
+	_, err = tracker2.Done(ctx, rt.VK, "01981fa0-0001-7000-8000-000000000000", 2)
+	require.NoError(t, err)
+
+	testsuite.RunWebTests(t, rt, "testdata/batches.json")
+}

--- a/web/task/batches.go
+++ b/web/task/batches.go
@@ -23,7 +23,7 @@ const maxBatchSets = 100
 //	  "sets": [
 //	    {
 //	      "owner_uuid": "0199bcb8-4e12-7e7f-a4d2-fabbf9d69dbb",
-//	      "info": {"type": "start_flow_batch", "org_id": 1, "org_name": "TextIt", "label": "Favorites", "total": 40, "queued_on": "2025-06-12T14:12:00Z"},
+//	      "info": {"type": "start_flow_batch", "org_id": 1, "label": "Favorites", "total": 40, "queued_on": "2025-06-12T14:12:00Z"},
 //	      "started": true,
 //	      "completed": 12,
 //	      "last_on": "2025-06-12T15:30:45Z"

--- a/web/task/batches.go
+++ b/web/task/batches.go
@@ -1,0 +1,40 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/nyaruka/mailroom/v26/core/tasks"
+	"github.com/nyaruka/mailroom/v26/runtime"
+	"github.com/nyaruka/mailroom/v26/web"
+)
+
+func init() {
+	web.InternalRoute(http.MethodGet, "/task/batches", web.MarshaledResponse(handleBatches))
+}
+
+const maxBatchSets = 100
+
+// Returns the sets of batch tasks which haven't finished, across all orgs, least recently active first. Each set is
+// the batches split out from a single flow start, broadcast, contact import or group population.
+//
+//	{
+//	  "sets": [
+//	    {
+//	      "owner_uuid": "0199bcb8-4e12-7e7f-a4d2-fabbf9d69dbb",
+//	      "info": {"type": "start_flow_batch", "org_id": 1, "org_name": "TextIt", "label": "Favorites", "total": 40, "queued_on": "2025-06-12T14:12:00Z"},
+//	      "started": true,
+//	      "completed": 12,
+//	      "last_on": "2025-06-12T15:30:45Z"
+//	    }
+//	  ]
+//	}
+func handleBatches(ctx context.Context, rt *runtime.Runtime, r *http.Request) (any, int, error) {
+	sets, err := tasks.GetBatchTasks(ctx, rt.VK, maxBatchSets)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error getting batch task sets: %w", err)
+	}
+
+	return map[string]any{"sets": sets}, http.StatusOK, nil
+}

--- a/web/task/testdata/batches.json
+++ b/web/task/testdata/batches.json
@@ -20,7 +20,6 @@
                     "info": {
                         "type": "start_flow_batch",
                         "org_id": 1,
-                        "org_name": "TextIt",
                         "label": "Favorites",
                         "total": 3,
                         "queued_on": "2025-06-12T14:12:00Z"
@@ -34,7 +33,6 @@
                     "info": {
                         "type": "import_contact_batch",
                         "org_id": 2,
-                        "org_name": "Nyaruka",
                         "total": 2,
                         "queued_on": "2025-06-12T14:12:02Z"
                     },

--- a/web/task/testdata/batches.json
+++ b/web/task/testdata/batches.json
@@ -1,0 +1,48 @@
+[
+    {
+        "label": "illegal method",
+        "method": "POST",
+        "path": "/mi/task/batches",
+        "status": 405,
+        "response": {
+            "error": "illegal method: POST"
+        }
+    },
+    {
+        "label": "sets listed least recently active first",
+        "method": "GET",
+        "path": "/mi/task/batches",
+        "status": 200,
+        "response": {
+            "sets": [
+                {
+                    "owner_uuid": "11111111-0000-7000-8000-000000000000",
+                    "info": {
+                        "type": "start_flow_batch",
+                        "org_id": 1,
+                        "org_name": "TextIt",
+                        "label": "Favorites",
+                        "total": 3,
+                        "queued_on": "2025-06-12T14:12:00Z"
+                    },
+                    "started": false,
+                    "completed": 0,
+                    "last_on": "2025-06-12T14:12:01Z"
+                },
+                {
+                    "owner_uuid": "22222222-0000-7000-8000-000000000000",
+                    "info": {
+                        "type": "import_contact_batch",
+                        "org_id": 2,
+                        "org_name": "Nyaruka",
+                        "total": 2,
+                        "queued_on": "2025-06-12T14:12:02Z"
+                    },
+                    "started": true,
+                    "completed": 1,
+                    "last_on": "2025-06-12T14:12:04Z"
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
## Summary

Sets of batch tasks (the batches split out from a flow start, broadcast, contact import or group population) were individually tracked in Valkey but unlistable - the keys were only reachable if you already knew the owner UUID. This records each set's description at queue time and holds all in-flight sets in a single index, exposed by a new internal endpoint, so long running batch work can be monitored globally.

## Changes

- `core/tasks/tracker.go`
  - new `Queued()` records a `BatchInfo` (type, org ID, label, total batches, queue time) under `batch_task:<uuid>:info` and adds the set to a `batch_tasks` sorted set scored by when it last made progress
  - `Done()` now also rescores the set in the index - or removes it when the last batch completes - and extends the info key's TTL along with the other two
  - new `GetBatchTasks()` returns in-flight sets, least recently active first: one `ZRANGE` plus a single pipelined round trip of `GET`/`EXISTS`/`HLEN` per set, no keyspace scanning; entries older than the TTL are trimmed since their underlying keys have expired
- `core/tasks/base.go` — new `RecordQueued()` helper; tracker errors are logged, not escalated
- Fan-out sites (`start_flow.go`, `send_broadcast.go`, `populate_group.go`, `web/contact/import.go`) record their set at queue time - flow starts are labeled with the flow name, group populations with the group name
- `web/task/batches.go` — new `GET /mi/task/batches` internal endpoint returning up to 100 in-flight sets

The info deliberately carries only the org ID, not the org name - a consumer can resolve names itself, and recording them would have meant loading org assets at fan-out purely to label best-effort tracking.

## Behavior

```
GET /mi/task/batches

{
  "sets": [
    {
      "owner_uuid": "0199bcb8-4e12-7e7f-a4d2-fabbf9d69dbb",
      "info": {"type": "start_flow_batch", "org_id": 1, "label": "Favorites", "total": 40, "queued_on": "2025-06-12T14:12:00Z"},
      "started": true,
      "completed": 12,
      "last_on": "2025-06-12T15:30:45Z"
    }
  ]
}
```

- Sets are ordered least recently active first, so stalled work tops the list
- A set queued behind a throttled org that hasn't run any batch yet appears with `started: false, completed: 0` - previously such sets had no tracking at all
- A set still indexed but whose info key has expired is returned with `info: null` rather than dropped
- Completion of the last batch removes the set immediately; sets that stall for longer than the tracker TTL age out of the index

## Test plan

- `TestBatchTracker` reworked around the new lifecycle: queued → started → progress → completion removes from index, plus the existing TTL refresh and expiry-boundary assertions
- New `TestGetBatchTasks` covers ordering, rescoring on progress, the result limit, trimming of aged entries and expired-info handling
- New web test for `/mi/task/batches` including response shape
- Full suite green locally, CI green on the final head