### PR TITLE
Restructure mrindex command into mrelastic and add contacts prune mode

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,9 +8,9 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: mrindex
-    main: ./cmd/mrindex/main.go
-    binary: mrindex
+  - id: mrelastic
+    main: ./cmd/mrelastic/main.go
+    binary: mrelastic
     goos:
       - linux
     goarch:

--- a/cmd/elastic.go
+++ b/cmd/elastic.go
@@ -20,9 +20,9 @@ import (
 
 const indexBatchSize = 500
 
-// Index is the entry point for the mrindex command which re-indexes all contacts or messages. Configuration is
+// Elastic is the entry point for the mrelastic command which manages the search indexes. Configuration is
 // loaded on top of the given defaults, e.g. runtime.NewDefaultConfig().
-func Index(defaults *runtime.Config) error {
+func Elastic(defaults *runtime.Config) error {
 	cfg, err := runtime.LoadConfig(defaults)
 	if err != nil {
 		return err
@@ -30,6 +30,18 @@ func Index(defaults *runtime.Config) error {
 
 	// only output ERROR logs
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	// parse verb and target from args
+	flags := flag.NewFlagSet("mrelastic", flag.ExitOnError)
+	startUUID := flags.String("start-uuid", "", "UUID to start from (index messages only, works backwards from here)")
+	del := flags.Bool("delete", false, "delete orphaned documents instead of just reporting them (prune contacts only)")
+	flags.Parse(os.Args[1:])
+
+	verb, target := flags.Arg(0), flags.Arg(1)
+	valid := (verb == "index" && (target == "contacts" || target == "messages")) || (verb == "prune" && target == "contacts")
+	if !valid {
+		return fmt.Errorf("usage: mrelastic [flags] <verb> <target> where valid combinations are 'index contacts', 'index messages' and 'prune contacts'")
+	}
 
 	rt, err := runtime.NewRuntime(cfg)
 	if err != nil {
@@ -43,23 +55,31 @@ func Index(defaults *runtime.Config) error {
 
 	models.InitCache(rt)
 
-	// parse mode from args
-	flags := flag.NewFlagSet("mrindex", flag.ExitOnError)
-	startUUID := flags.String("start-uuid", "", "UUID to start from (messages mode only, works backwards from here)")
-	flags.Parse(os.Args[1:])
-
-	mode := flags.Arg(0)
-	if mode != "contacts" && mode != "messages" {
-		return fmt.Errorf("usage: mrindex [--start-uuid UUID] <contacts|messages>")
-	}
-
 	ctx := context.TODO()
 
-	switch mode {
-	case "contacts":
-		return indexAllContacts(ctx, rt)
-	case "messages":
+	switch verb {
+	case "index":
+		if target == "contacts" {
+			return indexAllContacts(ctx, rt)
+		}
 		return indexAllMessages(ctx, rt, *startUUID)
+	case "prune":
+		return pruneAllContacts(ctx, rt, *del)
+	}
+	return nil
+}
+
+func pruneAllContacts(ctx context.Context, rt *runtime.Runtime, del bool) error {
+	counts, err := search.PruneContacts(ctx, rt, del, func(c search.PruneCounts) {
+		fmt.Printf(" > scanned %d docs (%d orphans found, %d deleted)\n", c.Scanned, c.Orphaned, c.Deleted)
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Completed prune (%d docs scanned, %d orphans found, %d deleted)\n", counts.Scanned, counts.Orphaned, counts.Deleted)
+	if !del && counts.Orphaned > 0 {
+		fmt.Println("Re-run with --delete to delete orphaned documents.")
 	}
 	return nil
 }

--- a/cmd/mrelastic/main.go
+++ b/cmd/mrelastic/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	cmd.Run(cmd.Index(runtime.NewDefaultConfig()))
+	cmd.Run(cmd.Elastic(runtime.NewDefaultConfig()))
 }

--- a/core/models/contact.go
+++ b/core/models/contact.go
@@ -373,6 +373,29 @@ func GetContactIDsFromUUIDs(ctx context.Context, db Queryer, orgID OrgID, uuids 
 	return ids, nil
 }
 
+// GetActiveContactUUIDs returns which of the given contact UUIDs belong to active (i.e. not released) contacts.
+func GetActiveContactUUIDs(ctx context.Context, db Queryer, uuids []core.ContactUUID) ([]core.ContactUUID, error) {
+	if len(uuids) == 0 {
+		return nil, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT uuid FROM contacts_contact WHERE uuid = ANY($1) AND is_active = TRUE`, pq.Array(uuids))
+	if err != nil {
+		return nil, fmt.Errorf("error selecting contact uuids: %w", err)
+	}
+	defer rows.Close()
+
+	existing := make([]core.ContactUUID, 0, len(uuids))
+	for rows.Next() {
+		var uuid core.ContactUUID
+		if err := rows.Scan(&uuid); err != nil {
+			return nil, fmt.Errorf("error scanning contact uuid: %w", err)
+		}
+		existing = append(existing, uuid)
+	}
+	return existing, rows.Err()
+}
+
 const sqlSelectContactExists = `
 SELECT EXISTS(
 	SELECT 1 FROM contacts_contact

--- a/core/models/contact_test.go
+++ b/core/models/contact_test.go
@@ -405,6 +405,25 @@ func TestGetContactIDsFromReferences(t *testing.T) {
 	assert.ElementsMatch(t, []models.ContactID{testdb.Ann.ID, testdb.Bob.ID}, ids)
 }
 
+func TestGetActiveContactUUIDs(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	rt.DB.MustExec(`UPDATE contacts_contact SET is_active = FALSE WHERE id = $1`, testdb.Bob.ID)
+
+	uuids, err := models.GetActiveContactUUIDs(ctx, rt.DB, []core.ContactUUID{
+		testdb.Ann.UUID,
+		testdb.Bob.UUID,                        // released
+		testdb.Org2Contact.UUID,                // other org but still active
+		"e0c261e1-c95f-4a04-92c6-e6d13ea16d1a", // no such contact
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []core.ContactUUID{testdb.Ann.UUID, testdb.Org2Contact.UUID}, uuids)
+
+	uuids, err = models.GetActiveContactUUIDs(ctx, rt.DB, nil)
+	require.NoError(t, err)
+	assert.Empty(t, uuids)
+}
+
 func TestContactExists(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -182,6 +182,10 @@ func DeindexContactsByUUID(ctx context.Context, rt *runtime.Runtime, orgID model
 // deindexContactDocs bulk-deletes the given contact docs from Elastic. The index uses custom routing so each delete
 // must be routed to the org of the doc it's deleting.
 func deindexContactDocs(ctx context.Context, rt *runtime.Runtime, contactUUIDs []core.ContactUUID, routing func(core.ContactUUID) string) (int, error) {
+	if len(contactUUIDs) == 0 {
+		return 0, nil // ES rejects an empty bulk request
+	}
+
 	cmds := &bytes.Buffer{}
 	for _, uuid := range contactUUIDs {
 		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": string(uuid), "routing": routing(uuid)}}))

--- a/core/search/contacts.go
+++ b/core/search/contacts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v9/typedapi/types/enums/operationtype"
@@ -173,18 +174,21 @@ func IndexContacts(ctx context.Context, rt *runtime.Runtime, oa *models.OrgAsset
 
 // DeindexContactsByUUID de-indexes the contacts with the given UUIDs from Elastic
 func DeindexContactsByUUID(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID, contactUUIDs []core.ContactUUID) (int, error) {
-	ids := make([]string, len(contactUUIDs))
-	for i, uuid := range contactUUIDs {
-		ids[i] = string(uuid)
-	}
+	routing := orgID.String()
 
+	return deindexContactDocs(ctx, rt, contactUUIDs, func(core.ContactUUID) string { return routing })
+}
+
+// deindexContactDocs bulk-deletes the given contact docs from Elastic. The index uses custom routing so each delete
+// must be routed to the org of the doc it's deleting.
+func deindexContactDocs(ctx context.Context, rt *runtime.Runtime, contactUUIDs []core.ContactUUID, routing func(core.ContactUUID) string) (int, error) {
 	cmds := &bytes.Buffer{}
-	for _, id := range ids {
-		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": id}}))
+	for _, uuid := range contactUUIDs {
+		cmds.Write(jsonx.MustMarshal(map[string]any{"delete": map[string]any{"_id": string(uuid), "routing": routing(uuid)}}))
 		cmds.WriteString("\n")
 	}
 
-	resp, err := rt.ES.Client.Bulk().Index(rt.Config.ElasticContactsIndex).Routing(orgID.String()).Raw(bytes.NewReader(cmds.Bytes())).Do(ctx)
+	resp, err := rt.ES.Client.Bulk().Index(rt.Config.ElasticContactsIndex).Raw(bytes.NewReader(cmds.Bytes())).Do(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("error deindexing deleted contacts from elastic: %w", err)
 	}
@@ -197,6 +201,120 @@ func DeindexContactsByUUID(ctx context.Context, rt *runtime.Runtime, orgID model
 	}
 
 	return deleted, nil
+}
+
+const pruneBatchSize = 10_000
+
+// PruneCounts are the running totals reported by PruneContacts.
+type PruneCounts struct {
+	Scanned  int
+	Orphaned int
+	Deleted  int
+}
+
+// PruneContacts scans the entire contacts index for orphaned documents - docs whose contact no longer exists in the
+// database or has been released - and optionally deletes them. If progress is non-nil it is called with the running
+// totals after each scanned batch.
+func PruneContacts(ctx context.Context, rt *runtime.Runtime, del bool, progress func(PruneCounts)) (PruneCounts, error) {
+	counts := PruneCounts{}
+
+	pit, err := rt.ES.Client.OpenPointInTime(rt.Config.ElasticContactsIndex).KeepAlive("1m").Do(ctx)
+	if err != nil {
+		return counts, fmt.Errorf("error creating ES point-in-time: %w", err)
+	}
+	defer func() {
+		cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := rt.ES.Client.ClosePointInTime().Id(pit.Id).Do(cctx); err != nil {
+			slog.Error("error closing ES point-in-time", "error", err)
+		}
+	}()
+
+	src := map[string]any{
+		"_source":          []string{"org_id"},
+		"sort":             []any{map[string]any{"_shard_doc": "asc"}},
+		"pit":              map[string]any{"id": pit.Id, "keep_alive": "1m"},
+		"size":             pruneBatchSize,
+		"track_total_hits": false,
+	}
+
+	for {
+		results, err := rt.ES.Client.Search().Raw(bytes.NewReader(jsonx.MustMarshal(src))).Do(ctx)
+		if err != nil {
+			return counts, fmt.Errorf("error searching ES index: %w", err)
+		}
+
+		if len(results.Hits.Hits) == 0 {
+			break
+		}
+
+		uuids := make([]core.ContactUUID, len(results.Hits.Hits))
+		routings := make(map[core.ContactUUID]string, len(results.Hits.Hits))
+		for i, hit := range results.Hits.Hits {
+			var doc struct {
+				OrgID models.OrgID `json:"org_id"`
+			}
+			if err := json.Unmarshal(hit.Source_, &doc); err != nil {
+				return counts, fmt.Errorf("error unmarshalling contact doc %s: %w", *hit.Id_, err)
+			}
+			uuids[i] = core.ContactUUID(*hit.Id_)
+			routings[uuids[i]] = doc.OrgID.String()
+		}
+
+		counts.Scanned += len(uuids)
+
+		orphans, err := getOrphanedUUIDs(ctx, rt, uuids)
+		if err != nil {
+			return counts, err
+		}
+
+		counts.Orphaned += len(orphans)
+
+		if del && len(orphans) > 0 {
+			// re-check against the database immediately before deleting
+			orphans, err = getOrphanedUUIDs(ctx, rt, orphans)
+			if err != nil {
+				return counts, err
+			}
+
+			deleted, err := deindexContactDocs(ctx, rt, orphans, func(uuid core.ContactUUID) string { return routings[uuid] })
+			if err != nil {
+				return counts, err
+			}
+
+			counts.Deleted += deleted
+		}
+
+		if progress != nil {
+			progress(counts)
+		}
+
+		lastHit := results.Hits.Hits[len(results.Hits.Hits)-1]
+		src["search_after"] = lastHit.Sort
+	}
+
+	return counts, nil
+}
+
+// getOrphanedUUIDs returns which of the given contact UUIDs don't belong to an active contact in the database
+func getOrphanedUUIDs(ctx context.Context, rt *runtime.Runtime, uuids []core.ContactUUID) ([]core.ContactUUID, error) {
+	existing, err := models.GetActiveContactUUIDs(ctx, rt.DB, uuids)
+	if err != nil {
+		return nil, fmt.Errorf("error checking contact UUIDs against database: %w", err)
+	}
+
+	existingSet := make(map[core.ContactUUID]bool, len(existing))
+	for _, uuid := range existing {
+		existingSet[uuid] = true
+	}
+
+	orphans := make([]core.ContactUUID, 0, len(uuids)-len(existing))
+	for _, uuid := range uuids {
+		if !existingSet[uuid] {
+			orphans = append(orphans, uuid)
+		}
+	}
+	return orphans, nil
 }
 
 // DeindexContactsByOrg de-indexes all contacts in the given org from Elastic

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -130,8 +130,13 @@ func TestDeindexContacts(t *testing.T) {
 	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
 	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
 
+	// deindexing an empty set of UUIDs is a noop
+	deindexedByUUID, err := search.DeindexContactsByUUID(ctx, rt, testdb.Org1.ID, []core.ContactUUID{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, deindexedByUUID)
+
 	// DeindexContactsByUUID operates on the v3 index
-	deindexedByUUID, err := search.DeindexContactsByUUID(ctx, rt, testdb.Org1.ID, []core.ContactUUID{testdb.Bob.UUID, testdb.Cat.UUID})
+	deindexedByUUID, err = search.DeindexContactsByUUID(ctx, rt, testdb.Org1.ID, []core.ContactUUID{testdb.Bob.UUID, testdb.Cat.UUID})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, deindexedByUUID)
 

--- a/core/search/contacts_test.go
+++ b/core/search/contacts_test.go
@@ -164,6 +164,61 @@ func TestDeindexContacts(t *testing.T) {
 	assert.Equal(t, 0, deindexed)
 }
 
+func TestPruneContacts(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	testsuite.IndexContacts(t, rt)
+
+	refresh := func() {
+		_, err := rt.ES.Client.Indices.Refresh().Index(rt.Config.ElasticContactsIndex).Do(ctx)
+		require.NoError(t, err)
+	}
+
+	// release Bob in the database without deindexing him
+	rt.DB.MustExec(`UPDATE contacts_contact SET is_active = FALSE WHERE id = $1`, testdb.Bob.ID)
+
+	// and index a doc for a contact which doesn't exist in the database at all
+	fakeUUID := core.ContactUUID("826a1421-2d51-45ca-a5a5-b26783d49e2c")
+	rt.ES.Writer.Queue(&elastic.Document{
+		Index:   rt.Config.ElasticContactsIndex,
+		ID:      string(fakeUUID),
+		Routing: testdb.Org2.ID.String(),
+		Body:    jsonx.MustMarshal(map[string]any{"id": 123456789, "org_id": testdb.Org2.ID}),
+	})
+	rt.ES.Writer.Flush()
+	refresh()
+
+	// default is report only.. no docs are deleted
+	counts, err := search.PruneContacts(ctx, rt, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, search.PruneCounts{Scanned: 246, Orphaned: 2, Deleted: 0}, counts)
+
+	refresh()
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 124)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 122)
+
+	// with delete flag, orphaned docs are deleted
+	var progress []search.PruneCounts
+	counts, err = search.PruneContacts(ctx, rt, true, func(c search.PruneCounts) { progress = append(progress, c) })
+	require.NoError(t, err)
+	assert.Equal(t, search.PruneCounts{Scanned: 246, Orphaned: 2, Deleted: 2}, counts)
+	assert.Equal(t, []search.PruneCounts{{Scanned: 246, Orphaned: 2, Deleted: 2}}, progress)
+
+	refresh()
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org1.ID), 123)
+	assertSearchCountV2(t, rt, elastic.Term("org_id", testdb.Org2.ID), 121)
+
+	// Bob's doc and the fake doc are gone, other contacts are untouched
+	assertSearchCountV2(t, rt, elastic.Ids(string(testdb.Bob.UUID)), 0)
+	assertSearchCountV2(t, rt, elastic.Ids(string(fakeUUID)), 0)
+	assertSearchCountV2(t, rt, elastic.Ids(string(testdb.Ann.UUID)), 1)
+
+	// re-running finds nothing to prune
+	counts, err = search.PruneContacts(ctx, rt, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, search.PruneCounts{Scanned: 244, Orphaned: 0, Deleted: 0}, counts)
+}
+
 func assertSearchCountV2(t *testing.T, rt *runtime.Runtime, query elastic.Query, expected int) {
 	src := map[string]any{"query": query}
 


### PR DESCRIPTION
## Summary

Replaces the `mrindex` command with a new `mrelastic` command with a `<verb> <target>` CLI, and adds a new mode to prune orphaned documents from the contacts index.

## Changes

- **Command rename**: `cmd/mrindex` → `cmd/mrelastic` (`cmd/index.go` → `cmd/elastic.go`, entry point `cmd.Index` → `cmd.Elastic`), with the goreleaser build updated to match.
- **CLI**: valid invocations are `mrelastic index contacts`, `mrelastic index messages` (keeps `--start-uuid`) and `mrelastic prune contacts`. Anything else exits with a usage error — including `prune messages`, since old messages are cleaned up by dropping whole monthly indices rather than by DB existence checks.
- **New `search.PruneContacts`**: scans the entire contacts index via a point-in-time and `search_after` (sorted by `_shard_doc`, `_source` limited to `org_id`, batches of 10,000), checks each batch against the database for contacts that no longer exist or have been released, and reports the orphans. With `--delete` it re-checks each orphan batch against the database immediately before bulk-deleting, with each delete routed by the doc's `org_id` since the index uses custom routing.
- **`search.DeindexContactsByUUID`** is now a thin wrapper around a generalized bulk-delete helper that supports per-doc routing. The helper short-circuits on an empty doc set, since Elasticsearch rejects an empty bulk request — this also protects the existing deindex web endpoint, which could previously pass an empty UUID list through to Elastic.
- **New `models.GetActiveContactUUIDs`**: returns which of a set of contact UUIDs belong to active contacts.

## Behavior examples

| Before | After |
|---|---|
| `mrindex contacts` | `mrelastic index contacts` |
| `mrindex --start-uuid <uuid> messages` | `mrelastic --start-uuid <uuid> index messages` |
| n/a | `mrelastic prune contacts` (report only) |
| n/a | `mrelastic --delete prune contacts` |

Prune output:

```
 > scanned 246 docs (2 orphans found, 0 deleted)
Completed prune (246 docs scanned, 2 orphans found, 0 deleted)
Re-run with --delete to delete orphaned documents.
```

## Test plan

- [x] `TestPruneContacts`: indexes all test-org contacts, releases one contact and plants a doc for a nonexistent contact without deindexing, then verifies report-only mode deletes nothing, delete mode removes exactly the orphans (including correct cross-org routing), and a re-run finds nothing to prune
- [x] `TestGetActiveContactUUIDs` covers released, other-org and nonexistent UUIDs
- [x] `TestDeindexContacts` passes against the generalized bulk-delete helper, including the empty-set noop
- [x] Full test suite green